### PR TITLE
PE-639: Ask prompt option on uploads

### DIFF
--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -781,12 +781,13 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Derive destination name and names already within provided destination folder
 		destParentFolderName ??= wrappedFolder.getBaseFileName();
-		const nameConflictInfo = await this.arFsDao.getPublicNameConflictInfoInFolder(parentFolderId);
+		const nameConflictInfo = await this.arFsDao.getPrivateNameConflictInfoInFolder(parentFolderId, driveKey);
 
 		await resolveFolderNameConflicts({
 			conflictResolution,
 			destinationFolderName: destParentFolderName,
-			getConflictInfoFn: (folderId: FolderID) => this.arFsDao.getPublicNameConflictInfoInFolder(folderId),
+			getConflictInfoFn: (folderId: FolderID) =>
+				this.arFsDao.getPrivateNameConflictInfoInFolder(folderId, driveKey),
 			nameConflictInfo,
 			wrappedFolder,
 			prompts

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -45,7 +45,10 @@ import {
 	UploadPublicFileParams,
 	UploadPrivateFileParams,
 	ArFSManifestResult,
-	UploadPublicManifestParams
+	UploadPublicManifestParams,
+	errorOnConflict,
+	skipOnConflicts,
+	upsertOnConflicts
 } from './types';
 import {
 	CommunityTipParams,
@@ -81,13 +84,7 @@ import { JWKWallet } from './jwk_wallet';
 import { WalletDAO } from './wallet_dao';
 import { fakeEntityId } from './utils/constants';
 import { ARDataPriceChunkEstimator } from './pricing/ar_data_price_chunk_estimator';
-import {
-	errorOnConflict,
-	resolveFileNameConflicts,
-	resolveFolderNameConflicts,
-	skipOnConflicts,
-	upsertOnConflicts
-} from './utils/upload_conflict_resolution';
+import { resolveFileNameConflicts, resolveFolderNameConflicts } from './utils/upload_conflict_resolution';
 
 export class ArDrive extends ArDriveAnonymous {
 	constructor(

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -48,8 +48,6 @@ import {
 	MovePrivateFileParams,
 	MovePublicFolderParams,
 	MovePrivateFolderParams,
-	upsertOnConflicts,
-	skipOnConflicts,
 	emptyArFSResult,
 	BulkPublicUploadParams,
 	RecursivePublicBulkUploadParams,
@@ -61,7 +59,6 @@ import {
 	CreatePrivateFolderParams,
 	CreatePublicDriveParams,
 	CreatePrivateDriveParams,
-	FileNameConflictResolution,
 	GetPrivateDriveParams,
 	GetPrivateFolderParams,
 	GetPrivateFileParams,
@@ -77,6 +74,11 @@ import { JWKWallet } from './jwk_wallet';
 import { WalletDAO } from './wallet_dao';
 import { fakeEntityId } from './utils/constants';
 import { ARDataPriceChunkEstimator } from './pricing/ar_data_price_chunk_estimator';
+import {
+	resolveFileNameConflicts,
+	resolveFolderNameConflicts,
+	upsertOnConflicts
+} from './utils/upload_conflict_resolution';
 
 export class ArDrive extends ArDriveAnonymous {
 	constructor(
@@ -389,7 +391,8 @@ export class ArDrive extends ArDriveAnonymous {
 		parentFolderId,
 		wrappedFile,
 		destinationFileName,
-		conflictResolution = upsertOnConflicts
+		conflictResolution = upsertOnConflicts,
+		prompts
 	}: UploadPublicFileParams): Promise<ArFSResult> {
 		const driveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
 
@@ -397,42 +400,24 @@ export class ArDrive extends ArDriveAnonymous {
 		await this.assertOwnerAddress(owner);
 
 		// Derive destination name and names already within provided destination folder
-		const destFileName = destinationFileName ?? wrappedFile.getBaseFileName();
-		const filesAndFolderNames = await this.arFsDao.getPublicNameConflictInfoInFolder(parentFolderId);
+		destinationFileName ??= wrappedFile.getBaseFileName();
+		const nameConflictInfo = await this.arFsDao.getPublicNameConflictInfoInFolder(parentFolderId);
 
-		// Files cannot overwrite folder names
-		if (filesAndFolderNames.folders.find((f) => f.folderName === destFileName)) {
-			if (conflictResolution === skipOnConflicts) {
-				// Return empty result if resolution set to skip on FILE to FOLDER name conflicts
-				return emptyArFSResult;
-			}
+		await resolveFileNameConflicts({
+			conflictResolution,
+			destinationFileName,
+			nameConflictInfo,
+			wrappedFile,
+			prompts
+		});
 
-			// TODO: Add optional interactive prompt to resolve name conflicts in ticket PE-599
-			throw new Error(errorMessage.entityNameExists);
+		if (wrappedFile.skipThisUpload) {
+			return emptyArFSResult;
 		}
 
-		const conflictingFileName = filesAndFolderNames.files.find((f) => f.fileName === destFileName);
-
-		if (conflictingFileName) {
-			if (conflictResolution === skipOnConflicts) {
-				// File has the same name, skip the upload
-				return emptyArFSResult;
-			}
-
-			if (
-				conflictResolution === upsertOnConflicts &&
-				conflictingFileName.lastModifiedDate.valueOf() === wrappedFile.lastModifiedDate.valueOf()
-			) {
-				// These files have the same name and last modified date, skip the upload
-				return emptyArFSResult;
-			}
-
-			// TODO: Handle this.conflictResolution === 'ask' PE-639
+		if (wrappedFile.newFileName) {
+			destinationFileName = wrappedFile.newFileName;
 		}
-
-		// File is a new revision if destination name conflicts
-		// with an existing file in the destination folder
-		const existingFileId = conflictingFileName?.fileId;
 
 		const uploadBaseCosts = await this.estimateAndAssertCostOfFileUpload(
 			new ByteCount(wrappedFile.fileStats.size),
@@ -449,7 +434,7 @@ export class ArDrive extends ArDriveAnonymous {
 			fileDataRewardSettings,
 			metadataRewardSettings,
 			destFileName: destinationFileName,
-			existingFileId
+			existingFileId: wrappedFile.existingId
 		});
 
 		const { tipData, reward: communityTipTrxReward } = await this.sendCommunityTip({
@@ -478,7 +463,8 @@ export class ArDrive extends ArDriveAnonymous {
 		parentFolderId,
 		wrappedFolder,
 		destParentFolderName,
-		conflictResolution = upsertOnConflicts
+		conflictResolution = upsertOnConflicts,
+		prompts
 	}: BulkPublicUploadParams): Promise<ArFSResult> {
 		const driveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
 
@@ -486,26 +472,21 @@ export class ArDrive extends ArDriveAnonymous {
 		await this.assertOwnerAddress(owner);
 
 		// Derive destination name and names already within provided destination folder
-		const destFolderName = destParentFolderName ?? wrappedFolder.getBaseFileName();
-		const filesAndFolderNames = await this.arFsDao.getPublicNameConflictInfoInFolder(parentFolderId);
+		destParentFolderName ??= wrappedFolder.getBaseFileName();
+		const nameConflictInfo = await this.arFsDao.getPublicNameConflictInfoInFolder(parentFolderId);
 
-		// Folders cannot overwrite file names
-		if (filesAndFolderNames.files.find((f) => f.fileName === destFolderName)) {
-			// TODO: Add optional interactive prompt to resolve name conflicts in ticket PE-599
-			throw new Error(errorMessage.entityNameExists);
-		}
-
-		// Use existing folder id if the intended destination name
-		// conflicts with an existing folder in the destination folder
-		wrappedFolder.existingId = filesAndFolderNames.folders.find((f) => f.folderName === destFolderName)?.folderId;
-		wrappedFolder.destinationName = destParentFolderName;
-
-		// Check for conflicting names and assign existing IDs for later use
-		await this.checkAndAssignExistingPublicNames(wrappedFolder);
+		await resolveFolderNameConflicts({
+			conflictResolution,
+			destinationFolderName: destParentFolderName,
+			getConflictInfoFn: (folderId) => this.arFsDao.getPublicNameConflictInfoInFolder(folderId),
+			nameConflictInfo,
+			wrappedFolder,
+			prompts
+		});
 
 		// Estimate and assert the cost of the entire bulk upload
 		// This will assign the calculated base costs to each wrapped file and folder
-		const bulkEstimation = await this.estimateAndAssertCostOfBulkUpload(wrappedFolder, conflictResolution);
+		const bulkEstimation = await this.estimateAndAssertCostOfBulkUpload(wrappedFolder);
 
 		// TODO: Add interactive confirmation of price estimation before uploading
 
@@ -513,8 +494,7 @@ export class ArDrive extends ArDriveAnonymous {
 			parentFolderId,
 			wrappedFolder,
 			driveId,
-			owner: await this.wallet.getAddress(),
-			conflictResolution
+			owner
 		});
 
 		if (bulkEstimation.communityWinstonTip.isGreaterThan(W(0))) {
@@ -543,8 +523,7 @@ export class ArDrive extends ArDriveAnonymous {
 		parentFolderId,
 		wrappedFolder,
 		driveId,
-		owner,
-		conflictResolution
+		owner
 	}: RecursivePublicBulkUploadParams): Promise<{
 		entityResults: ArFSEntityData[];
 		feeResults: ArFSFees;
@@ -553,17 +532,20 @@ export class ArDrive extends ArDriveAnonymous {
 		let uploadEntityResults: ArFSEntityData[] = [];
 		let folderId: FolderID;
 
-		if (wrappedFolder.existingFileAtDestConflict) {
-			// Folder names cannot conflict with file names
-			// Return an empty result to continue other parts of upload
+		if (wrappedFolder.skipThisUpload) {
+			// We may skip a folder upload if it conflicts with an existing file name.
+			// This would one be the FAIL cases from the table, ideally we'd throw an
+			// error -- but we don't want to interrupt other parts of the bulk upload
 			return { entityResults: [], feeResults: {} };
-		} else if (wrappedFolder.existingId) {
+		}
+
+		if (wrappedFolder.existingId) {
 			// Re-use existing parent folder ID for bulk upload if it exists
 			folderId = wrappedFolder.existingId;
 		} else {
 			// Create the parent folder
 			const folderData = new ArFSPublicFolderTransactionData(
-				wrappedFolder.destinationName ?? wrappedFolder.getBaseFileName()
+				wrappedFolder.newFolderName ?? wrappedFolder.getBaseFileName()
 			);
 
 			const createFolderResult = await this.arFsDao.createPublicFolder({
@@ -595,15 +577,9 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Upload all files in the folder
 		for await (const wrappedFile of wrappedFolder.files) {
-			if (
-				// Conflict resolution is set to skip and there is an existing file
-				(conflictResolution === skipOnConflicts && wrappedFile.existingId) ||
-				// Conflict resolution is set to upsert and an existing file has the same last modified date
-				(conflictResolution === upsertOnConflicts && wrappedFile.hasSameLastModifiedDate) ||
-				// File names cannot conflict with folder names
-				wrappedFile.existingFolderAtDestConflict
-			) {
-				// Continue loop, don't upload this file
+			if (wrappedFile.skipThisUpload) {
+				// Continue loop, don't upload this file, and don't throw
+				// errors inside loop so the other results get returned
 				continue;
 			}
 
@@ -623,7 +599,8 @@ export class ArDrive extends ArDriveAnonymous {
 				driveId,
 				fileDataRewardSettings,
 				metadataRewardSettings,
-				existingFileId: wrappedFile.existingId
+				existingFileId: wrappedFile.existingId,
+				destFileName: wrappedFile.newFileName ?? wrappedFile.getBaseFileName()
 			});
 
 			// Capture all file results
@@ -650,8 +627,7 @@ export class ArDrive extends ArDriveAnonymous {
 				parentFolderId: folderId,
 				wrappedFolder: childFolder,
 				driveId,
-				owner,
-				conflictResolution
+				owner
 			});
 
 			// Capture all folder results
@@ -682,7 +658,8 @@ export class ArDrive extends ArDriveAnonymous {
 		wrappedFile,
 		driveKey,
 		destinationFileName,
-		conflictResolution = upsertOnConflicts
+		conflictResolution = upsertOnConflicts,
+		prompts
 	}: UploadPrivateFileParams): Promise<ArFSResult> {
 		const driveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
 
@@ -690,42 +667,24 @@ export class ArDrive extends ArDriveAnonymous {
 		await this.assertOwnerAddress(owner);
 
 		// Derive destination name and names already within provided destination folder
-		const destFileName = destinationFileName ?? wrappedFile.getBaseFileName();
-		const filesAndFolderNames = await this.arFsDao.getPrivateNameConflictInfoInFolder(parentFolderId, driveKey);
+		destinationFileName ??= wrappedFile.getBaseFileName();
+		const nameConflictInfo = await this.arFsDao.getPrivateNameConflictInfoInFolder(parentFolderId, driveKey);
 
-		// Files cannot overwrite folder names
-		if (filesAndFolderNames.folders.find((f) => f.folderName === destFileName)) {
-			if (conflictResolution === skipOnConflicts) {
-				// Return empty result if resolution set to skip on FILE to FOLDER name conflicts
-				return emptyArFSResult;
-			}
+		await resolveFileNameConflicts({
+			conflictResolution,
+			destinationFileName,
+			nameConflictInfo,
+			wrappedFile,
+			prompts
+		});
 
-			// TODO: Add optional interactive prompt to resolve name conflicts in ticket PE-599
-			throw new Error(errorMessage.entityNameExists);
+		if (wrappedFile.skipThisUpload) {
+			return emptyArFSResult;
 		}
 
-		const conflictingFileName = filesAndFolderNames.files.find((f) => f.fileName === destFileName);
-
-		if (conflictingFileName) {
-			if (conflictResolution === skipOnConflicts) {
-				// File has the same name, skip the upload
-				return emptyArFSResult;
-			}
-
-			if (
-				conflictResolution === upsertOnConflicts &&
-				conflictingFileName.lastModifiedDate.valueOf() === wrappedFile.lastModifiedDate.valueOf()
-			) {
-				// These files have the same name and last modified date, skip the upload
-				return emptyArFSResult;
-			}
-
-			// TODO: Handle this.conflictResolution === 'ask' PE-639
+		if (wrappedFile.newFileName) {
+			destinationFileName = wrappedFile.newFileName;
 		}
-
-		// File is a new revision if destination name conflicts
-		// with an existing file in the destination folder
-		const existingFileId = conflictingFileName?.fileId;
 
 		const uploadBaseCosts = await this.estimateAndAssertCostOfFileUpload(
 			new ByteCount(wrappedFile.fileStats.size),
@@ -752,7 +711,7 @@ export class ArDrive extends ArDriveAnonymous {
 			fileDataRewardSettings,
 			metadataRewardSettings,
 			destFileName: destinationFileName,
-			existingFileId
+			existingFileId: wrappedFile.existingId
 		});
 
 		const { tipData, reward: communityTipTrxReward } = await this.sendCommunityTip({
@@ -783,7 +742,8 @@ export class ArDrive extends ArDriveAnonymous {
 		wrappedFolder,
 		driveKey,
 		destParentFolderName,
-		conflictResolution = upsertOnConflicts
+		conflictResolution = upsertOnConflicts,
+		prompts
 	}: BulkPrivateUploadParams): Promise<ArFSResult> {
 		// Retrieve drive ID from folder ID
 		const driveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
@@ -795,30 +755,21 @@ export class ArDrive extends ArDriveAnonymous {
 		await this.assertOwnerAddress(owner);
 
 		// Derive destination name and names already within provided destination folder
-		const destFolderName = destParentFolderName ?? wrappedFolder.getBaseFileName();
-		const filesAndFolderNames = await this.arFsDao.getPrivateNameConflictInfoInFolder(parentFolderId, driveKey);
+		destParentFolderName ??= wrappedFolder.getBaseFileName();
+		const nameConflictInfo = await this.arFsDao.getPublicNameConflictInfoInFolder(parentFolderId);
 
-		// Folders cannot overwrite file names
-		if (filesAndFolderNames.files.find((f) => f.fileName === destFolderName)) {
-			// TODO: Add optional interactive prompt to resolve name conflicts in ticket PE-599
-			throw new Error(errorMessage.entityNameExists);
-		}
-
-		// Use existing folder id if the intended destination name
-		// conflicts with an existing folder in the destination folder
-		wrappedFolder.existingId = filesAndFolderNames.folders.find((f) => f.folderName === destFolderName)?.folderId;
-		wrappedFolder.destinationName = destParentFolderName;
-
-		// Check for conflicting names and assign existing IDs for later use
-		await this.checkAndAssignExistingPrivateNames(wrappedFolder, driveKey);
+		await resolveFolderNameConflicts({
+			conflictResolution,
+			destinationFolderName: destParentFolderName,
+			getConflictInfoFn: (folderId: FolderID) => this.arFsDao.getPublicNameConflictInfoInFolder(folderId),
+			nameConflictInfo,
+			wrappedFolder,
+			prompts
+		});
 
 		// Estimate and assert the cost of the entire bulk upload
 		// This will assign the calculated base costs to each wrapped file and folder
-		const bulkEstimation = await this.estimateAndAssertCostOfBulkUpload(
-			wrappedFolder,
-			conflictResolution,
-			driveKey
-		);
+		const bulkEstimation = await this.estimateAndAssertCostOfBulkUpload(wrappedFolder, driveKey);
 
 		// TODO: Add interactive confirmation of price estimation before uploading
 
@@ -827,8 +778,7 @@ export class ArDrive extends ArDriveAnonymous {
 			wrappedFolder,
 			driveKey,
 			driveId,
-			owner,
-			conflictResolution
+			owner
 		});
 
 		if (bulkEstimation.communityWinstonTip.isGreaterThan(W(0))) {
@@ -853,28 +803,12 @@ export class ArDrive extends ArDriveAnonymous {
 		});
 	}
 
-	protected async checkAndAssignExistingPublicNames(wrappedFolder: ArFSFolderToUpload): Promise<void> {
-		await wrappedFolder.checkAndAssignExistingNames((parentFolderId) =>
-			this.arFsDao.getPublicNameConflictInfoInFolder(parentFolderId)
-		);
-	}
-
-	protected async checkAndAssignExistingPrivateNames(
-		wrappedFolder: ArFSFolderToUpload,
-		driveKey: DriveKey
-	): Promise<void> {
-		await wrappedFolder.checkAndAssignExistingNames((parentFolderId) =>
-			this.arFsDao.getPrivateNameConflictInfoInFolder(parentFolderId, driveKey)
-		);
-	}
-
 	protected async recursivelyCreatePrivateFolderAndUploadChildren({
 		wrappedFolder,
 		driveId,
 		parentFolderId,
 		driveKey,
-		owner,
-		conflictResolution
+		owner
 	}: RecursivePrivateBulkUploadParams): Promise<{
 		entityResults: ArFSEntityData[];
 		feeResults: ArFSFees;
@@ -883,17 +817,20 @@ export class ArDrive extends ArDriveAnonymous {
 		let uploadEntityResults: ArFSEntityData[] = [];
 		let folderId: FolderID;
 
-		if (wrappedFolder.existingFileAtDestConflict) {
-			// Folder names cannot conflict with file names
-			// Return an empty result to continue other parts of upload
+		if (wrappedFolder.skipThisUpload) {
+			// We may skip a folder upload if it conflicts with an existing file name.
+			// This would one be the FAIL cases from the table, ideally we'd throw an
+			// error -- but we don't want to interrupt other parts of the bulk upload
 			return { entityResults: [], feeResults: {} };
-		} else if (wrappedFolder.existingId) {
+		}
+
+		if (wrappedFolder.existingId) {
 			// Re-use existing parent folder ID for bulk upload if it exists
 			folderId = wrappedFolder.existingId;
 		} else {
 			// Create parent folder
 			const folderData = await ArFSPrivateFolderTransactionData.from(
-				wrappedFolder.destinationName ?? wrappedFolder.getBaseFileName(),
+				wrappedFolder.newFolderName ?? wrappedFolder.getBaseFileName(),
 				driveKey
 			);
 			const createFolderResult = await this.arFsDao.createPrivateFolder({
@@ -927,15 +864,9 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Upload all files in the folder
 		for await (const wrappedFile of wrappedFolder.files) {
-			if (
-				// Conflict resolution is set to skip and there is an existing file
-				(conflictResolution === skipOnConflicts && wrappedFile.existingId) ||
-				// Conflict resolution is set to upsert and an existing file has the same last modified date
-				(conflictResolution === upsertOnConflicts && wrappedFile.hasSameLastModifiedDate) ||
-				// File names cannot conflict with folder names
-				wrappedFile.existingFolderAtDestConflict
-			) {
-				// Continue loop, don't upload this file
+			if (wrappedFile.skipThisUpload) {
+				// Continue loop, don't upload this file, and don't throw
+				// errors inside loop so the other results get returned
 				continue;
 			}
 
@@ -955,7 +886,8 @@ export class ArDrive extends ArDriveAnonymous {
 				driveKey,
 				fileDataRewardSettings,
 				metadataRewardSettings,
-				existingFileId: wrappedFile.existingId
+				existingFileId: wrappedFile.existingId,
+				destFileName: wrappedFile.newFileName ?? wrappedFile.getBaseFileName()
 			});
 
 			// Capture all file results
@@ -984,8 +916,7 @@ export class ArDrive extends ArDriveAnonymous {
 				wrappedFolder: childFolder,
 				driveId,
 				driveKey,
-				owner,
-				conflictResolution
+				owner
 			});
 
 			// Capture all folder results
@@ -1200,22 +1131,21 @@ export class ArDrive extends ArDriveAnonymous {
 	 *  */
 	async estimateAndAssertCostOfBulkUpload(
 		folderToUpload: ArFSFolderToUpload,
-		conflictResolution: FileNameConflictResolution,
 		driveKey?: DriveKey,
 		isParentFolder = true
 	): Promise<{ totalPrice: Winston; totalFilePrice: Winston; communityWinstonTip: Winston }> {
 		let totalPrice = W(0);
 		let totalFilePrice = W(0);
 
-		if (folderToUpload.existingFileAtDestConflict) {
-			// Return an empty estimation, folders CANNOT overwrite files
+		if (folderToUpload.skipThisUpload) {
+			// Return empty estimation if this folder will be skipped, do not recurse
 			return { totalPrice: W('0'), totalFilePrice: W('0'), communityWinstonTip: W('0') };
 		}
 
 		// Don't estimate cost of folder metadata if using existing folder
 		if (!folderToUpload.existingId) {
 			const folderMetadataTrxData = await (async () => {
-				const folderName = folderToUpload.destinationName ?? folderToUpload.getBaseFileName();
+				const folderName = folderToUpload.newFolderName ?? folderToUpload.getBaseFileName();
 
 				if (driveKey) {
 					return ArFSPrivateFolderTransactionData.from(folderName, driveKey);
@@ -1234,22 +1164,19 @@ export class ArDrive extends ArDriveAnonymous {
 		}
 
 		for await (const file of folderToUpload.files) {
-			if (
-				(conflictResolution === skipOnConflicts && file.existingId) ||
-				(conflictResolution === upsertOnConflicts && file.hasSameLastModifiedDate) ||
-				file.existingFolderAtDestConflict
-			) {
-				// File will skipped, don't estimate it; continue the loop
+			if (file.skipThisUpload) {
+				// Continue loop, won't upload this file
 				continue;
 			}
 
 			const fileSize = driveKey ? file.encryptedDataSize() : new ByteCount(file.fileStats.size);
 
 			const fileDataBaseReward = await this.priceEstimator.getBaseWinstonPriceForByteCount(fileSize);
+			const destFileName = file.newFileName ?? file.getBaseFileName();
 
 			const stubFileMetaData = driveKey
-				? await this.stubPrivateFileMetadata(file, file.getBaseFileName())
-				: this.stubPublicFileMetadata(file, file.getBaseFileName());
+				? await this.stubPrivateFileMetadata(file, destFileName)
+				: this.stubPublicFileMetadata(file, destFileName);
 			const metaDataBaseReward = await this.priceEstimator.getBaseWinstonPriceForByteCount(
 				stubFileMetaData.sizeOf()
 			);
@@ -1267,12 +1194,7 @@ export class ArDrive extends ArDriveAnonymous {
 		}
 
 		for await (const folder of folderToUpload.folders) {
-			const childFolderResults = await this.estimateAndAssertCostOfBulkUpload(
-				folder,
-				conflictResolution,
-				driveKey,
-				false
-			);
+			const childFolderResults = await this.estimateAndAssertCostOfBulkUpload(folder, driveKey, false);
 
 			totalPrice = totalPrice.plus(childFolderResults.totalPrice);
 			totalFilePrice = totalFilePrice.plus(childFolderResults.totalFilePrice);

--- a/src/arfs/arfs_file_wrapper.ts
+++ b/src/arfs/arfs_file_wrapper.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import { basename, join } from 'path';
-import { errorOnConflict, skipOnConflicts, upsertOnConflicts } from '../exports';
 import {
 	ByteCount,
 	DataContentType,
@@ -11,7 +10,7 @@ import {
 	Manifest,
 	ManifestPathMap
 } from '../types';
-import { BulkFileBaseCosts, MetaDataBaseCosts } from '../types';
+import { BulkFileBaseCosts, MetaDataBaseCosts, errorOnConflict, skipOnConflicts, upsertOnConflicts } from '../types';
 import { extToMime } from '../utils/common';
 import { alphabeticalOrder } from '../utils/sort_functions';
 import { ArFSPublicFileOrFolderWithPaths } from './arfs_entities';

--- a/src/arfs/arfs_file_wrapper.ts
+++ b/src/arfs/arfs_file_wrapper.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import { basename, join } from 'path';
+import { errorOnConflict, skipOnConflicts, upsertOnConflicts } from '../exports';
 import {
 	ByteCount,
 	DataContentType,
@@ -139,6 +140,9 @@ export class ArFSManifestToUpload implements ArFSEntityToUpload {
 	}
 }
 
+export type FolderConflictResolution = typeof skipOnConflicts | undefined;
+export type FileConflictResolution = FolderConflictResolution | typeof upsertOnConflicts | typeof errorOnConflict;
+
 export class ArFSFileToUpload implements ArFSEntityToUpload {
 	constructor(public readonly filePath: FilePath, public readonly fileStats: fs.Stats) {
 		if (+this.fileStats.size > +maxFileSize) {
@@ -149,7 +153,7 @@ export class ArFSFileToUpload implements ArFSEntityToUpload {
 	baseCosts?: BulkFileBaseCosts;
 	existingId?: FileID;
 	newFileName?: string;
-	skipThisUpload = false;
+	conflictResolution: FileConflictResolution = undefined;
 
 	public gatherFileInfo(): FileInfo {
 		const dataContentType = this.contentType;
@@ -199,7 +203,7 @@ export class ArFSFolderToUpload {
 	baseCosts?: MetaDataBaseCosts;
 	existingId?: FolderID;
 	newFolderName?: string;
-	skipThisUpload = false;
+	conflictResolution: FolderConflictResolution = undefined;
 
 	constructor(public readonly filePath: FilePath, public readonly fileStats: fs.Stats) {
 		const entitiesInFolder = fs.readdirSync(this.filePath);

--- a/src/arfs/arfs_file_wrapper.ts
+++ b/src/arfs/arfs_file_wrapper.ts
@@ -3,7 +3,6 @@ import { basename, join } from 'path';
 import { ByteCount, DataContentType, UnixTime, FileID, FolderID } from '../types';
 import { BulkFileBaseCosts, MetaDataBaseCosts } from '../types';
 import { extToMime } from '../utils/common';
-import { EntityNamesAndIds } from '../utils/mapper_functions';
 
 type BaseFileName = string;
 type FilePath = string;
@@ -62,8 +61,8 @@ export class ArFSFileToUpload {
 
 	baseCosts?: BulkFileBaseCosts;
 	existingId?: FileID;
-	existingFolderAtDestConflict = false;
-	hasSameLastModifiedDate = false;
+	newFileName?: string;
+	skipThisUpload = false;
 
 	public gatherFileInfo(): FileInfo {
 		const dataContentType = this.contentType;
@@ -112,8 +111,8 @@ export class ArFSFolderToUpload {
 
 	baseCosts?: MetaDataBaseCosts;
 	existingId?: FolderID;
-	destinationName?: string;
-	existingFileAtDestConflict = false;
+	newFolderName?: string;
+	skipThisUpload = false;
 
 	constructor(public readonly filePath: FilePath, public readonly fileStats: fs.Stats) {
 		const entitiesInFolder = fs.readdirSync(this.filePath);
@@ -132,72 +131,6 @@ export class ArFSFolderToUpload {
 				if (childFile.getBaseFileName() !== '.DS_Store') {
 					this.files.push(childFile);
 				}
-			}
-		}
-	}
-
-	public async checkAndAssignExistingNames(
-		getExistingNamesFn: (parentFolderId: FolderID) => Promise<EntityNamesAndIds>
-	): Promise<void> {
-		if (!this.existingId) {
-			// Folder has no existing ID to check
-			return;
-		}
-
-		const existingEntityNamesAndIds = await getExistingNamesFn(this.existingId);
-
-		for await (const file of this.files) {
-			const baseFileName = file.getBaseFileName();
-
-			const existingFolderAtDestConflict = existingEntityNamesAndIds.folders.find(
-				({ folderName }) => folderName === baseFileName
-			);
-
-			if (existingFolderAtDestConflict) {
-				// Folder name cannot conflict with a file name
-				file.existingFolderAtDestConflict = true;
-				continue;
-			}
-
-			const existingFileAtDestConflict = existingEntityNamesAndIds.files.find(
-				({ fileName }) => fileName === baseFileName
-			);
-
-			// Conflicting file name creates a REVISION by default
-			if (existingFileAtDestConflict) {
-				file.existingId = existingFileAtDestConflict.fileId;
-
-				if (existingFileAtDestConflict.lastModifiedDate.valueOf() === file.lastModifiedDate.valueOf()) {
-					// Check last modified date and set to true to resolve upsert conditional
-					file.hasSameLastModifiedDate = true;
-				}
-			}
-		}
-
-		for await (const folder of this.folders) {
-			const baseFolderName = folder.getBaseFileName();
-
-			const existingFileAtDestConflict = existingEntityNamesAndIds.files.find(
-				({ fileName }) => fileName === baseFolderName
-			);
-
-			if (existingFileAtDestConflict) {
-				// Folder name cannot conflict with a file name
-				this.existingFileAtDestConflict = true;
-				continue;
-			}
-
-			const existingFolderAtDestConflict = existingEntityNamesAndIds.folders.find(
-				({ folderName }) => folderName === baseFolderName
-			);
-
-			// Conflicting folder name uses EXISTING folder by default
-			if (existingFolderAtDestConflict) {
-				// Assigns existing id for later use
-				folder.existingId = existingFolderAtDestConflict.folderId;
-
-				// Recurse into existing folder on folder name conflict
-				await folder.checkAndAssignExistingNames(getExistingNamesFn);
 			}
 		}
 	}

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -90,7 +90,7 @@ import {
 import { latestRevisionFilter, fileFilter, folderFilter } from '../utils/filter_methods';
 import {
 	entityToNameMap,
-	EntityNamesAndIds,
+	NameConflictInfo,
 	fileConflictInfoMap,
 	folderToNameAndIdMap
 } from '../utils/mapper_functions';
@@ -848,7 +848,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		return childrenOfFolder.map(entityToNameMap);
 	}
 
-	async getPublicNameConflictInfoInFolder(folderId: FolderID): Promise<EntityNamesAndIds> {
+	async getPublicNameConflictInfoInFolder(folderId: FolderID): Promise<NameConflictInfo> {
 		const childrenOfFolder = await this.getPublicEntitiesInFolder(folderId, true);
 		return {
 			files: childrenOfFolder.filter(fileFilter).map(fileConflictInfoMap),
@@ -856,7 +856,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		};
 	}
 
-	async getPrivateNameConflictInfoInFolder(folderId: FolderID, driveKey: DriveKey): Promise<EntityNamesAndIds> {
+	async getPrivateNameConflictInfoInFolder(folderId: FolderID, driveKey: DriveKey): Promise<NameConflictInfo> {
 		const childrenOfFolder = await this.getPrivateEntitiesInFolder(folderId, driveKey, true);
 		return {
 			files: childrenOfFolder.filter(fileFilter).map(fileConflictInfoMap),

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -55,3 +55,4 @@ export * from './utils/query';
 export * from './utils/crypto';
 export * from './utils/sort_functions';
 export * from './utils/wallet_utils';
+export * from './utils/upload_conflict_resolution';

--- a/src/types/ardrive_types.ts
+++ b/src/types/ardrive_types.ts
@@ -1,14 +1,21 @@
-import { TransactionID, AnyEntityID, MakeOptional, ArweaveAddress, Winston, FolderID, DriveID, FileID } from '.';
+import {
+	TransactionID,
+	AnyEntityID,
+	MakeOptional,
+	ArweaveAddress,
+	Winston,
+	FolderID,
+	DriveID,
+	FileID,
+	FileConflictPrompts,
+	FileNameConflictResolution,
+	FolderConflictPrompts
+} from '.';
 import { WithDriveKey } from '../arfs/arfs_entity_result_factory';
 import { ArFSFolderToUpload, ArFSFileToUpload } from '../arfs/arfs_file_wrapper';
 import { PrivateDriveKeyData } from '../arfs/arfsdao';
 import { ArFSListPublicFolderParams } from '../arfs/arfsdao_anonymous';
 import { PrivateKeyData } from '../arfs/private_key_data';
-import {
-	FileConflictPrompts,
-	FileNameConflictResolution,
-	FolderConflictPrompts
-} from '../utils/upload_conflict_resolution';
 
 export type ArFSEntityDataType = 'drive' | 'folder' | 'file';
 

--- a/src/types/ardrive_types.ts
+++ b/src/types/ardrive_types.ts
@@ -93,7 +93,8 @@ export interface UploadPublicManifestParams {
 	folderId: FolderID;
 	maxDepth?: number;
 	destManifestName?: string;
-	conflictResolution?: Exclude<FileNameConflictResolution, 'ask'>;
+	conflictResolution?: FileNameConflictResolution;
+	prompts?: FileConflictPrompts;
 }
 
 export interface CreatePublicManifestParams extends Required<UploadPublicManifestParams> {

--- a/src/types/ardrive_types.ts
+++ b/src/types/ardrive_types.ts
@@ -87,7 +87,7 @@ export interface UploadPublicManifestParams {
 	folderId: FolderID;
 	maxDepth?: number;
 	destManifestName?: string;
-	conflictResolution?: FileNameConflictResolution;
+	conflictResolution?: Exclude<FileNameConflictResolution, 'ask'>;
 }
 
 export interface CreatePublicManifestParams extends Required<UploadPublicManifestParams> {

--- a/src/types/ardrive_types.ts
+++ b/src/types/ardrive_types.ts
@@ -4,6 +4,11 @@ import { ArFSFolderToUpload, ArFSFileToUpload } from '../arfs/arfs_file_wrapper'
 import { PrivateDriveKeyData } from '../arfs/arfsdao';
 import { ArFSListPublicFolderParams } from '../arfs/arfsdao_anonymous';
 import { PrivateKeyData } from '../arfs/private_key_data';
+import {
+	FileConflictPrompts,
+	FileNameConflictResolution,
+	FolderConflictPrompts
+} from '../utils/upload_conflict_resolution';
 
 export type ArFSEntityDataType = 'drive' | 'folder' | 'file';
 
@@ -64,7 +69,6 @@ export interface RecursivePublicBulkUploadParams {
 	wrappedFolder: ArFSFolderToUpload;
 	driveId: DriveID;
 	owner: ArweaveAddress;
-	conflictResolution: FileNameConflictResolution;
 }
 export type RecursivePrivateBulkUploadParams = RecursivePublicBulkUploadParams & WithDriveKey;
 
@@ -75,14 +79,6 @@ export interface CreatePublicFolderParams {
 }
 export type CreatePrivateFolderParams = CreatePublicFolderParams & WithDriveKey;
 
-export const skipOnConflicts = 'skip';
-export const replaceOnConflicts = 'replace';
-export const upsertOnConflicts = 'upsert';
-// export  const askOnConflicts = 'ask';
-
-export type FileNameConflictResolution = typeof skipOnConflicts | typeof replaceOnConflicts | typeof upsertOnConflicts;
-// | typeof askOnConflicts;
-
 export interface UploadParams {
 	parentFolderId: FolderID;
 	conflictResolution?: FileNameConflictResolution;
@@ -90,12 +86,15 @@ export interface UploadParams {
 
 export interface BulkPublicUploadParams extends UploadParams {
 	wrappedFolder: ArFSFolderToUpload;
+	parentFolderId: FolderID;
+	prompts?: FolderConflictPrompts;
 	destParentFolderName?: string;
 }
 export type BulkPrivateUploadParams = BulkPublicUploadParams & WithDriveKey;
 
 export interface UploadPublicFileParams extends UploadParams {
 	wrappedFile: ArFSFileToUpload;
+	prompts?: FileConflictPrompts;
 	destinationFileName?: string;
 }
 export type UploadPrivateFileParams = UploadPublicFileParams & WithDriveKey;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,3 +13,4 @@ export * from './type_conditionals';
 export * from './type_guards';
 export * from './types';
 export * from './ardrive_types';
+export * from './upload_conflict_types';

--- a/src/types/upload_conflict_types.ts
+++ b/src/types/upload_conflict_types.ts
@@ -1,5 +1,5 @@
 import { FileID, FolderID } from '.';
-import { ArFSFileToUpload, ArFSFolderToUpload } from '../arfs/arfs_file_wrapper';
+import { ArFSEntityToUpload, ArFSFolderToUpload } from '../arfs/arfs_file_wrapper';
 import { FileConflictInfo, NameConflictInfo } from '../utils/mapper_functions';
 
 export const skipOnConflicts = 'skip';
@@ -85,7 +85,7 @@ export interface ResolveNameConflictsParams {
 
 export interface ResolveFileNameConflictsParams extends ResolveNameConflictsParams {
 	destinationFileName: string;
-	wrappedFile: ArFSFileToUpload;
+	wrappedFile: ArFSEntityToUpload;
 	prompts?: FileConflictPrompts;
 }
 

--- a/src/types/upload_conflict_types.ts
+++ b/src/types/upload_conflict_types.ts
@@ -1,0 +1,96 @@
+import { FileID, FolderID } from '.';
+import { FileConflictInfo, NameConflictInfo, ArFSFileToUpload, ArFSFolderToUpload } from '../exports';
+
+export const skipOnConflicts = 'skip';
+export const replaceOnConflicts = 'replace';
+export const upsertOnConflicts = 'upsert';
+export const askOnConflicts = 'ask';
+
+export const renameOnConflicts = 'rename';
+export const useExistingFolder = 'useFolder';
+
+export const errorOnConflict = 'error';
+
+/** Conflict settings used by ArDrive class */
+export type FileNameConflictResolution =
+	| typeof skipOnConflicts
+	| typeof replaceOnConflicts
+	| typeof upsertOnConflicts
+	| typeof askOnConflicts;
+
+export interface ConflictPromptParams {
+	namesWithinDestFolder: string[];
+}
+export interface FileConflictPromptParams extends ConflictPromptParams {
+	fileName: string;
+	fileId: FileID;
+}
+
+export interface FileToFileConflictPromptParams extends FileConflictPromptParams {
+	hasSameLastModifiedDate: boolean;
+}
+
+export interface FolderConflictPromptParams extends ConflictPromptParams {
+	folderName: string;
+	folderId: FolderID;
+}
+
+export type FileToFileNameConflictPrompt = (
+	params: FileToFileConflictPromptParams
+) => Promise<
+	| { resolution: typeof skipOnConflicts | typeof replaceOnConflicts }
+	| { resolution: typeof renameOnConflicts; newFileName: string }
+>;
+
+export type FileToFolderConflictAskPrompt = (
+	params: FolderConflictPromptParams
+) => Promise<{ resolution: typeof skipOnConflicts } | { resolution: typeof renameOnConflicts; newFileName: string }>;
+
+export type FolderToFileConflictAskPrompt = (
+	params: FileConflictPromptParams
+) => Promise<{ resolution: typeof skipOnConflicts } | { resolution: typeof renameOnConflicts; newFolderName: string }>;
+
+export type FolderToFolderConflictAskPrompt = (
+	params: FolderConflictPromptParams
+) => Promise<
+	| { resolution: typeof skipOnConflicts | typeof useExistingFolder }
+	| { resolution: typeof renameOnConflicts; newFolderName: string }
+>;
+
+export type FileConflictResolutionFnResult = { existingFileId?: FileID; newFileName?: string } | typeof skipOnConflicts;
+
+export interface FileConflictPrompts {
+	fileToFileNameConflict: FileToFileNameConflictPrompt;
+	fileToFolderNameConflict: FileToFolderConflictAskPrompt;
+}
+
+export interface FolderConflictPrompts extends FileConflictPrompts {
+	folderToFileNameConflict: FolderToFileConflictAskPrompt;
+	folderToFolderNameConflict: FolderToFolderConflictAskPrompt;
+}
+
+export type FileConflictResolutionFn = (params: {
+	conflictResolution: FileNameConflictResolution;
+	conflictingFileInfo: FileConflictInfo;
+	hasSameLastModifiedDate: boolean;
+	prompts?: FileConflictPrompts;
+	namesWithinDestFolder: string[];
+}) => Promise<FileConflictResolutionFnResult>;
+
+export interface ResolveNameConflictsParams {
+	conflictResolution: FileNameConflictResolution;
+	nameConflictInfo: NameConflictInfo;
+}
+
+export interface ResolveFileNameConflictsParams extends ResolveNameConflictsParams {
+	destinationFileName: string;
+	wrappedFile: ArFSFileToUpload;
+	prompts?: FileConflictPrompts;
+}
+
+export interface ResolveFolderNameConflictsParams extends ResolveNameConflictsParams {
+	destinationFolderName: string;
+	wrappedFolder: ArFSFolderToUpload;
+	getConflictInfoFn: (parentFolderId: FolderID) => Promise<NameConflictInfo>;
+	prompts?: FolderConflictPrompts;
+}

--- a/src/types/upload_conflict_types.ts
+++ b/src/types/upload_conflict_types.ts
@@ -1,5 +1,6 @@
 import { FileID, FolderID } from '.';
-import { FileConflictInfo, NameConflictInfo, ArFSFileToUpload, ArFSFolderToUpload } from '../exports';
+import { ArFSFileToUpload, ArFSFolderToUpload } from '../arfs/arfs_file_wrapper';
+import { FileConflictInfo, NameConflictInfo } from '../utils/mapper_functions';
 
 export const skipOnConflicts = 'skip';
 export const replaceOnConflicts = 'replace';

--- a/src/utils/error_message.ts
+++ b/src/utils/error_message.ts
@@ -5,6 +5,7 @@ export const errorMessage = {
 	cannotMoveToDifferentDrive: 'Entity must stay in the same drive!',
 	cannotMoveParentIntoChildFolder: 'Parent folder cannot be moved inside any of its children folders!',
 	folderCannotMoveIntoItself: 'Folders cannot be moved into themselves!',
+	fileIsTheSame: 'The file to upload matches an existing file entity!',
 	cannotMoveIntoSamePlace: (type: 'File' | 'Folder', parentFolderId: FolderID): string =>
 		`${type} already has parent folder with ID: ${parentFolderId}`
 };

--- a/src/utils/mapper_functions.ts
+++ b/src/utils/mapper_functions.ts
@@ -1,17 +1,17 @@
 import { ArFSFileOrFolderEntity } from '../arfs/arfs_entities';
 import { FileID, FolderID, UnixTime } from '../types';
 
-export interface EntityNamesAndIds {
+export interface NameConflictInfo {
 	files: FileConflictInfo[];
 	folders: FolderNameAndId[];
 }
 
-interface FolderNameAndId {
+export interface FolderNameAndId {
 	folderName: string;
 	folderId: FolderID;
 }
 
-interface FileConflictInfo {
+export interface FileConflictInfo {
 	fileName: string;
 	fileId: FileID;
 	lastModifiedDate: UnixTime;

--- a/src/utils/upload_conflict_resolution.test.ts
+++ b/src/utils/upload_conflict_resolution.test.ts
@@ -59,6 +59,8 @@ describe('The resolveFileNameConflicts function', () => {
 			nameConflictInfo: stubConflictInfo
 		});
 
+		expect(wrappedFile.newFileName).to.be.undefined;
+		expect(wrappedFile.existingId).to.be.undefined;
 		expect(wrappedFile.conflictResolution).to.be.undefined;
 	});
 
@@ -73,6 +75,7 @@ describe('The resolveFileNameConflicts function', () => {
 		});
 
 		expect(wrappedFile.conflictResolution).to.be.undefined;
+		expect(wrappedFile.newFileName).to.be.undefined;
 		expect(wrappedFile.existingId?.equals(stubEntityID)).to.be.true;
 	});
 
@@ -86,6 +89,8 @@ describe('The resolveFileNameConflicts function', () => {
 			nameConflictInfo: stubConflictInfo
 		});
 
+		expect(wrappedFile.newFileName).to.be.undefined;
+		expect(wrappedFile.existingId).to.be.undefined;
 		expect(wrappedFile.conflictResolution).to.be.equal(upsertOnConflicts);
 	});
 
@@ -97,6 +102,8 @@ describe('The resolveFileNameConflicts function', () => {
 			nameConflictInfo: stubConflictInfo
 		});
 
+		expect(wrappedFile.newFileName).to.be.undefined;
+		expect(wrappedFile.existingId).to.be.undefined;
 		expect(wrappedFile.conflictResolution).to.be.equal(skipOnConflicts);
 	});
 
@@ -119,6 +126,8 @@ describe('The resolveFileNameConflicts function', () => {
 			nameConflictInfo: stubConflictInfo
 		});
 
+		expect(wrappedFile.newFileName).to.be.undefined;
+		expect(wrappedFile.existingId).to.be.undefined;
 		expect(wrappedFile.conflictResolution).to.be.equal(errorOnConflict);
 	});
 
@@ -145,6 +154,8 @@ describe('The resolveFileNameConflicts function', () => {
 			prompts: stubbedFileAskPrompts
 		});
 
+		expect(wrappedFile.newFileName).to.be.undefined;
+		expect(wrappedFile.existingId).to.be.undefined;
 		expect(wrappedFile.conflictResolution).to.be.equal(skipOnConflicts);
 	});
 
@@ -159,6 +170,8 @@ describe('The resolveFileNameConflicts function', () => {
 			prompts: stubbedFileAskPrompts
 		});
 
+		expect(wrappedFile.newFileName).to.be.undefined;
+		expect(wrappedFile.existingId).to.be.undefined;
 		expect(wrappedFile.conflictResolution).to.be.equal(skipOnConflicts);
 	});
 
@@ -174,6 +187,7 @@ describe('The resolveFileNameConflicts function', () => {
 		});
 
 		expect(wrappedFile.conflictResolution).to.be.undefined;
+		expect(wrappedFile.newFileName).to.be.undefined;
 		expect(wrappedFile.existingId?.equals(stubEntityID)).to.be.true;
 	});
 
@@ -192,6 +206,7 @@ describe('The resolveFileNameConflicts function', () => {
 		});
 
 		expect(wrappedFile.conflictResolution).to.be.undefined;
+		expect(wrappedFile.existingId).to.be.undefined;
 		expect(wrappedFile.newFileName).to.equal('non-conflicting-name');
 	});
 
@@ -257,6 +272,8 @@ describe('The resolveFolderNameConflicts function', () => {
 			getConflictInfoFn: stubGetConflictInfoFn
 		});
 
+		expect(wrappedFolder.newFolderName).to.be.undefined;
+		expect(wrappedFolder.existingId).to.be.undefined;
 		expect(wrappedFolder.conflictResolution).to.be.undefined;
 	});
 
@@ -269,6 +286,8 @@ describe('The resolveFolderNameConflicts function', () => {
 			getConflictInfoFn: stubGetConflictInfoFn
 		});
 
+		expect(wrappedFolder.newFolderName).to.be.undefined;
+		expect(wrappedFolder.existingId).to.be.undefined;
 		expect(wrappedFolder.conflictResolution).to.equal(skipOnConflicts);
 	});
 
@@ -283,6 +302,7 @@ describe('The resolveFolderNameConflicts function', () => {
 
 		expect(wrappedFolder.conflictResolution).to.be.undefined;
 		expect(wrappedFolder.existingId?.equals(stubEntityIDAlt)).to.be.true;
+		expect(wrappedFolder.newFolderName).to.be.undefined;
 	});
 
 	it('throws an error if resolution is set to ask and there are no prompts defined', async () => {
@@ -312,6 +332,8 @@ describe('The resolveFolderNameConflicts function', () => {
 		});
 
 		expect(wrappedFolder.conflictResolution).to.equal(skipOnConflicts);
+		expect(wrappedFolder.newFolderName).to.be.undefined;
+		expect(wrappedFolder.existingId).to.be.undefined;
 	});
 
 	it('resolves wrappedFolder.conflictResolution to skip a when there is a folder to file name conflict in the destination folder, the resolution is set to ask, and the user chooses to skip the folder', async () => {
@@ -327,6 +349,8 @@ describe('The resolveFolderNameConflicts function', () => {
 		});
 
 		expect(wrappedFolder.conflictResolution).to.equal(skipOnConflicts);
+		expect(wrappedFolder.newFolderName).to.be.undefined;
+		expect(wrappedFolder.existingId).to.be.undefined;
 	});
 
 	it('resolves wrappedFolder.conflictResolution to undefined and re-uses the existing Folder ID when there is a folder to folder name conflict in the destination folder, the resolution is set to ask, and the user chooses to re-use the folder', async () => {
@@ -343,6 +367,7 @@ describe('The resolveFolderNameConflicts function', () => {
 
 		expect(wrappedFolder.conflictResolution).to.be.undefined;
 		expect(wrappedFolder.existingId?.equals(stubEntityIDAlt)).to.be.true;
+		expect(wrappedFolder.newFolderName).to.be.undefined;
 	});
 
 	it('resolves wrappedFolder.conflictResolution to undefined and assigns the new folder name when there is a folder to folder name conflict in the destination folder, the resolution is set to ask, and the user chooses to rename the folder to a non conflicting name', async () => {
@@ -362,6 +387,7 @@ describe('The resolveFolderNameConflicts function', () => {
 
 		expect(wrappedFolder.conflictResolution).to.be.undefined;
 		expect(wrappedFolder.newFolderName).to.equal('non-conflicting-name');
+		expect(wrappedFolder.existingId).to.be.undefined;
 	});
 
 	it('throws an error when there is a folder to folder name conflict in the destination folder, the resolution is set to ask, and the user chooses to rename the folder to another conflicting name', async () => {

--- a/src/utils/upload_conflict_resolution.test.ts
+++ b/src/utils/upload_conflict_resolution.test.ts
@@ -1,0 +1,241 @@
+import { expect } from 'chai';
+import { stub } from 'sinon';
+import { stubEntityID, stubEntityIDAlt, stubEntityIDAltTwo } from '../../tests/stubs';
+import { expectAsyncErrorThrow } from '../../tests/test_helpers';
+import {
+	ArFSFileToUpload,
+	errorOnConflict,
+	FileConflictPrompts,
+	skipOnConflicts,
+	upsertOnConflicts,
+	wrapFileOrFolder
+} from '../exports';
+import { UnixTime } from '../types';
+import { NameConflictInfo } from './mapper_functions';
+import { resolveFileNameConflicts } from './upload_conflict_resolution';
+
+const matchingLastModifiedDate = new UnixTime(123456789);
+const differentLastModifiedDate = new UnixTime(987654321);
+
+const stubbedFileAskPrompts: FileConflictPrompts = {
+	fileToFileNameConflict: () => Promise.resolve({ resolution: 'skip' }),
+	fileToFolderNameConflict: () => Promise.resolve({ resolution: 'skip' })
+};
+
+const stubConflictInfo: NameConflictInfo = {
+	files: [
+		{
+			fileName: 'CONFLICTING_FILE_NAME',
+			fileId: stubEntityID,
+			lastModifiedDate: matchingLastModifiedDate
+		}
+	],
+	folders: [
+		{
+			folderName: 'CONFLICTING_FOLDER_NAME',
+			folderId: stubEntityIDAlt
+		}
+	]
+};
+
+describe('The resolveFileNameConflicts function', () => {
+	let wrappedFile: ArFSFileToUpload;
+
+	beforeEach(() => {
+		// Start each test with a newly wrapped file object
+		wrappedFile = wrapFileOrFolder('test_wallet.json') as ArFSFileToUpload;
+	});
+
+	it('resolves wrappedFile.conflictResolution to undefined when there are no conflicts in the destination folder', async () => {
+		await resolveFileNameConflicts({
+			wrappedFile,
+			conflictResolution: 'upsert',
+			destinationFileName: 'non-conflicting-test-name',
+			nameConflictInfo: stubConflictInfo
+		});
+
+		expect(wrappedFile.conflictResolution).to.be.undefined;
+	});
+
+	it('resolves wrappedFile.conflictResolution to undefined and uses the existing File ID when there is a file to file name conflict in the destination folder and the file has a DIFFERENT last modified date  and the resolution is set to upsert', async () => {
+		stub(wrappedFile, 'lastModifiedDate').get(() => differentLastModifiedDate);
+
+		await resolveFileNameConflicts({
+			wrappedFile,
+			conflictResolution: 'upsert',
+			destinationFileName: 'CONFLICTING_FILE_NAME',
+			nameConflictInfo: stubConflictInfo
+		});
+
+		expect(wrappedFile.conflictResolution).to.be.undefined;
+		expect(wrappedFile.existingId?.equals(stubEntityID)).to.be.true;
+	});
+
+	it('resolves wrappedFile.conflictResolution to upsert when there is a file to file name conflict in the destination folder and the file has a MATCHING last modified date and the resolution is set to upsert', async () => {
+		stub(wrappedFile, 'lastModifiedDate').get(() => matchingLastModifiedDate);
+
+		await resolveFileNameConflicts({
+			wrappedFile,
+			conflictResolution: 'upsert',
+			destinationFileName: 'CONFLICTING_FILE_NAME',
+			nameConflictInfo: stubConflictInfo
+		});
+
+		expect(wrappedFile.conflictResolution).to.be.equal(upsertOnConflicts);
+	});
+
+	it('resolves wrappedFile.conflictResolution to skip when there is a file to file name conflict in the destination folder and the resolution is set to skip', async () => {
+		await resolveFileNameConflicts({
+			wrappedFile,
+			conflictResolution: 'skip',
+			destinationFileName: 'CONFLICTING_FILE_NAME',
+			nameConflictInfo: stubConflictInfo
+		});
+
+		expect(wrappedFile.conflictResolution).to.be.equal(skipOnConflicts);
+	});
+
+	it('resolves wrappedFile.conflictResolution to undefined and re-uses the existing file ID when there is a file to file name conflict in the destination folder and the resolution is set to replace', async () => {
+		await resolveFileNameConflicts({
+			wrappedFile,
+			conflictResolution: 'replace',
+			destinationFileName: 'CONFLICTING_FILE_NAME',
+			nameConflictInfo: stubConflictInfo
+		});
+
+		expect(wrappedFile.existingId?.equals(stubEntityID)).to.be.true;
+	});
+
+	it('resolves wrappedFile.conflictResolution to an error when there is a file to folder name conflict in the destination folder', async () => {
+		await resolveFileNameConflicts({
+			wrappedFile,
+			conflictResolution: 'upsert',
+			destinationFileName: 'CONFLICTING_FOLDER_NAME',
+			nameConflictInfo: stubConflictInfo
+		});
+
+		expect(wrappedFile.conflictResolution).to.be.equal(errorOnConflict);
+	});
+
+	it('throws an error if resolution is set to ask and there are no prompts defined', async () => {
+		await expectAsyncErrorThrow({
+			promiseToError: resolveFileNameConflicts({
+				wrappedFile,
+				conflictResolution: 'ask',
+				destinationFileName: 'CONFLICTING_FILE_NAME',
+				nameConflictInfo: stubConflictInfo
+			}),
+			errorMessage:
+				'App must provide a file name conflict resolution prompt to use the `ask` conflict resolution!'
+		});
+	});
+
+	it('resolves wrappedFile.conflictResolution to skip when there is a file to file name conflict in the destination folder, the resolution is set to ask, and the user chooses to skip the file', async () => {
+		stub(stubbedFileAskPrompts, 'fileToFileNameConflict').resolves({ resolution: 'skip' });
+
+		await resolveFileNameConflicts({
+			wrappedFile,
+			conflictResolution: 'ask',
+			destinationFileName: 'CONFLICTING_FILE_NAME',
+			nameConflictInfo: stubConflictInfo,
+			prompts: stubbedFileAskPrompts
+		});
+
+		expect(wrappedFile.conflictResolution).to.be.equal(skipOnConflicts);
+	});
+
+	it('resolves wrappedFile.conflictResolution to skip when there is a file to folder name conflict in the destination folder, the resolution is set to ask, and the user chooses to skip the file', async () => {
+		stub(stubbedFileAskPrompts, 'fileToFolderNameConflict').resolves({ resolution: 'skip' });
+
+		await resolveFileNameConflicts({
+			wrappedFile,
+			conflictResolution: 'ask',
+			destinationFileName: 'CONFLICTING_FOLDER_NAME',
+			nameConflictInfo: stubConflictInfo,
+			prompts: stubbedFileAskPrompts
+		});
+
+		expect(wrappedFile.conflictResolution).to.be.equal(skipOnConflicts);
+	});
+
+	it('resolves wrappedFile.conflictResolution to undefined and re-uses the existing File ID when there is a file to file name conflict in the destination folder, the resolution is set to ask, and the user chooses to replace the file', async () => {
+		stub(stubbedFileAskPrompts, 'fileToFileNameConflict').resolves({ resolution: 'replace' });
+
+		await resolveFileNameConflicts({
+			wrappedFile,
+			conflictResolution: 'ask',
+			destinationFileName: 'CONFLICTING_FILE_NAME',
+			nameConflictInfo: stubConflictInfo,
+			prompts: stubbedFileAskPrompts
+		});
+
+		expect(wrappedFile.conflictResolution).to.be.undefined;
+		expect(wrappedFile.existingId?.equals(stubEntityID)).to.be.true;
+	});
+
+	it('resolves wrappedFile.conflictResolution to undefined and assigns the new name field when there is a file to file name conflict in the destination folder, the resolution is set to ask, and the user chooses to rename the file to a non conflicting name', async () => {
+		stub(stubbedFileAskPrompts, 'fileToFileNameConflict').resolves({
+			resolution: 'rename',
+			newFileName: 'non-conflicting-name'
+		});
+
+		await resolveFileNameConflicts({
+			wrappedFile,
+			conflictResolution: 'ask',
+			destinationFileName: 'CONFLICTING_FILE_NAME',
+			nameConflictInfo: stubConflictInfo,
+			prompts: stubbedFileAskPrompts
+		});
+
+		expect(wrappedFile.conflictResolution).to.be.undefined;
+		expect(wrappedFile.newFileName).to.equal('non-conflicting-name');
+	});
+
+	it('throws an error when there is a file to file name conflict in the destination folder, the resolution is set to ask, and the user chooses to rename the file to another conflicting name', async () => {
+		const stubConflictInfoWithAnotherConflict: NameConflictInfo = {
+			...stubConflictInfo,
+			files: [
+				...stubConflictInfo.files,
+				{
+					fileName: 'ANOTHER_CONFLICTING_NAME',
+					fileId: stubEntityIDAltTwo,
+					lastModifiedDate: differentLastModifiedDate
+				}
+			]
+		};
+
+		stub(stubbedFileAskPrompts, 'fileToFileNameConflict').resolves({
+			resolution: 'rename',
+			newFileName: 'ANOTHER_CONFLICTING_NAME'
+		});
+
+		await expectAsyncErrorThrow({
+			promiseToError: resolveFileNameConflicts({
+				wrappedFile,
+				conflictResolution: 'ask',
+				destinationFileName: 'CONFLICTING_FILE_NAME',
+				nameConflictInfo: stubConflictInfoWithAnotherConflict,
+				prompts: stubbedFileAskPrompts
+			}),
+			errorMessage: 'That name also exists within dest folder!'
+		});
+	});
+
+	it('throws an error when there is a file to file name conflict in the destination folder, the resolution is set to ask, and the user chooses to rename the file to the same name', async () => {
+		stub(stubbedFileAskPrompts, 'fileToFileNameConflict').resolves({
+			resolution: 'rename',
+			newFileName: 'CONFLICTING_FILE_NAME'
+		});
+
+		await expectAsyncErrorThrow({
+			promiseToError: resolveFileNameConflicts({
+				wrappedFile,
+				conflictResolution: 'ask',
+				destinationFileName: 'CONFLICTING_FILE_NAME',
+				nameConflictInfo: stubConflictInfo,
+				prompts: stubbedFileAskPrompts
+			}),
+			errorMessage: 'You must provide a different name!'
+		});
+	});
+});

--- a/src/utils/upload_conflict_resolution.ts
+++ b/src/utils/upload_conflict_resolution.ts
@@ -1,99 +1,15 @@
-import { ArFSFileToUpload, ArFSFolderToUpload, FileConflictInfo, FolderNameAndId, NameConflictInfo } from '../exports';
-import { FileID, FolderID } from '../types';
-
-export const skipOnConflicts = 'skip';
-export const replaceOnConflicts = 'replace';
-export const upsertOnConflicts = 'upsert';
-export const askOnConflicts = 'ask';
-
-export const renameOnConflicts = 'rename';
-export const useExistingFolder = 'useFolder';
-
-export const errorOnConflict = 'error';
-
-/** Conflict settings used by ArDrive class */
-export type FileNameConflictResolution =
-	| typeof skipOnConflicts
-	| typeof replaceOnConflicts
-	| typeof upsertOnConflicts
-	| typeof askOnConflicts;
-
-export interface ConflictPromptParams {
-	namesWithinDestFolder: string[];
-}
-export interface FileConflictPromptParams extends ConflictPromptParams {
-	fileName: string;
-	fileId: FileID;
-}
-
-export interface FileToFileConflictPromptParams extends FileConflictPromptParams {
-	hasSameLastModifiedDate: boolean;
-}
-
-export interface FolderConflictPromptParams extends ConflictPromptParams {
-	folderName: string;
-	folderId: FolderID;
-}
-
-export type FileToFileNameConflictPrompt = (
-	params: FileToFileConflictPromptParams
-) => Promise<
-	| { resolution: typeof skipOnConflicts | typeof replaceOnConflicts }
-	| { resolution: typeof renameOnConflicts; newFileName: string }
->;
-
-export type FileToFolderConflictAskPrompt = (
-	params: FolderConflictPromptParams
-) => Promise<{ resolution: typeof skipOnConflicts } | { resolution: typeof renameOnConflicts; newFileName: string }>;
-
-export type FolderToFileConflictAskPrompt = (
-	params: FileConflictPromptParams
-) => Promise<{ resolution: typeof skipOnConflicts } | { resolution: typeof renameOnConflicts; newFolderName: string }>;
-
-export type FolderToFolderConflictAskPrompt = (
-	params: FolderConflictPromptParams
-) => Promise<
-	| { resolution: typeof skipOnConflicts | typeof useExistingFolder }
-	| { resolution: typeof renameOnConflicts; newFolderName: string }
->;
-
-export type FileConflictResolutionFnResult = { existingFileId?: FileID; newFileName?: string } | typeof skipOnConflicts;
-
-export interface FileConflictPrompts {
-	fileToFileNameConflict: FileToFileNameConflictPrompt;
-	fileToFolderNameConflict: FileToFolderConflictAskPrompt;
-}
-
-export interface FolderConflictPrompts extends FileConflictPrompts {
-	folderToFileNameConflict: FolderToFileConflictAskPrompt;
-	folderToFolderNameConflict: FolderToFolderConflictAskPrompt;
-}
-
-export type FileConflictResolutionFn = (params: {
-	conflictResolution: FileNameConflictResolution;
-	conflictingFileInfo: FileConflictInfo;
-	hasSameLastModifiedDate: boolean;
-	prompts?: FileConflictPrompts;
-	namesWithinDestFolder: string[];
-}) => Promise<FileConflictResolutionFnResult>;
-
-interface ResolveNameConflictsParams {
-	conflictResolution: FileNameConflictResolution;
-	nameConflictInfo: NameConflictInfo;
-}
-
-interface ResolveFileNameConflictsParams extends ResolveNameConflictsParams {
-	destinationFileName: string;
-	wrappedFile: ArFSFileToUpload;
-	prompts?: FileConflictPrompts;
-}
-
-interface ResolveFolderNameConflictsParams extends ResolveNameConflictsParams {
-	destinationFolderName: string;
-	wrappedFolder: ArFSFolderToUpload;
-	getConflictInfoFn: (parentFolderId: FolderID) => Promise<NameConflictInfo>;
-	prompts?: FolderConflictPrompts;
-}
+import {
+	ResolveFileNameConflictsParams,
+	askOnConflicts,
+	errorOnConflict,
+	skipOnConflicts,
+	replaceOnConflicts,
+	upsertOnConflicts,
+	renameOnConflicts,
+	ResolveFolderNameConflictsParams,
+	useExistingFolder
+} from '../exports';
+import { NameConflictInfo, FolderNameAndId, FileConflictInfo } from './mapper_functions';
 
 export const resolveFileNameConflicts = async (params: ResolveFileNameConflictsParams): Promise<void> => {
 	const { wrappedFile, conflictResolution, destinationFileName: destFileName, nameConflictInfo, prompts } = params;

--- a/src/utils/upload_conflict_resolution.ts
+++ b/src/utils/upload_conflict_resolution.ts
@@ -1,14 +1,14 @@
 import {
-	ResolveFileNameConflictsParams,
 	askOnConflicts,
 	errorOnConflict,
-	skipOnConflicts,
-	replaceOnConflicts,
-	upsertOnConflicts,
 	renameOnConflicts,
+	replaceOnConflicts,
+	ResolveFileNameConflictsParams,
 	ResolveFolderNameConflictsParams,
+	skipOnConflicts,
+	upsertOnConflicts,
 	useExistingFolder
-} from '../exports';
+} from '../types';
 import { NameConflictInfo, FolderNameAndId, FileConflictInfo } from './mapper_functions';
 
 export const resolveFileNameConflicts = async ({
@@ -60,9 +60,7 @@ export const resolveFileNameConflicts = async ({
 
 	// Use the ask prompt behavior
 	if (!prompts) {
-		throw new Error(
-			'App must provide a file name conflict resolution prompt to use the `ask` conflict resolution!'
-		);
+		throw new Error('App must provide file name conflict resolution prompts to use the `ask` conflict resolution!');
 	}
 
 	const allExistingNames = [
@@ -140,7 +138,9 @@ export const resolveFolderNameConflicts = async ({
 	} else {
 		// Use the ask prompt behavior
 		if (!prompts) {
-			throw new Error('App must provide name conflict resolution prompts to use the `ask` conflict resolution!');
+			throw new Error(
+				'App must provide folder and file name conflict resolution prompts to use the `ask` conflict resolution!'
+			);
 		}
 
 		const allExistingNames = [
@@ -171,14 +171,12 @@ export const resolveFolderNameConflicts = async ({
 				return;
 
 			case useExistingFolder:
-				if (!existingNameAtDestConflict.existingFolderConflict) {
-					// useExistingFolder will only ever be returned from a folderToFolder prompt, which
-					// WILL have existingFolderConflict -- this error should never happen
-					throw new Error('Cannot use existing folder id of non existent folder...');
-				}
-
 				// Re-use this folder, upload its contents within the existing folder
-				wrappedFolder.existingId = existingNameAtDestConflict.existingFolderConflict.folderId;
+
+				// useExistingFolder will only ever be returned from a folderToFolder prompt, which
+				// WILL have existingFolderConflict -- this can not be null here
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				wrappedFolder.existingId = existingNameAtDestConflict.existingFolderConflict!.folderId;
 
 				// Break to check conflicts within folder
 				break;

--- a/src/utils/upload_conflict_resolution.ts
+++ b/src/utils/upload_conflict_resolution.ts
@@ -1,0 +1,328 @@
+import { ArFSFileToUpload, ArFSFolderToUpload, FileConflictInfo, FolderNameAndId, NameConflictInfo } from '../exports';
+import { FileID, FolderID } from '../types';
+
+export const skipOnConflicts = 'skip';
+export const replaceOnConflicts = 'replace';
+export const upsertOnConflicts = 'upsert';
+export const askOnConflicts = 'ask';
+
+export const renameOnConflicts = 'rename';
+export const useExistingFolder = 'useFolder';
+
+/** Conflict settings used by ArDrive class */
+export type FileNameConflictResolution =
+	| typeof skipOnConflicts
+	| typeof replaceOnConflicts
+	| typeof upsertOnConflicts
+	| typeof askOnConflicts;
+
+export interface ConflictPromptParams {
+	namesWithinDestFolder: string[];
+}
+export interface FileConflictPromptParams extends ConflictPromptParams {
+	fileName: string;
+	fileId: FileID;
+}
+
+export interface FileToFileConflictPromptParams extends FileConflictPromptParams {
+	hasSameLastModifiedDate: boolean;
+}
+
+export interface FolderConflictPromptParams extends ConflictPromptParams {
+	folderName: string;
+	folderId: FolderID;
+}
+
+export type FileToFileNameConflictPrompt = (
+	params: FileToFileConflictPromptParams
+) => Promise<
+	| { resolution: typeof skipOnConflicts | typeof replaceOnConflicts }
+	| { resolution: typeof renameOnConflicts; newFileName: string }
+>;
+
+export type FileToFolderConflictAskPrompt = (
+	params: FolderConflictPromptParams
+) => Promise<{ resolution: typeof skipOnConflicts } | { resolution: typeof renameOnConflicts; newFileName: string }>;
+
+export type FolderToFileConflictAskPrompt = (
+	params: FileConflictPromptParams
+) => Promise<{ resolution: typeof skipOnConflicts } | { resolution: typeof renameOnConflicts; newFolderName: string }>;
+
+export type FolderToFolderConflictAskPrompt = (
+	params: FolderConflictPromptParams
+) => Promise<
+	| { resolution: typeof skipOnConflicts | typeof useExistingFolder }
+	| { resolution: typeof renameOnConflicts; newFolderName: string }
+>;
+
+export type FileConflictResolutionFnResult = { existingFileId?: FileID; newFileName?: string } | typeof skipOnConflicts;
+
+export interface FileConflictPrompts {
+	fileToFileNameConflict: FileToFileNameConflictPrompt;
+	fileToFolderNameConflict: FileToFolderConflictAskPrompt;
+}
+
+export interface FolderConflictPrompts extends FileConflictPrompts {
+	folderToFileNameConflict: FolderToFileConflictAskPrompt;
+	folderToFolderNameConflict: FolderToFolderConflictAskPrompt;
+}
+
+export type FileConflictResolutionFn = (params: {
+	conflictResolution: FileNameConflictResolution;
+	conflictingFileInfo: FileConflictInfo;
+	hasSameLastModifiedDate: boolean;
+	prompts?: FileConflictPrompts;
+	namesWithinDestFolder: string[];
+}) => Promise<FileConflictResolutionFnResult>;
+
+interface ResolveNameConflictsParams {
+	conflictResolution: FileNameConflictResolution;
+	nameConflictInfo: NameConflictInfo;
+}
+
+interface ResolveFileNameConflictsParams extends ResolveNameConflictsParams {
+	destinationFileName: string;
+	wrappedFile: ArFSFileToUpload;
+	prompts?: FileConflictPrompts;
+}
+
+interface ResolveFolderNameConflictsParams extends ResolveNameConflictsParams {
+	destinationFolderName: string;
+	wrappedFolder: ArFSFolderToUpload;
+	getConflictInfoFn: (parentFolderId: FolderID) => Promise<NameConflictInfo>;
+	prompts?: FolderConflictPrompts;
+}
+
+export const resolveFileNameConflicts = async (params: ResolveFileNameConflictsParams): Promise<void> => {
+	const { wrappedFile, conflictResolution, destinationFileName: destFileName, nameConflictInfo, prompts } = params;
+
+	const existingNameAtDestConflict = checkNameInfoForConflicts(destFileName, nameConflictInfo);
+
+	if (!existingNameAtDestConflict.existingFileConflict && !existingNameAtDestConflict.existingFolderConflict) {
+		// There are no conflicts, continue file upload
+		return;
+	}
+
+	const hasSameLastModifiedDate =
+		existingNameAtDestConflict.existingFileConflict?.lastModifiedDate === wrappedFile.lastModifiedDate;
+
+	if (conflictResolution !== askOnConflicts) {
+		if (existingNameAtDestConflict.existingFolderConflict || conflictResolution === skipOnConflicts) {
+			// Skip this file
+			wrappedFile.skipThisUpload = true;
+			return;
+		}
+
+		if (conflictResolution === replaceOnConflicts) {
+			// Proceed with new revision
+			wrappedFile.existingId = existingNameAtDestConflict.existingFileConflict.fileId;
+			return;
+		}
+
+		// Otherwise, default to upsert behavior
+		if (hasSameLastModifiedDate) {
+			// Skip this file, it has a matching last modified date
+			wrappedFile.skipThisUpload = true;
+			return;
+		}
+		// Proceed with creating a new revision
+		wrappedFile.existingId = existingNameAtDestConflict.existingFileConflict.fileId;
+		return;
+	}
+
+	// Use the ask prompt behavior
+	if (!prompts) {
+		throw new Error(
+			'App must provide a file name conflict resolution prompt to use the `ask` conflict resolution!'
+		);
+	}
+
+	const allExistingNames = [
+		...nameConflictInfo.files.map((f) => f.fileName),
+		...nameConflictInfo.folders.map((f) => f.folderName)
+	];
+
+	const userInput = await (() => {
+		if (existingNameAtDestConflict.existingFolderConflict) {
+			return prompts.fileToFolderNameConflict({
+				folderId: existingNameAtDestConflict.existingFolderConflict.folderId,
+				folderName: destFileName,
+				namesWithinDestFolder: allExistingNames
+			});
+		}
+
+		return prompts.fileToFileNameConflict({
+			fileId: existingNameAtDestConflict.existingFileConflict.fileId,
+			fileName: destFileName,
+			hasSameLastModifiedDate,
+			namesWithinDestFolder: allExistingNames
+		});
+	})();
+
+	switch (userInput.resolution) {
+		case skipOnConflicts:
+			// Skip this file
+			wrappedFile.skipThisUpload = true;
+			return;
+
+		case renameOnConflicts:
+			// These cases should be handled at the app level, but throw errors here if not
+			if (destFileName === userInput.newFileName) {
+				throw new Error('You must provide a different name!');
+			}
+			if (allExistingNames.includes(userInput.newFileName)) {
+				throw new Error('That name also exists within dest folder!');
+			}
+
+			// Use specified new file name
+			wrappedFile.newFileName = userInput.newFileName;
+			return;
+
+		case replaceOnConflicts:
+			// Proceed with new revision
+			wrappedFile.existingId = existingNameAtDestConflict.existingFileConflict?.fileId;
+			return;
+	}
+};
+
+export const resolveFolderNameConflicts = async ({
+	wrappedFolder,
+	nameConflictInfo,
+	destinationFolderName: destFolderName,
+	prompts,
+	conflictResolution,
+	getConflictInfoFn
+}: ResolveFolderNameConflictsParams): Promise<void> => {
+	const existingNameAtDestConflict = checkNameInfoForConflicts(destFolderName, nameConflictInfo);
+
+	if (!existingNameAtDestConflict.existingFileConflict && !existingNameAtDestConflict.existingFolderConflict) {
+		// There are no conflicts, continue folder upload
+		return;
+	}
+
+	if (conflictResolution !== askOnConflicts) {
+		if (existingNameAtDestConflict.existingFileConflict) {
+			// Folders cannot overwrite files
+			// Skip this folder and all its contents
+			wrappedFolder.skipThisUpload = true;
+			return;
+		}
+		// Re-use this folder, upload its contents within the existing folder
+		wrappedFolder.existingId = existingNameAtDestConflict.existingFolderConflict.folderId;
+	} else {
+		// Use the ask prompt behavior
+		if (!prompts) {
+			throw new Error('App must provide name conflict resolution prompts to use the `ask` conflict resolution!');
+		}
+
+		const allExistingNames = [
+			...nameConflictInfo.files.map((f) => f.fileName),
+			...nameConflictInfo.folders.map((f) => f.folderName)
+		];
+
+		const userInput = await (() => {
+			if (existingNameAtDestConflict.existingFolderConflict) {
+				return prompts.folderToFolderNameConflict({
+					folderId: existingNameAtDestConflict.existingFolderConflict.folderId,
+					folderName: destFolderName,
+					namesWithinDestFolder: allExistingNames
+				});
+			}
+
+			return prompts.folderToFileNameConflict({
+				fileId: existingNameAtDestConflict.existingFileConflict.fileId,
+				fileName: destFolderName,
+				namesWithinDestFolder: allExistingNames
+			});
+		})();
+
+		switch (userInput.resolution) {
+			case skipOnConflicts:
+				// Skip this folder and all its contents
+				wrappedFolder.skipThisUpload = true;
+				return;
+
+			case useExistingFolder:
+				if (!existingNameAtDestConflict.existingFolderConflict) {
+					// useExistingFolder will only ever be returned from a folderToFolder prompt, which
+					// WILL have existingFolderConflict -- this error should never happen
+					throw new Error('Cannot use existing folder id of non existent folder...');
+				}
+
+				// Re-use this folder, upload its contents within the existing folder
+				wrappedFolder.existingId = existingNameAtDestConflict.existingFolderConflict.folderId;
+
+				// Break to check conflicts within folder
+				break;
+
+			case renameOnConflicts:
+				// These cases should be handled at the app level, but throw errors here if not
+				if (destFolderName === userInput.newFolderName) {
+					throw new Error('You must provide a different name!');
+				}
+				if (allExistingNames.includes(userInput.newFolderName)) {
+					throw new Error('That name also exists within dest folder!');
+				}
+
+				// Use new folder name and upload all contents within new folder
+				wrappedFolder.newFolderName = userInput.newFolderName;
+
+				// Conflict resolved by rename -- return early, do NOT recurse into this folder
+				return;
+		}
+	}
+
+	if (wrappedFolder.existingId) {
+		// Re-using existing folder id, check for name conflicts inside the folder
+		const childConflictInfo = await getConflictInfoFn(wrappedFolder.existingId);
+
+		for await (const file of wrappedFolder.files) {
+			// Check each file upload within the folder for name conflicts
+			await resolveFileNameConflicts({
+				wrappedFile: file,
+				conflictResolution,
+				destinationFileName: file.getBaseFileName(),
+				nameConflictInfo: childConflictInfo,
+				prompts
+			});
+		}
+
+		for await (const folder of wrappedFolder.folders) {
+			// Recurse into each folder to check for more name conflicts
+			await resolveFolderNameConflicts({
+				wrappedFolder: folder,
+				conflictResolution,
+				getConflictInfoFn,
+				destinationFolderName: folder.getBaseFileName(),
+				nameConflictInfo: childConflictInfo,
+				prompts
+			});
+		}
+	}
+};
+
+/**
+ * Utility function for finding name conflicts within NameConflictInfo
+ * Returns a union of objects to be safely used in type narrowing
+ */
+function checkNameInfoForConflicts(
+	destinationName: string,
+	nameConflictInfo: NameConflictInfo
+):
+	| { existingFolderConflict: FolderNameAndId; existingFileConflict: undefined }
+	| { existingFolderConflict: undefined; existingFileConflict: FileConflictInfo }
+	| { existingFolderConflict: undefined; existingFileConflict: undefined } {
+	const conflictResult = { existingFolderConflict: undefined, existingFileConflict: undefined };
+
+	const existingFolderConflict = nameConflictInfo.folders.find((f) => f.folderName === destinationName);
+	if (existingFolderConflict) {
+		return { ...conflictResult, existingFolderConflict };
+	}
+
+	const existingFileConflict = nameConflictInfo.files.find((f) => f.fileName === destinationName);
+	if (existingFileConflict) {
+		return { ...conflictResult, existingFileConflict };
+	}
+
+	return conflictResult;
+}

--- a/src/utils/upload_conflict_resolution.ts
+++ b/src/utils/upload_conflict_resolution.ts
@@ -11,9 +11,13 @@ import {
 } from '../exports';
 import { NameConflictInfo, FolderNameAndId, FileConflictInfo } from './mapper_functions';
 
-export const resolveFileNameConflicts = async (params: ResolveFileNameConflictsParams): Promise<void> => {
-	const { wrappedFile, conflictResolution, destinationFileName: destFileName, nameConflictInfo, prompts } = params;
-
+export const resolveFileNameConflicts = async ({
+	wrappedFile,
+	conflictResolution,
+	destinationFileName: destFileName,
+	nameConflictInfo,
+	prompts
+}: ResolveFileNameConflictsParams): Promise<void> => {
 	const existingNameAtDestConflict = checkNameInfoForConflicts(destFileName, nameConflictInfo);
 
 	if (!existingNameAtDestConflict.existingFileConflict && !existingNameAtDestConflict.existingFolderConflict) {

--- a/src/utils/upload_conflict_resolution.ts
+++ b/src/utils/upload_conflict_resolution.ts
@@ -11,13 +11,13 @@ import {
 } from '../types';
 import { NameConflictInfo, FolderNameAndId, FileConflictInfo } from './mapper_functions';
 
-export const resolveFileNameConflicts = async ({
+export async function resolveFileNameConflicts({
 	wrappedFile,
 	conflictResolution,
 	destinationFileName: destFileName,
 	nameConflictInfo,
 	prompts
-}: ResolveFileNameConflictsParams): Promise<void> => {
+}: ResolveFileNameConflictsParams): Promise<void> {
 	const existingNameAtDestConflict = checkNameInfoForConflicts(destFileName, nameConflictInfo);
 
 	if (!existingNameAtDestConflict.existingFileConflict && !existingNameAtDestConflict.existingFolderConflict) {
@@ -109,16 +109,16 @@ export const resolveFileNameConflicts = async ({
 			wrappedFile.existingId = existingNameAtDestConflict.existingFileConflict?.fileId;
 			return;
 	}
-};
+}
 
-export const resolveFolderNameConflicts = async ({
+export async function resolveFolderNameConflicts({
 	wrappedFolder,
 	nameConflictInfo,
 	destinationFolderName: destFolderName,
 	prompts,
 	conflictResolution,
 	getConflictInfoFn
-}: ResolveFolderNameConflictsParams): Promise<void> => {
+}: ResolveFolderNameConflictsParams): Promise<void> {
 	const existingNameAtDestConflict = checkNameInfoForConflicts(destFolderName, nameConflictInfo);
 
 	if (!existingNameAtDestConflict.existingFileConflict && !existingNameAtDestConflict.existingFolderConflict) {
@@ -225,7 +225,7 @@ export const resolveFolderNameConflicts = async ({
 			});
 		}
 	}
-};
+}
 
 /**
  * Utility function for finding name conflicts within NameConflictInfo

--- a/tests/integration/ardrive.int.test.ts
+++ b/tests/integration/ardrive.int.test.ts
@@ -19,7 +19,8 @@ import {
 	Winston,
 	DrivePrivacy,
 	FileID,
-	ArFSManifestResult
+	ArFSManifestResult,
+	FileConflictPrompts
 } from '../../src/types';
 import { readJWKFile, urlEncodeHashKey } from '../../src/utils/common';
 import {
@@ -41,7 +42,6 @@ import {
 import { expectAsyncErrorThrow } from '../test_helpers';
 import { JWKWallet } from '../../src/jwk_wallet';
 import { WalletDAO } from '../../src/wallet_dao';
-import { FileConflictPrompts } from '../../src/utils/upload_conflict_resolution';
 
 // Don't use the existing constants just to make sure our expectations don't change
 const entityIdRegex = /^[a-f\d]{8}-([a-f\d]{4}-){3}[a-f\d]{12}$/i;

--- a/tests/integration/ardrive.int.test.ts
+++ b/tests/integration/ardrive.int.test.ts
@@ -523,19 +523,16 @@ describe('ArDrive class - integrated', () => {
 					});
 				});
 
-				it('returns an empty ArFS result if destination folder has a conflicting FOLDER name', async () => {
+				it('throws an error if destination folder has a conflicting FOLDER name', async () => {
 					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 
-					const result = await arDrive.uploadPublicFile({
-						parentFolderId: stubEntityID,
-						wrappedFile,
-						destinationFileName: 'CONFLICTING_FOLDER_NAME'
-					});
-
-					expect(result).to.deep.equal({
-						created: [],
-						tips: [],
-						fees: {}
+					await expectAsyncErrorThrow({
+						promiseToError: arDrive.uploadPublicFile({
+							parentFolderId: stubEntityID,
+							wrappedFile,
+							destinationFileName: 'CONFLICTING_FOLDER_NAME'
+						}),
+						errorMessage: 'Entity name already exists in destination folder!'
 					});
 				});
 
@@ -570,21 +567,18 @@ describe('ArDrive class - integrated', () => {
 					assertUploadFileExpectations(result, W(3204), W(171), W(0), W(1), 'public', existingFileId);
 				});
 
-				it('returns an empty ArFSResult if destination folder has a conflicting FILE name and a matching last modified date and the conflict resolution is set to upsert', async () => {
+				it('throws an error if destination folder has a conflicting FILE name and a matching last modified date and the conflict resolution is set to upsert', async () => {
 					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 					stub(wrappedFile, 'lastModifiedDate').get(() => matchingLastModifiedDate);
 
-					const result = await arDrive.uploadPublicFile({
-						parentFolderId: stubEntityID,
-						wrappedFile,
-						destinationFileName: 'CONFLICTING_FILE_NAME',
-						conflictResolution: 'upsert'
-					});
-
-					expect(result).to.deep.equal({
-						created: [],
-						tips: [],
-						fees: {}
+					await expectAsyncErrorThrow({
+						promiseToError: arDrive.uploadPublicFile({
+							parentFolderId: stubEntityID,
+							wrappedFile,
+							destinationFileName: 'CONFLICTING_FILE_NAME',
+							conflictResolution: 'upsert'
+						}),
+						errorMessage: 'The file to upload matches an existing file entity!'
 					});
 				});
 
@@ -702,20 +696,17 @@ describe('ArDrive class - integrated', () => {
 					});
 				});
 
-				it('returns an empty ArFS result if destination folder has a conflicting FOLDER name', async () => {
+				it('throws an error if destination folder has a conflicting FOLDER name', async () => {
 					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 
-					const result = await arDrive.uploadPrivateFile({
-						parentFolderId: stubEntityID,
-						wrappedFile,
-						driveKey: await getStubDriveKey(),
-						destinationFileName: 'CONFLICTING_FOLDER_NAME'
-					});
-
-					expect(result).to.deep.equal({
-						created: [],
-						tips: [],
-						fees: {}
+					await expectAsyncErrorThrow({
+						promiseToError: arDrive.uploadPrivateFile({
+							parentFolderId: EID(stubEntityID.toString()),
+							wrappedFile,
+							driveKey: await getStubDriveKey(),
+							destinationFileName: 'CONFLICTING_FOLDER_NAME'
+						}),
+						errorMessage: 'Entity name already exists in destination folder!'
 					});
 				});
 
@@ -752,22 +743,19 @@ describe('ArDrive class - integrated', () => {
 					assertUploadFileExpectations(result, W(3220), W(187), W(0), W(1), 'private', existingFileId);
 				});
 
-				it('returns an empty ArFSResult if destination folder has a conflicting FILE name and a matching last modified date and the conflict resolution is set to upsert', async () => {
+				it('throws an error if destination folder has a conflicting FILE name and a matching last modified date and the conflict resolution is set to upsert', async () => {
 					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 					stub(wrappedFile, 'lastModifiedDate').get(() => matchingLastModifiedDate);
 
-					const result = await arDrive.uploadPrivateFile({
-						parentFolderId: stubEntityID,
-						wrappedFile,
-						destinationFileName: 'CONFLICTING_FILE_NAME',
-						conflictResolution: 'upsert',
-						driveKey: await getStubDriveKey()
-					});
-
-					expect(result).to.deep.equal({
-						created: [],
-						tips: [],
-						fees: {}
+					await expectAsyncErrorThrow({
+						promiseToError: arDrive.uploadPrivateFile({
+							parentFolderId: EID(stubEntityID.toString()),
+							wrappedFile,
+							driveKey: await getStubDriveKey(),
+							destinationFileName: 'CONFLICTING_FILE_NAME',
+							conflictResolution: 'upsert'
+						}),
+						errorMessage: 'The file to upload matches an existing file entity!'
 					});
 				});
 


### PR DESCRIPTION
This PR adds support the `--ask` option in ArDrive Core. The growing conflict resolution logic has been moved out of the ArDrive method logic and into its own file.

The Core layer defines all of the types for each prompt to implement, which the CLI (or any other app) will optionally implement.

Suggested review order:

```shell
upload_conflict_resolution.test.ts
upload_conflict_resolution.ts
ardrive.int.test.ts
ardrive.ts
```