### PR TITLE
PE-51: Change private folders to encrypt with driveKey

### DIFF
--- a/src/private/arfs_private.ts
+++ b/src/private/arfs_private.ts
@@ -129,15 +129,14 @@ export async function newArFSPrivateFolderMetaDataItem(
 		// Convert to JSON string
 		const secondaryFileMetaDataJSON = JSON.stringify(secondaryFileMetaDataTags);
 
-		// Private file, so it must be encrypted
+		// Private folder, so it must be encrypted with the driveKey
 		const driveKey: Buffer = await deriveDriveKey(
 			user.dataProtectionKey,
 			folder.entity.driveId,
 			user.walletPrivateKey
 		);
-		const fileKey: Buffer = await deriveFileKey(folder.entity.entityId, driveKey);
 		const encryptedData: types.ArFSEncryptedData = await fileEncrypt(
-			fileKey,
+			driveKey,
 			Buffer.from(secondaryFileMetaDataJSON)
 		);
 


### PR DESCRIPTION
This PR fixes #58 

Adds a check for folders in two `arfs.ts` methods, and if they are folders it will now encrypt with the driveKey rather than the invalid fileKey. Also changes `newArFSPrivateFolderMetaDataItem()` to not use derive a fileKey, as the method only handles folders.

## Before hotfix

Private folders could not be viewed in the web app. Seemingly every private drive created was immediately orphaned and unrecoverable

## After hotfix

Private folders can now be viewed and interacted with in the web app. Nested folders work, and all files are visible