### PR TITLE
feat: Add unit test for formatBytes function RM-301

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -1,0 +1,20 @@
+name: Node.js CI
+
+on: [ push, pull_request ]
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - name: Install dependencies
+        run: yarn --immutable-cache
+      - name: Test codebase
+        run: yarn test
+      - name: Build codebase
+        run: yarn build

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -8,13 +8,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14.x
+
+      - name: Read .nvmrc
+        id: node_version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+
+      - name: Set Up node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
+
       - name: Install dependencies
         run: yarn --immutable-cache
-      - name: Test codebase
-        run: yarn test
-      - name: Build codebase
-        run: yarn build
+
+      - name: Test and Build Codebase
+        run: yarn ci

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"format": "prettier --write \"src/**/*.ts\"",
 		"lint": "eslint . --ext .ts",
 		"lintfix": "eslint . --ext .ts --fix",
-		"test": "mocha -r ts-node/register tests/**/*.test.ts",
+		"test": "mocha -r ts-node/register src/**/*.test.ts",
 		"typecheck": "tsc --noemit",
 		"build": "yarn clean && tsc",
 		"version": "yarn run format && git add -A src",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
 		"typecheck": "tsc --noemit",
 		"build": "yarn clean && tsc",
 		"version": "yarn run format && git add -A src",
