### PR TITLE
[TASK RM-303] Strict guards

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -11,7 +11,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { hashElement, HashElementOptions } from 'folder-hash';
 import { Wallet } from './types/arfs_Types';
 import { ArDriveUser } from './types/base_Types';
-import { cipher } from './constants';
+import { defaultCipher } from './constants';
 
 export const prodAppUrl = 'https://app.ardrive.io';
 export const stagingAppUrl = 'https://staging.ardrive.io';
@@ -364,7 +364,7 @@ export async function createNewPrivateDrive(login: string, driveName: string): P
 		appVersion: appVersion,
 		driveName,
 		rootFolderId,
-		cipher,
+		cipher: defaultCipher,
 		cipherIV: '',
 		unixTime,
 		arFS: arFSVersion,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { cipherType } from './types/type_guards';
+import { CipherType } from './types/type_guards';
 
 export const prodAppUrl = 'https://app.ardrive.io';
 export const stagingAppUrl = 'https://staging.ardrive.io';
@@ -9,7 +9,7 @@ export const appName = 'ArDrive-Desktop';
 export const webAppName = 'ArDrive-Web';
 export const appVersion = '0.1.0';
 export const arFSVersion = '0.11';
-export const cipher: cipherType = 'AES256-GCM';
+export const cipher: CipherType = 'AES256-GCM';
 
 //Note: Just to easily copy paste later where it's needed
 //import {prodAppUrl,stagingAppUrl,gatewayURL,appName,webAppName,appVersion,arFSVersion,cipher} from './constants';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,7 +9,7 @@ export const appName = 'ArDrive-Desktop';
 export const webAppName = 'ArDrive-Web';
 export const appVersion = '0.1.0';
 export const arFSVersion = '0.11';
-export const cipher: CipherType = 'AES256-GCM';
+export const defaultCipher: CipherType = 'AES256-GCM';
 
 //Note: Just to easily copy paste later where it's needed
 //import {prodAppUrl,stagingAppUrl,gatewayURL,appName,webAppName,appVersion,arFSVersion,cipher} from './constants';

--- a/src/gql.ts
+++ b/src/gql.ts
@@ -9,6 +9,7 @@ import { getTransactionData } from './gateway';
 import { deriveDriveKey, driveDecrypt, deriveFileKey, fileDecrypt } from './crypto';
 
 import Arweave from 'arweave';
