### PR TITLE
refactor: change create arfs private file sharing link arguments

### DIFF
--- a/src/sharing_private.ts
+++ b/src/sharing_private.ts
@@ -1,24 +1,12 @@
-import { ArDriveUser } from './types/base_Types';
-import { ArFSLocalFile } from './types/client_Types';
-import { deriveDriveKey, deriveFileKey } from './crypto';
+import { deriveFileKey } from './crypto';
 import { stagingAppUrl } from './constants';
 
 // Derives a file key from the drive key and formats it into a Private file sharing link using the file id
-export async function createArFSPrivateFileSharingLink(user: ArDriveUser, fileToShare: ArFSLocalFile): Promise<string> {
+export async function createArFSPrivateFileSharingLink(driveKey: Buffer, fileId: string): Promise<string> {
 	let fileSharingUrl = '';
 	try {
-		const driveKey: Buffer = await deriveDriveKey(
-			user.dataProtectionKey,
-			fileToShare.entity.driveId,
-			user.walletPrivateKey
-		);
-		const fileKey: Buffer = await deriveFileKey(fileToShare.entity.entityId, driveKey);
-		fileSharingUrl = stagingAppUrl.concat(
-			'/#/file/',
-			fileToShare.entity.entityId,
-			'/view?fileKey=',
-			fileKey.toString('base64')
-		);
+		const fileKey: Buffer = await deriveFileKey(fileId, driveKey);
+		fileSharingUrl = stagingAppUrl.concat('/#/file/', fileId, '/view?fileKey=', fileKey.toString('base64'));
 	} catch (err) {
 		console.log(err);
 		console.log('Cannot generate Private File Sharing Link');


### PR DESCRIPTION
Changes the function to take a driveKey and fileId as arguments instead of generating them from the user object and file entity.