### PR TITLE
Handle data cipher IV more directly

### DIFF
--- a/src/arweave.ts
+++ b/src/arweave.ts
@@ -23,6 +23,7 @@ import { deriveDriveKey, deriveFileKey, fileDecrypt } from './crypto';
 import { uploadArFSDriveMetaData, uploadArFSFileData, uploadArFSFileMetaData } from './public/arfs';
 import { selectTokenHolder } from './smartweave';
 import { arDriveCommunityOracle } from './ardrive_community_oracle';
+import { getPrivateTransactionCipherIV } from './gql';
 
 // Initialize Arweave
 export const arweave = Arweave.init({
@@ -413,7 +414,8 @@ export async function downloadArDriveFileByTx(user: ArDriveUser, fileToDownload:
 						user.walletPrivateKey
 					);
 					const fileKey: Buffer = await deriveFileKey(fileToDownload.fileId, driveKey);
-					const decryptedData = await fileDecrypt(fileToDownload.dataCipherIV, fileKey, dataBuffer);
+					const cipherIV = await getPrivateTransactionCipherIV(fileToDownload.dataTxId);
+					const decryptedData = await fileDecrypt(cipherIV, fileKey, dataBuffer);
 
 					// Overwrite the file with the decrypted version
 					writeFileSync(fileToDownload.filePath, decryptedData);

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -1,4 +1,5 @@
 import { arweave } from './arweave';
+import { GQLNodeInterface } from './types/gql_Types';
 import Axios from 'axios';
 
 // List (in order of initial preference) of the gateways for requests.
@@ -49,6 +50,18 @@ export function getTransactionData(txid: string): Promise<Uint8Array> {
 			method: 'get',
 			url: url + "/" + txid,
 			responseType: 'arraybuffer'
+		});
+		return response.data;
+	});
+}
+
+// Gets metadata (in particular, tags) of a transaction as JSON.
+export function getTransactionMetadata(txid: string): Promise<GQLNodeInterface> {
+	return queryGateway(async (url: string): Promise<GQLNodeInterface> => {
+		const response = await Axios({
+			method: 'get',
+			url: url + "/tx/" + txid,
+			responseType: 'json'
 		});
 		return response.data;
 	});

--- a/src/gql.ts
+++ b/src/gql.ts
@@ -2375,11 +2375,6 @@ export async function getFileMetaDataFromTx(fileDataTx: gqlTypes.GQLEdgeInterfac
 			fileToSync.contentType = common.extToMime(dataJSON.name);
 			fileToSync.permaWebLink = common.gatewayURL.concat(dataJSON.dataTxId);
 
-			if (fileToSync.isPublic === 0) {
-				// if this is a private file, the CipherIV of the Data transaction should also be captured
-				fileToSync.dataCipherIV = await getPrivateTransactionCipherIV(fileToSync.dataTxId);
-			}
-
 			// Check to see if a previous version exists, and if so, increment the version.
 			// Versions are determined by comparing old/new file hash.
 			const latestFile = await getDb.getLatestFileVersionFromSyncTable(fileToSync.fileId);


### PR DESCRIPTION
This streamlines the way the cipher IV for file data is handled:  Instead of querying for it during sync and with GQL, we retrieve it directly from the gateway by txid, and only during download.  This helps reduce GQL queries (and thus rate-limiting issues), and also speeds up the initial sync (especially when folders are cloud-only).

Also includes a new method for handling gateway requests / failures / retries / switching, which can be used to gradually replace the ad-hoc logic about this in the current codebase.