### PR TITLE
fix(file meta data): Use application/json on content-type for meta tags PE-294

### DIFF
--- a/src/arweave.ts
+++ b/src/arweave.ts
@@ -186,7 +186,7 @@ export async function prepareArFSMetaDataTransaction(
 		transaction.addTag('Cipher-IV', fileMetaData.metaDataCipherIV);
 	} else {
 		// Tag file with public tags only
-		transaction.addTag('Content-Type', fileMetaData.contentType);
+		transaction.addTag('Content-Type', 'application/json');
 	}
 	transaction.addTag('ArFS', arFSVersion);
 	transaction.addTag('Entity-Type', fileMetaData.entityType);


### PR DESCRIPTION
This PR fixes the Content-Type tag on file meta tags issue