### PR TITLE
Refactor/create classes and constructors for types

### DIFF
--- a/src/gql.ts
+++ b/src/gql.ts
@@ -231,7 +231,8 @@ export async function getPublicFolderEntity(
 		parentFolderId: '',
 		txId: '',
 		unixTime: 0,
-		syncStatus: 0
+		syncStatus: 0,
+		lastModifiedDate: 0
 	};
 	try {
 		const query = {
@@ -327,7 +328,8 @@ export async function getPrivateFolderEntity(
 		parentFolderId: '',
 		txId: '',
 		unixTime: 0,
-		syncStatus: 0
+		syncStatus: 0,
+		lastModifiedDate: 0
 	};
 	try {
 		const query = {
@@ -427,7 +429,8 @@ export async function getPublicFileEntity(
 		parentFolderId: '',
 		txId: '',
 		unixTime: 0,
-		syncStatus: 0
+		syncStatus: 0,
+		lastModifiedDate: 0
 	};
 	try {
 		const query = {
@@ -523,7 +526,8 @@ export async function getPrivateFileEntity(
 		parentFolderId: '',
 		txId: '',
 		unixTime: 0,
-		syncStatus: 0
+		syncStatus: 0,
+		lastModifiedDate: 0
 	};
 	try {
 		const query = {
@@ -895,7 +899,8 @@ export async function getAllPublicFolderEntities(
 					parentFolderId: '',
 					unixTime: 0,
 					txId: '',
-					syncStatus: 0
+					syncStatus: 0,
+					lastModifiedDate: 0
 				};
 				cursor = edge.cursor;
 				const { node } = edge;
@@ -1037,7 +1042,8 @@ export async function getAllPrivateFolderEntities(
 					parentFolderId: '',
 					unixTime: 0,
 					txId: '',
-					syncStatus: 0
+					syncStatus: 0,
+					lastModifiedDate: 0
 				};
 				cursor = edge.cursor;
 				const { node } = edge;
@@ -1183,7 +1189,8 @@ export async function getAllPublicFileEntities(
 					parentFolderId: '',
 					txId: '',
 					unixTime: 0,
-					syncStatus: 0
+					syncStatus: 0,
+					lastModifiedDate: 0
 				};
 				cursor = edge.cursor;
 				const { node } = edge;
@@ -1325,7 +1332,8 @@ export async function getAllPrivateFileEntities(
 					parentFolderId: '',
 					txId: '',
 					unixTime: 0,
-					syncStatus: 0
+					syncStatus: 0,
+					lastModifiedDate:0,
 				};
 				cursor = edge.cursor;
 				const { node } = edge;

--- a/src/types/arfs_Types.ts
+++ b/src/types/arfs_Types.ts
@@ -22,7 +22,7 @@ export interface Wallet {
 }
 
 // The primary ArFS entity that all other entities inherit from.
-export interface ArFSEntity {
+export class ArFSEntity {
 	appName: string; // The app that has submitted this entity.  Should not be longer than 64 characters.  eg. ArDrive-Web
 	appVersion: string; // The app version that has submitted this entity.  Must not be longer than 8 digits, numbers only. eg. 0.1.14
 	arFS: string; // The version of Arweave File System that is used for this entity.  Must not be longer than 4 digits. eg 0.11
@@ -33,6 +33,56 @@ export interface ArFSEntity {
 	syncStatus: number; // the status of this transaction.  0 = 'ready to download', 1 = 'ready to upload', 2 = 'getting mined', 3 = 'successfully uploaded'
 	txId: string; // the arweave transaction id for this entity. 43 numbers/letters eg. 1xRhN90Mu5mEgyyrmnzKgZP0y3aK8AwSucwlCOAwsaI
 	unixTime: number; // seconds since unix epoch, taken at the time of upload, 10 numbers eg. 1620068042
+
+	constructor(
+		appName: string,
+		appVersion: string,
+		arFS: string,
+		contentType: string,
+		driveId: string,
+		entityType: string,
+		name: string,
+		syncStatus: number,
+		txId: string,
+		unixTime: number
+	) {
+		this.appName = appName;
+		this.appVersion = appVersion;
+		this.arFS = arFS;
+		this.contentType = contentType;
+		this.driveId = driveId;
+		this.entityType = entityType;
+		this.name = name;
+		this.syncStatus = syncStatus;
+		this.txId = txId;
+		this.unixTime = unixTime;
+	}
+
+	static From(
+		appName?: string,
+		appVersion?: string,
+		arFS?: string,
+		contentType?: string,
+		driveId?: string,
+		entityType?: string,
+		name?: string,
+		syncStatus?: number,
+		txId?: string,
+		unixTime?: number
+	): ArFSEntity {
+		return new ArFSEntity(
+			appName ?? '',
+			appVersion ?? '',
+			arFS ?? '',
+			contentType ?? '',
+			driveId ?? '',
+			entityType ?? '',
+			name ?? '',
+			syncStatus ?? 0,
+			txId ?? '0',
+			unixTime ?? 0
+		);
+	}
 }
 
 // A Drive is a logical grouping of folders and files. All folders and files must be part of a drive, and reference the Drive ID.
@@ -59,6 +109,7 @@ export interface ArFSPrivateDriveEntity extends ArFSDriveEntity {
 export interface ArFSFileFolderEntity extends ArFSEntity {
 	parentFolderId: string; // the uuid of the parent folder that this entity sits within.  Folder Entities used for the drive root must not have a parent folder ID, eg. 41800747-a852-4dc9-9078-6c20f85c0f3a
 	entityId: string; // the unique folder identifier, created with uuidv4 https://www.npmjs.com/package/uuidv4 eg. 41800747-a852-4dc9-9078-6c20f85c0f3a
+	lastModifiedDate: number; // the last modified date of the file or folder as seconds since unix epoch
 }
 
 // Used for private Files/Folders only.
@@ -69,17 +120,87 @@ export interface ArFSPrivateFileFolderEntity extends ArFSFileFolderEntity {
 
 // File entity metadata transactions do not include the actual File data they represent.
 // Instead, the File data must be uploaded as a separate transaction, called the File data transaction.
-export interface ArFSFileData {
+export class ArFSFileData {
 	appName: string; // The app that has submitted this entity
 	appVersion: string; // The app version that has submitted this entity
 	contentType: string; // the mime type of the file uploaded.  Could be any file/mime type: https://www.freeformatter.com/mime-types-list.html
 	syncStatus: number; // the status of this transaction.  0 = 'ready to download', 1 = 'ready to upload', 2 = 'getting mined', 3 = 'successfully uploaded'
 	txId: string; // the arweave transaction id for this file data. 43 numbers/letters eg. 1xRhN90Mu5mEgyyrmnzKgZP0y3aK8AwSucwlCOAwsaI
 	unixTime: number; // seconds since unix epoch, taken at the time of upload, 10 numbers eg. 1620068042
+	constructor(
+		appName: string,
+		appVersion: string,
+		contentType: string,
+		syncStatus: number,
+		txId: string,
+		unixTime: number
+	) {
+		this.appName = appName;
+		this.appVersion = appVersion;
+		this.contentType = contentType;
+		this.syncStatus = syncStatus;
+		this.txId = txId;
+		this.unixTime = unixTime;
+	}
+
+	static From(
+		appName?: string,
+		appVersion?: string,
+		contentType?: string,
+		syncStatus?: number,
+		txId?: string,
+		unixTime?: number
+	): ArFSFileData {
+		return new ArFSFileData(
+			appName ?? '',
+			appVersion ?? '',
+			contentType ?? '',
+			syncStatus ?? 0,
+			txId ?? '0',
+			unixTime ?? 0
+		);
+	}
 }
 
 // Used for private file data only
-export interface ArFSPrivateFileData extends ArFSFileData {
+export class ArFSPrivateFileData extends ArFSFileData {
 	cipher: string; // The ArFS Cipher used.  Only available cipher is AES256-GCM
-	cipherIV: string; // The cipher initialization vector used for encryption, 12 bytes as base 64, 16 characters. eg YJxNOmlg0RWuMHij
+	cipherIV: string; // The cipher initialization vector used for encryption, 12 bytes as base 64, 16 characters. eg cipher:string,YJxNOmlg0RWuMHijcipher: string
+
+	constructor(
+		appName: string,
+		appVersion: string,
+		contentType: string,
+		syncStatus: number,
+		txId: string,
+		unixTime: number,
+		cipher: string,
+		cipherIV: string
+	) {
+		super(appName, appVersion, contentType, syncStatus, txId, unixTime);
+		this.cipher = cipher;
+		this.cipherIV = cipherIV;
+	}
+
+	static From(
+		appName?: string,
+		appVersion?: string,
+		contentType?: string,
+		syncStatus?: number,
+		txId?: string,
+		unixTime?: number,
+		cipher?: string,
+		cipherIV?: string
+	): ArFSPrivateFileData {
+		return new ArFSPrivateFileData(
+			appName ?? '',
+			appVersion ?? '',
+			contentType ?? '',
+			syncStatus ?? 0,
+			txId ?? '0',
+			unixTime ?? 0,
+			cipher ?? '',
+			cipherIV ?? ''
+		);
+	}
 }

--- a/src/types/client_Types.ts
+++ b/src/types/client_Types.ts
@@ -19,29 +19,321 @@ export interface ArFSLocalPrivateDriveEntity {
 }
 
 // Contains all of the metadata needed to for an ArFS client to sync a file or folder
-export interface ArFSLocalMetaData {
+export interface ArFSLocalMetaDataArguments {
+	id?: number;
+	owner?: string;
+	hash?: string;
+	path?: string;
+	size?: number;
+	version?: number;
+	isLocal?: number;
+}
+export class ArFSLocalMetaData {
 	id: number; // an identifier that can be used in any underlying database, eg. 1, 2, 3 etc.
 	owner: string; // the public arweave wallet address that owns this drive eg. FAxDUPlFfJrLDl6BvUlPw3EJOEEeg6WQbhiWidU7ueY
 	hash: string; // A SHA512 hash of a the file or a hash of a folder's contents using the folder-hash package, https://www.npmjs.com/package/folder-hash
 	path: string; // The local OS path of the file.  Should this be a path object?
+	size: number; // The size in bytes of the underlying file data
 	version: number; // The version number of the underlying file data.  Should be incremented by 1 for each version found for a given fileId.
 	isLocal: number; // Indicates if the drive is being synchronized locally or not.  0 for "no", 1 for "yes"
+
+	constructor(id: number, owner: string, hash: string, path: string, size: number, version: number, isLocal: number) {
+		this.id = id;
+		this.owner = owner;
+		this.hash = hash;
+		this.path = path;
+		this.size = size;
+		this.version = version;
+		this.isLocal = isLocal;
+	}
+
+	static From({ id, owner, hash, path, size, version, isLocal }: ArFSLocalMetaDataArguments) {
+		return new ArFSLocalMetaData(
+			id ?? 0,
+			owner ?? '',
+			hash ?? '',
+			path ?? '',
+			size ?? 0,
+			version ?? 0,
+			isLocal ?? 1
+		);
+	}
 }
 
 // Contains metadata needed to synchronize folder's metadata
 export interface ArFSLocalFolder extends ArFSLocalMetaData {
-	entity: arfsTypes.ArFSFileFolderEntity | arfsTypes.ArFSPrivateFileFolderEntity; // The underlying ArFS Entity
+	entity: arfsTypes.ArFSFileFolderEntity; // The underlying ArFS Entity
 }
 
+export interface ArFSLocalPrivateFolder extends ArFSLocalMetaData {
+	entity: arfsTypes.ArFSPrivateFileFolderEntity; // The underlying ArFS Entity
+}
+export interface ArFSLocalFileArguments {
+	id?: number;
+	owner?: string;
+	hash?: string;
+	path?: string;
+	size?: number;
+	version?: number;
+	isLocal?: number;
+	entityId?: string;
+	parentFolderId?: string;
+	appName?: string;
+	appVersion?: string;
+	arFS?: string;
+	contentType?: string;
+	driveId?: string;
+	entityType?: string;
+	name?: string;
+	syncStatus?: number;
+	txId?: string;
+	unixTime?: number;
+	dataContentType?: string;
+	dataSyncStatus?: number;
+	dataTxId?: string;
+	dataUnixTime?: number;
+	lastModifiedDate?: number;
+}
 // Contains metadata needed to synchronize a file's metadata and its data
-export interface ArFSLocalFile extends ArFSLocalMetaData {
+export class ArFSLocalFile extends ArFSLocalMetaData {
 	entity: arfsTypes.ArFSFileFolderEntity;
 	data: arfsTypes.ArFSFileData;
-}
 
-export interface ArFSLocalPrivateFile extends ArFSLocalMetaData {
+	constructor(
+		id: number,
+		owner: string,
+		hash: string,
+		path: string,
+		size: number,
+		version: number,
+		isLocal: number,
+		entityId: string,
+		parentFolderId: string,
+		appName: string,
+		appVersion: string,
+		arFS: string,
+		contentType: string,
+		driveId: string,
+		entityType: string,
+		name: string,
+		syncStatus: number,
+		txId: string,
+		unixTime: number,
+		dataContentType: string,
+		dataSyncStatus: number,
+		dataTxId: string,
+		dataUnixTime: number,
+		lastModifiedDate: number
+	) {
+		super(id, owner, hash, path, size, version, isLocal);
+		this.entity = {
+			appName,
+			appVersion,
+			arFS,
+			contentType,
+			driveId,
+			entityId,
+			entityType,
+			name,
+			parentFolderId,
+			syncStatus,
+			txId,
+			unixTime,
+			lastModifiedDate
+		};
+		this.data = {
+			appName,
+			appVersion,
+			contentType: dataContentType,
+			syncStatus: dataSyncStatus,
+			txId: dataTxId,
+			unixTime: dataUnixTime
+		};
+	}
+
+	static From({
+		id,
+		owner,
+		hash,
+		path,
+		size,
+		version,
+		isLocal,
+		entityId,
+		parentFolderId,
+		appName,
+		appVersion,
+		arFS,
+		contentType,
+		driveId,
+		entityType,
+		name,
+		syncStatus,
+		txId,
+		unixTime,
+		dataContentType,
+		dataSyncStatus,
+		dataTxId,
+		dataUnixTime,
+		lastModifiedDate
+	}: ArFSLocalFileArguments): ArFSLocalFile {
+		return new ArFSLocalFile(
+			id ?? 0,
+			owner ?? '',
+			hash ?? '',
+			path ?? '',
+			size ?? 0,
+			version ?? 0,
+			isLocal ?? 0,
+			entityId ?? '',
+			parentFolderId ?? '',
+			appName ?? '',
+			appVersion ?? '',
+			arFS ?? '',
+			contentType ?? '',
+			driveId ?? '',
+			entityType ?? '',
+			name ?? '',
+			syncStatus ?? 0,
+			txId ?? '',
+			unixTime ?? 0,
+			dataContentType ?? '',
+			dataSyncStatus ?? 0,
+			dataTxId ?? '',
+			dataUnixTime ?? 0,
+			lastModifiedDate ?? 0
+		);
+	}
+}
+export interface ArFSLocalPrivateFileArguments extends ArFSLocalFileArguments {
+	cipher?: string;
+	cipherIV?: string;
+	dataCipher?: string;
+	dataCipherIV?: string;
+}
+export class ArFSLocalPrivateFile extends ArFSLocalMetaData {
 	entity: arfsTypes.ArFSPrivateFileFolderEntity;
-	data: arfsTypes.ArFSFileData;
+	data: arfsTypes.ArFSPrivateFileData;
+	constructor(
+		id: number,
+		owner: string,
+		hash: string,
+		path: string,
+		size: number,
+		version: number,
+		isLocal: number,
+		entityId: string,
+		parentFolderId: string,
+		appName: string,
+		appVersion: string,
+		arFS: string,
+		contentType: string,
+		driveId: string,
+		entityType: string,
+		name: string,
+		syncStatus: number,
+		txId: string,
+		unixTime: number,
+		dataContentType: string,
+		dataSyncStatus: number,
+		dataTxId: string,
+		dataUnixTime: number,
+		cipher: string,
+		cipherIV: string,
+		dataCipher: string,
+		dataCipherIV: string,
+		lastModifiedDate: number
+	) {
+		super(id, owner, hash, path, size, version, isLocal);
+		this.entity = {
+			appName,
+			appVersion,
+			arFS,
+			contentType,
+			driveId,
+			entityId,
+			entityType,
+			name,
+			parentFolderId,
+			syncStatus,
+			txId,
+			unixTime,
+			cipher,
+			cipherIV,
+			lastModifiedDate
+		};
+		this.data = {
+			appName,
+			appVersion,
+			contentType: dataContentType,
+			syncStatus: dataSyncStatus,
+			txId: dataTxId,
+			unixTime: dataUnixTime,
+			cipher: dataCipher,
+			cipherIV: dataCipherIV
+		};
+	}
+	static From({
+		id,
+		owner,
+		hash,
+		path,
+		size,
+		version,
+		isLocal,
+		entityId,
+		parentFolderId,
+		appName,
+		appVersion,
+		arFS,
+		contentType,
+		driveId,
+		entityType,
+		name,
+		syncStatus,
+		txId,
+		unixTime,
+		dataContentType,
+		dataSyncStatus,
+		dataTxId,
+		dataUnixTime,
+		cipher,
+		cipherIV,
+		dataCipher,
+		dataCipherIV,
+		lastModifiedDate
+	}: ArFSLocalPrivateFileArguments): ArFSLocalPrivateFile {
+		return new ArFSLocalPrivateFile(
+			id ?? 0,
+			owner ?? '',
+			hash ?? '',
+			path ?? '',
+			size ?? 0,
+			version ?? 0,
+			isLocal ?? 0,
+			entityId ?? '',
+			parentFolderId ?? '',
+			appName ?? '',
+			appVersion ?? '',
+			arFS ?? '',
+			contentType ?? '',
+			driveId ?? '',
+			entityType ?? '',
+			name ?? '',
+			syncStatus ?? 0,
+			txId ?? '',
+			unixTime ?? 0,
+			dataContentType ?? '',
+			dataSyncStatus ?? 0,
+			dataTxId ?? '',
+			dataUnixTime ?? 0,
+			cipher ?? '',
+			cipherIV ?? '',
+			dataCipher ?? '',
+			dataCipherIV ?? '',
+			lastModifiedDate ?? 0
+		);
+	}
 }
 
 // ArFSBundles are only uploaded.  Once a bundle is uploaded, it is unpacked into individual transactions and graphQL objects.  ArDrive clients synchronize with thos individual objects, and not the bundle itself.  This means that less information is required for an ArFSBundle


### PR DESCRIPTION
PR changes the new type interfaces to classes.
Classes have constructors and a From method to initialize with only default variables.
Added lastModifiedDate to types.
Fixed errors in gql.ts.