-		"postversion": "git push && git push --tags"
+		"postversion": "git push && git push --tags",
+		"ci": "yarn test && yarn build"
 	},
 	"husky": {
 		"hooks": {

--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import { formatBytes } from './common';
+
+type byteTypes = 'Bytes' | 'KB' | 'MB' | 'GB';
+
+function formatBytesTestHelper(returnedString: string, type: byteTypes) {
+	const stringArray = returnedString.split(' ');
+
+	// Has correct string value, ex: 'Bytes'
+	expect(stringArray[1], `Incorrect string value: ${stringArray[1]}, expected: ${type}`).to.equal(type);
+
+	if (stringArray[0].includes('.')) {
+		// Byte value has been limited to 3 decimal places (thousandths), ex: 1743.432 KB
+		const decimalValue = stringArray[0].split('.')[1];
+		expect(decimalValue.length, `Decimal value is too long: "${stringArray[0]}"`).to.be.lessThan(4);
+	}
+}
+
+describe('The formatBytes function correctly returns', () => {
+	it('Bytes', () => {
+		// Very small integer for testing values without decimals
+		formatBytesTestHelper(formatBytes(85), 'Bytes');
+	});
+	it('KB', () => {
+		formatBytesTestHelper(formatBytes(8537), 'KB');
+	});
+	it('MB', () => {
+		formatBytesTestHelper(formatBytes(1262143), 'MB');
+	});
+	it('GB', () => {
+		// Very long integer for testing `.toFixed()` decimal places
+		formatBytesTestHelper(formatBytes(34737418246534), 'GB');
+	});
+});

--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -1,26 +1,53 @@
 import { expect } from 'chai';
 import { formatBytes } from './common';
 
-// Cases for rounding
-// Cases for max/min int
-// Cases for TB represented as GB
+describe('The formatBytes function ', () => {
+	describe('returns the properly formatted byte count description ', () => {
+		const inputToExpectedOutputMap = new Map<number, string>([
+			// Bytes range 0-1023
+			[0, '0 Bytes'],
+			[1023, '1023 Bytes'],
+			// KB range 1024-1048575
+			[1024, '1.000 KB'],
+			[1048575, '1023.999 KB'],
+			// MB range 1048576-1073741823
+			[1048576, '1.000 MB'],
+			[1073741823, '1024.000 MB'],
+			// GB range 1073741824-9007199254740991
+			[1073741824, '1.000 GB'],
+			[Number.MAX_SAFE_INTEGER, '8388608.000 GB'] // 9007199254740991 / 1024 / 1024 / 1024
+		]);
 
-describe('The formatBytes function correctly returns', () => {
-	const inputToExpectedOutputMap = new Map<number, string>([
-		[-12, '-12 Bytes'],
-		[0, '0 Bytes'],
-		[1023.999, '1023.999 Bytes'],
-		[1024, '1.000 KB'],
-		[85, '85 Bytes'],
-		[8537, '8.337 KB'],
-		[1262143, '1.204 MB'],
-		[34737418246534, '32351.742 GB'],
-		[Number.MAX_SAFE_INTEGER, '8388608.000 GB']
-	]);
-
-	inputToExpectedOutputMap.forEach((expectedOutput, input) => {
-		it(`${expectedOutput} with ${input}`, () => {
-			expect(formatBytes(input)).to.equal(expectedOutput);
+		inputToExpectedOutputMap.forEach((expectedOutput, input) => {
+			it(`'${expectedOutput}' when the byte count input is ${input}`, () => {
+				expect(formatBytes(input)).to.equal(expectedOutput);
+			});
 		});
+	});
+
+	it('successfully rounds up and down', () => {
+		// 1074341824 / 1024 / 1024 / 1024 = 1.000558794 GB rounds up to 1.001 GB
+		expect(formatBytes(1074341824)).to.equal('1.001 GB');
+		// 1074341824 / 1024 / 1024 / 1024 = 1.000465661 GB rounds down to 1.000 GB
+		expect(formatBytes(1074241824)).to.equal('1.000 GB');
+	});
+
+	it('represents TB sizes as GB', () => {
+		// 34737418246534 / 1024 / 1024 / 1024 / 1024 = 31.593497848 TB, returns as 32351.742 GB
+		expect(formatBytes(34737418246534)).to.equal('32351.742 GB');
+	});
+
+	// TODO?: Should these next three cases even happen?
+	it('works with Bytes represented as a decimal', () => {
+		expect(formatBytes(1023.999)).to.equal('1023.999 Bytes');
+	});
+
+	it('works with Bytes represented as a negative integer', () => {
+		expect(formatBytes(-12)).to.equal('-12 Bytes');
+	});
+
+	it('returns values as "1024.000 MB" instead of "1.000 GB" when rounded up', () => {
+		// Max range on MB: 1073741823
+		expect(formatBytes(1073741823)).to.equal('1024.000 MB');
 	});
 });

--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -1,6 +1,20 @@
 import { expect } from 'chai';
 import { formatBytes } from './common';
 
+/**
+ * formatBytes main test cases:
+ *
+ * All byte ranges return the properly formatted byte description
+ * Function is successfully rounding the up and down
+ * TB values are represented as GB
+ *
+ * Edge cases:
+ *
+ * Works with byte counts represented as a decimal
+ * Accepts negative integers as byte counts
+ * Does not round/convert negative byte counts
+ * Returns values as "1024.000 MB" instead of "1.000 GB" when rounded up
+ */
 describe('The formatBytes function ', () => {
 	describe('returns the properly formatted byte count description ', () => {
 		const inputToExpectedOutputMap = new Map<number, string>([

--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -1,34 +1,26 @@
 import { expect } from 'chai';
 import { formatBytes } from './common';
 
-type byteTypes = 'Bytes' | 'KB' | 'MB' | 'GB';
-
-function formatBytesTestHelper(returnedString: string, type: byteTypes) {
-	const stringArray = returnedString.split(' ');
-
-	// Has correct string value, ex: 'Bytes'
-	expect(stringArray[1], `Incorrect string value: ${stringArray[1]}, expected: ${type}`).to.equal(type);
-
-	if (stringArray[0].includes('.')) {
-		// Byte value has been limited to 3 decimal places (thousandths), ex: 1743.432 KB
-		const decimalValue = stringArray[0].split('.')[1];
-		expect(decimalValue.length, `Decimal value is too long: "${stringArray[0]}"`).to.be.lessThan(4);
-	}
-}
+// Cases for rounding
+// Cases for max/min int
+// Cases for TB represented as GB
 
 describe('The formatBytes function correctly returns', () => {
-	it('Bytes', () => {
-		// Very small integer for testing values without decimals
-		formatBytesTestHelper(formatBytes(85), 'Bytes');
-	});
-	it('KB', () => {
-		formatBytesTestHelper(formatBytes(8537), 'KB');
-	});
-	it('MB', () => {
-		formatBytesTestHelper(formatBytes(1262143), 'MB');
-	});
-	it('GB', () => {
-		// Very long integer for testing `.toFixed()` decimal places
-		formatBytesTestHelper(formatBytes(34737418246534), 'GB');
+	const inputToExpectedOutputMap = new Map<number, string>([
+		[-12, '-12 Bytes'],
+		[0, '0 Bytes'],
+		[1023.999, '1023.999 Bytes'],
+		[1024, '1.000 KB'],
+		[85, '85 Bytes'],
+		[8537, '8.337 KB'],
+		[1262143, '1.204 MB'],
+		[34737418246534, '32351.742 GB'],
+		[Number.MAX_SAFE_INTEGER, '8388608.000 GB']
+	]);
+
+	inputToExpectedOutputMap.forEach((expectedOutput, input) => {
+		it(`${expectedOutput} with ${input}`, () => {
+			expect(formatBytes(input)).to.equal(expectedOutput);
+		});
 	});
 });

--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -30,6 +30,7 @@ describe('The formatBytes function ', () => {
 		expect(formatBytes(1074341824)).to.equal('1.001 GB');
 		// 1074341824 / 1024 / 1024 / 1024 = 1.000465661 GB rounds down to 1.000 GB
 		expect(formatBytes(1074241824)).to.equal('1.000 GB');
+		//
 	});
 
 	it('represents TB sizes as GB', () => {
@@ -37,13 +38,17 @@ describe('The formatBytes function ', () => {
 		expect(formatBytes(34737418246534)).to.equal('32351.742 GB');
 	});
 
-	// TODO?: Should these next three cases even happen?
+	// TODO?: Should these next four cases even happen?
 	it('works with Bytes represented as a decimal', () => {
 		expect(formatBytes(1023.999)).to.equal('1023.999 Bytes');
 	});
 
-	it('works with Bytes represented as a negative integer', () => {
+	it('works with byte count represented as a negative integer', () => {
 		expect(formatBytes(-12)).to.equal('-12 Bytes');
+	});
+
+	it('does not round or convert large negative byte counts', () => {
+		expect(formatBytes(-57138495792)).to.equal('-57138495792 Bytes');
 	});
 
 	it('returns values as "1024.000 MB" instead of "1.000 GB" when rounded up', () => {


### PR DESCRIPTION
This should handle all of the cases returned by `formatBytes` and hooks up the existing testing environment with Mocha and Chai.