### PR TITLE
chore(version): Increment version to `0.5.0` PE-96

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ardrive-core-js",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"description": "ArDrive Core contains the essential back end application features to support the ArDrive CLI and Desktop apps, such as file management, Permaweb upload/download, wallet management and other common functions.",
 	"main": "./lib/exports.js",
 	"types": "./lib/exports.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,7 +7,7 @@ export const gatewayURL = 'https://arweave.net/';
 
 export const appName = 'ArDrive-Desktop';
 export const webAppName = 'ArDrive-Web';
-export const appVersion = '0.4.0';
+export const appVersion = '0.5.0';
 export const arFSVersion = '0.11';
 export const defaultCipher: CipherType = 'AES256-GCM';
 


### PR DESCRIPTION
This PR increments `ardrive-core-js` to `0.5.0`

`0.4.0` has already been released with a `beta` tag: https://www.npmjs.com/package/ardrive-core-js