### PR TITLE
Use latest version in getFolderFromSyncTable

### DIFF
--- a/src/db/db_get.ts
+++ b/src/db/db_get.ts
@@ -4,7 +4,7 @@ import { get, all } from './db_common';
 // GET SINGLE ITEM FUNCTIONS //
 ///////////////////////////////
 export const getFolderFromSyncTable = (driveId: string, filePath: string) => {
-	return get(`SELECT * FROM Sync WHERE driveId = ? AND filePath = ? AND entityType = 'folder'`, [driveId, filePath]);
+	return get(`SELECT * FROM Sync WHERE driveId = ? AND filePath = ? AND entityType = 'folder' ORDER BY unixTime DESC`, [driveId, filePath]);
 };
 
 export const checkIfExistsInSyncTable = (fileHash: string, fileName: string, fileId: string) => {


### PR DESCRIPTION
`getFolderFromSyncTable` (which is used e.g. to determine the parent folder ID for a new file) used to retrieve "any" entry with a matching path, which could be an old version of a moved folder.  In this case, files would be uploaded to a wrong location in the ArDrive.

This change makes the method return the latest matching entry by `unixTime`.  While this is not 100% perfect (it could still be wrong if there were situations where two folders had the same path and then one of them was renamed), it is a simple fix that works well most of the time.