+import { CipherType, DriveAuthMode, DrivePrivacy, EntityType } from './types/type_guards';
 
 const arweave = Arweave.init({
 	host: 'arweave.net', // Arweave Gateway
@@ -1720,7 +1721,7 @@ export async function getSharedPublicDrive(driveId: string): Promise<types.ArFSD
 						drive.arFS = value;
 						break;
 					case 'Drive-Privacy':
-						drive.drivePrivacy = value;
+						drive.drivePrivacy = value as DrivePrivacy;
 						break;
 					default:
 						break;
@@ -1840,7 +1841,7 @@ export async function getPrivateDriveRootFolderTxId(
 				const { value } = tag;
 				switch (key) {
 					case 'Cipher':
-						rootFolderMetaData.cipher = value;
+						rootFolderMetaData.cipher = value as CipherType;
 						break;
 					case 'Cipher-IV':
 						rootFolderMetaData.cipherIV = value;
@@ -1946,7 +1947,7 @@ export async function getAllMyPublicArDriveIds(
 						drive.arFS = value;
 						break;
 					case 'Drive-Privacy':
-						drive.drivePrivacy = value;
+						drive.drivePrivacy = value as DrivePrivacy;
 						break;
 					default:
 						break;
@@ -2069,13 +2070,13 @@ export async function getAllMyPrivateArDriveIds(
 					drive.arFS = value;
 					break;
 				case 'Drive-Privacy':
-					drive.drivePrivacy = value;
+					drive.drivePrivacy = value as DrivePrivacy;
 					break;
 				case 'Drive-Auth-Mode':
-					drive.driveAuthMode = value;
+					drive.driveAuthMode = value as DriveAuthMode;
 					break;
 				case 'Cipher':
-					drive.cipher = value;
+					drive.cipher = value as CipherType;
 					break;
 				case 'Cipher-IV':
 					drive.cipherIV = value;
@@ -2321,7 +2322,7 @@ export async function getFileMetaDataFromTx(fileDataTx: gqlTypes.GQLEdgeInterfac
 					fileToSync.contentType = value;
 					break;
 				case 'Entity-Type':
-					fileToSync.entityType = value;
+					fileToSync.entityType = value as EntityType;
 					break;
 				case 'Drive-Id':
 					fileToSync.driveId = value;
@@ -2336,7 +2337,7 @@ export async function getFileMetaDataFromTx(fileDataTx: gqlTypes.GQLEdgeInterfac
 					fileToSync.parentFolderId = value;
 					break;
 				case 'Cipher':
-					fileToSync.cipher = value;
+					fileToSync.cipher = value as CipherType;
 					break;
 				case 'Cipher-IV':
 					fileToSync.metaDataCipherIV = value;

--- a/src/private/drives_private.ts
+++ b/src/private/drives_private.ts
@@ -7,7 +7,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { deriveDriveKey, driveEncrypt } from '../crypto';
 import { JWKInterface } from 'arweave/node/lib/wallet';
 
-import { appName, appVersion, arFSVersion, cipher } from '../constants';
+import { appName, appVersion, arFSVersion, defaultCipher } from '../constants';
 import { createDataUploader } from '../transactions';
 
 // Creates an new Drive transaction and uploader using ArFS Metadata
@@ -82,7 +82,7 @@ export async function newArFSPrivateDrive(driveName: string, login?: string): Pr
 			unixTime: unixTime,
 			name: '',
 			entityType: '',
-			cipher: cipher,
+			cipher: defaultCipher,
 			cipherIV: '',
 			driveAuthMode: 'password'
 		}

--- a/src/types/base_Types.ts
+++ b/src/types/base_Types.ts
@@ -19,7 +19,7 @@ export interface UploadBatch {
 
 export interface ArFSRootFolderMetaData {
 	metaDataTxId: string;
-	cipher: guards.cipherType;
+	cipher: guards.CipherType | '';
 	cipherIV: string;
 }
 
@@ -38,14 +38,14 @@ export interface ArFSDriveMetaDataParameters {
 	appVersion: string;
 	driveName: string;
 	rootFolderId: string;
-	cipher: guards.cipherType;
+	cipher: guards.CipherType | '';
 	cipherIV: string;
 	unixTime: number;
 	arFS: string;
 	driveId: string;
 	driveSharing?: string;
-	drivePrivacy: guards.drivePrivacy;
-	driveAuthMode: guards.driveAuthMode;
+	drivePrivacy: guards.DrivePrivacy | '';
+	driveAuthMode: guards.DriveAuthMode | '';
 	metaDataTxId: string;
 	metaDataSyncStatus: number;
 	isLocal?: number;
@@ -58,14 +58,14 @@ export class ArFSDriveMetaData {
 	appVersion: string;
 	driveName: string;
 	rootFolderId: string;
-	cipher: guards.cipherType;
+	cipher: guards.CipherType | '';
 	cipherIV: string;
 	unixTime: number;
 	arFS: string;
 	driveId: string;
 	driveSharing?: string;
-	drivePrivacy: guards.drivePrivacy;
-	driveAuthMode: guards.driveAuthMode;
+	drivePrivacy: guards.DrivePrivacy | '';
+	driveAuthMode: guards.DriveAuthMode | '';
 	metaDataTxId: string;
 	metaDataSyncStatus: number;
 	isLocal?: number;
@@ -137,7 +137,7 @@ export interface ArFSFileMetaDataParameters {
 	appVersion: string;
 	unixTime: number;
 	contentType: string;
-	entityType: guards.entityType;
+	entityType: guards.EntityType | '';
 	driveId: string;
 	parentFolderId: string;
 	fileId: string;
@@ -146,7 +146,7 @@ export interface ArFSFileMetaDataParameters {
 	fileHash: string;
 	filePath: string;
 	fileVersion: number;
-	cipher: guards.cipherType;
+	cipher: guards.CipherType | '';
 	dataCipherIV: string;
 	metaDataCipherIV: string;
 	lastModifiedDate: number;
@@ -166,7 +166,7 @@ export class ArFSFileMetaData {
 	appVersion: string;
 	unixTime: number;
 	contentType: string;
-	entityType: guards.entityType;
+	entityType: guards.EntityType | '';
 	driveId: string;
 	parentFolderId: string;
 	fileId: string;
@@ -175,7 +175,7 @@ export class ArFSFileMetaData {
 	fileHash: string;
 	filePath: string;
 	fileVersion: number;
-	cipher: guards.cipherType;
+	cipher: guards.CipherType | '';
 	dataCipherIV: string;
 	metaDataCipherIV: string;
 	lastModifiedDate: number;
@@ -280,7 +280,7 @@ export class ArFSFileMetaData {
 }
 
 export interface ArFSEncryptedData {
-	cipher: guards.cipherType;
+	cipher: guards.CipherType;
 	cipherIV: string;
 	data: Buffer;
 }

--- a/src/types/type_conditionals.ts
+++ b/src/types/type_conditionals.ts
@@ -1,0 +1,1 @@
+export type UnionOfObjectPropertiesType<T extends { [key: string]: string | number }> = T[keyof T];

--- a/src/types/type_guards.ts
+++ b/src/types/type_guards.ts
@@ -1,5 +1,45 @@
-export type cipherType = 'aes-gcm-256' | 'AES256-GCM' | 'invalid' | string;
-export type entityType = 'drive' | 'file' | 'folder' | 'invalid' | string;
-export type drivePrivacy = 'private' | 'public' | 'invalid' | string;
-export type driveAuthMode = 'password' | 'invalid' | string;
-export type syncStatus = 0 | 1 | 2 | 3;
+import { UnionOfObjectPropertiesType } from './type_conditionals';
+
+export const cipherTypeValues = {
+	AES_GCM_256: 'aes-gcm-256',
+	AES_256_GCM: 'AES256-GCM'
+} as const;
+export const entityTypeValues = {
+	DRIVE: 'drive',
+	FILE: 'file',
+	FOLDER: 'folder'
+} as const;
+export const contentTypeValues = {
+	APPLICATION_JSON: 'application/json',
+	APPLICATION_OCTET_STREAM: 'application/octet-stream'
+} as const;
+export const drivePrivacyValues = {
+	PRIVATE: 'private',
+	PUBLIC: 'public'
+} as const;
+export const driveAuthModeValues = {
+	PASSWORD: 'password'
+} as const;
+export const driveSharingValues = {
+	SHARED: 'shared',
+	PERSONAL: 'personal'
+} as const;
+export const syncStatusValues = {
+	READY_TO_DOWNLOAD: 0,
+	READY_TO_UPLOAD: 1,
+	GETTING_MINED: 2,
+	SUCCESSFULLY_UPLOADED: 3
+} as const;
+export const yesNoIntegerValues = {
+	NO: 0,
+	YES: 1
+} as const;
+
+export type CipherType = UnionOfObjectPropertiesType<typeof cipherTypeValues>;
+export type EntityType = UnionOfObjectPropertiesType<typeof entityTypeValues>;
+export type ContentType = UnionOfObjectPropertiesType<typeof contentTypeValues>;
+export type DrivePrivacy = UnionOfObjectPropertiesType<typeof drivePrivacyValues>;
+export type DriveAuthMode = UnionOfObjectPropertiesType<typeof driveAuthModeValues>;
+export type DriveSharing = UnionOfObjectPropertiesType<typeof driveSharingValues>;
+export type SyncStatus = UnionOfObjectPropertiesType<typeof syncStatusValues>;
+export type YesNoInteger = UnionOfObjectPropertiesType<typeof yesNoIntegerValues>;


### PR DESCRIPTION
### Changes

- Removes the `string`, `""`, and `"invalid"` from the guard types;
- fixes all compiler errors involved in the change.

#### Note

I'm still using the `as` keyword, and also using union types with `""` to quick fix the compiler errors **without touching the algorithm**. That would be replaced in an upcoming PR for task RM-304.