### PR TITLE
refactor(create manifest): Add manifest field to result PE-740

### DIFF
--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -45,7 +45,8 @@ import {
 	UploadPublicFileParams,
 	UploadPrivateFileParams,
 	ArFSManifestResult,
-	UploadPublicManifestParams
+	UploadPublicManifestParams,
+	emptyManifestResult
 } from './types';
 import {
 	CommunityTipParams,
@@ -1034,7 +1035,7 @@ export class ArDrive extends ArDriveAnonymous {
 		const existingFileId = filesAndFolderNames.files.find((f) => f.fileName === destManifestName)?.fileId;
 		if (existingFileId && conflictResolution === skipOnConflicts) {
 			// Return empty result if there is an existing manifest and resolution is set to skip
-			return { ...emptyArFSResult, links: [] };
+			return emptyManifestResult;
 		}
 
 		const children = await this.listPublicFolder({
@@ -1082,6 +1083,7 @@ export class ArDrive extends ArDriveAnonymous {
 				[`${uploadFileResult.metaDataTrxId}`]: uploadFileResult.metaDataTrxReward,
 				[`${tipData.txId}`]: communityTipTrxReward
 			},
+			manifest: arweaveManifest.manifest,
 			links: arweaveManifest.getLinksOutput(uploadFileResult.dataTrxId)
 		});
 	}

--- a/src/types/ardrive_types.ts
+++ b/src/types/ardrive_types.ts
@@ -38,6 +38,7 @@ export interface ArFSResult {
 }
 
 export interface ArFSManifestResult extends ArFSResult {
+	manifest: Manifest;
 	links: string[];
 }
 
@@ -47,6 +48,16 @@ export const emptyArFSResult: ArFSResult = {
 	fees: {}
 };
 
+export const emptyManifestResult: ArFSManifestResult = {
+	...emptyArFSResult,
+	manifest: {
+		manifest: 'arweave/paths',
+		version: '0.1.0',
+		index: { path: '' },
+		paths: {}
+	},
+	links: []
+};
 export interface MetaDataBaseCosts {
 	metaDataBaseReward: Winston;
 }

--- a/tests/integration/ardrive.int.test.ts
+++ b/tests/integration/ardrive.int.test.ts
@@ -930,6 +930,12 @@ describe('ArDrive class - integrated', () => {
 				created: [],
 				tips: [],
 				fees: {},
+				manifest: {
+					manifest: 'arweave/paths',
+					version: '0.1.0',
+					index: { path: '' },
+					paths: {}
+				},
 				links: []
 			});
 		});
@@ -1176,8 +1182,8 @@ function assertUploadManifestExpectations(
 	expect(feeKeys[2]).to.equal(uploadTip.txId.toString());
 	expect(`${result.fees[uploadTip.txId.toString()]}`).to.equal(`${tipFee}`);
 
-	// Verify links are healthy
 	if (specialCharacters) {
+		// Verify links are healthy
 		expect(result.links.length).to.equal(4);
 		expect(result.links[0]).to.equal(`https://arweave.net/${result.created[0].dataTxId}`);
 		expect(result.links[1]).to.equal(
@@ -1189,7 +1195,24 @@ function assertUploadManifestExpectations(
 		expect(result.links[3]).to.equal(
 			`https://arweave.net/${result.created[0].dataTxId}/~!%40%23%24%25%5E%26*()_%2B%7B%7D%7C%5B%5D%3A%22%3B%3C%3E%3F%2C./%60/dwijqndjqwnjNJKNDKJANKDNJWNJIvmnbzxnmvbcxvbm%2Cuiqwerioeqwndjkla`
 		);
+
+		// Assert manifest shape
+		expect(result.manifest).to.deep.equal({
+			manifest: 'arweave/paths',
+			version: '0.1.0',
+			index: { path: '%&@*(%&(@*:">?{}[]' },
+			paths: {
+				'%&@*(%&(@*:">?{}[]': { id: '0000000000000000000000000000000000000000001' },
+				"~!@#$%^&*()_+{}|[]:\";<>?,./`/'/''_\\___''_'__/'___'''_/QWERTYUIOPASDFGHJKLZXCVBNM!@#$%^&*()_+{}:\">?":
+					// eslint-disable-next-line prettier/prettier
+					{ id: '0000000000000000000000000000000000000000003' },
+				'~!@#$%^&*()_+{}|[]:";<>?,./`/dwijqndjqwnjNJKNDKJANKDNJWNJIvmnbzxnmvbcxvbm,uiqwerioeqwndjkla': {
+					id: '0000000000000000000000000000000000000000002'
+				}
+			}
+		});
 	} else {
+		// Verify links are healthy
 		expect(result.links.length).to.equal(4);
 		expect(result.links[0]).to.equal(`https://arweave.net/${result.created[0].dataTxId}`);
 		expect(result.links[1]).to.equal(`https://arweave.net/${result.created[0].dataTxId}/file-in-root`);
@@ -1199,5 +1222,17 @@ function assertUploadManifestExpectations(
 		expect(result.links[3]).to.equal(
 			`https://arweave.net/${result.created[0].dataTxId}/parent-folder/file-in-parent`
 		);
+
+		// Assert manifest shape
+		expect(result.manifest).to.deep.equal({
+			manifest: 'arweave/paths',
+			version: '0.1.0',
+			index: { path: 'file-in-root' },
+			paths: {
+				'file-in-root': { id: '0000000000000000000000000000000000000000001' },
+				'parent-folder/child-folder/file-in-child': { id: '0000000000000000000000000000000000000000003' },
+				'parent-folder/file-in-parent': { id: '0000000000000000000000000000000000000000002' }
+			}
+		});
 	}
 }


### PR DESCRIPTION
This PR adds the `manifest` field to the `ArFSManifestResult` which gives users access to their manifest `.json` file. They can then pipe a copy of the manifest or verify the structure  with a `--dry-run `