### PR TITLE
Some cleanups in file-syncing code

### DIFF
--- a/src/db/db_common.ts
+++ b/src/db/db_common.ts
@@ -52,6 +52,22 @@ export const all = (sql: any, params: any[] = []): any[] => {
 	}
 };
 
+// Executes a closure with a savepoint applied to the database, so all changes
+// made by the closure are atomic (also avoids excessive disk writes).
+// If an exception is thrown, the savepoint gets reverted instead.
+export async function executeWithSavepoint(closure: () => any): Promise<any> {
+	run(`SAVEPOINT executeWithSavepoint`);
+	try {
+		const result = await closure ();
+		run(`RELEASE SAVEPOINT executeWithSavepoint`);
+		return result;
+	} catch (err) {
+		run(`ROLLBACK TO SAVEPOINT executeWithSavepoint`);
+		run(`RELEASE SAVEPOINT executeWithSavepoint`);
+		throw err;
+	}
+}
+
 ////////////////////////
 // DB SETUP FUNCTIONS //
 ////////////////////////


### PR DESCRIPTION
This is a collection of two mildly related cleanups for `getMyArDriveFilesFromPermaWeb`:
- Refactor the method to share the previously duplicated code for private, public and shared drives
- Batch database writes with `SAVEPOINT`s to improve performance and consistency