### PR TITLE
PE-821: Incorrect price estimation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ardrive-core-js",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "ArDrive Core contains the essential back end application features to support the ArDrive CLI and Desktop apps, such as file management, Permaweb upload/download, wallet management and other common functions.",
 	"main": "./lib/exports.js",
 	"types": "./lib/exports.d.ts",

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -86,11 +86,11 @@ import { Wallet } from './wallet';
 import { JWKWallet } from './jwk_wallet';
 import { WalletDAO } from './wallet_dao';
 import { fakeEntityId } from './utils/constants';
-import { ARDataPriceChunkEstimator } from './pricing/ar_data_price_chunk_estimator';
 import { StreamDecrypt } from './utils/stream_decrypt';
 import { assertFolderExists } from './utils/assert_folder';
 import { join as joinPath } from 'path';
 import { resolveFileNameConflicts, resolveFolderNameConflicts } from './utils/upload_conflict_resolution';
+import { ARDataPriceNetworkEstimator } from './pricing/ar_data_price_network_estimator';
 
 export class ArDrive extends ArDriveAnonymous {
 	constructor(
@@ -100,7 +100,7 @@ export class ArDrive extends ArDriveAnonymous {
 		private readonly communityOracle: CommunityOracle,
 		private readonly appName: string,
 		private readonly appVersion: string,
-		private readonly priceEstimator: ARDataPriceEstimator = new ARDataPriceChunkEstimator(true),
+		private readonly priceEstimator: ARDataPriceEstimator = new ARDataPriceNetworkEstimator(),
 		private readonly feeMultiple: FeeMultiple = new FeeMultiple(1.0),
 		private readonly dryRun: boolean = false
 	) {

--- a/src/ardrive_factory.ts
+++ b/src/ardrive_factory.ts
@@ -10,7 +10,7 @@ import { ArDrive } from './ardrive';
 import { ArDriveAnonymous } from './ardrive_anonymous';
 import { FeeMultiple } from './types';
 import { WalletDAO } from './wallet_dao';
-import { ARDataPriceChunkEstimator } from './pricing/ar_data_price_chunk_estimator';
+import { ARDataPriceNetworkEstimator } from './pricing/ar_data_price_network_estimator';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 
@@ -39,7 +39,7 @@ const defaultArweave = Arweave.init({
 
 export function arDriveFactory({
 	arweave = defaultArweave,
-	priceEstimator = new ARDataPriceChunkEstimator(true),
+	priceEstimator = new ARDataPriceNetworkEstimator(),
 	communityOracle = new ArDriveCommunityOracle(arweave),
 	wallet,
 	walletDao,

--- a/src/pricing/ar_data_price_chunk_estimator.ts
+++ b/src/pricing/ar_data_price_chunk_estimator.ts
@@ -3,7 +3,7 @@ import type { ArweaveOracle } from './arweave_oracle';
 import { AbstractARDataPriceAndCapacityEstimator } from './ar_data_price_estimator';
 import { AR, ByteCount, Winston, W, ArDriveCommunityTip } from '../types';
 
-const byteCountOfChunk = new ByteCount(Math.pow(2, 10) * 256); // 256 KiB
+const byteCountPerChunk = new ByteCount(Math.pow(2, 10) * 256); // 256 KiB
 
 interface ChunkPricingInfo {
 	baseWinstonPrice: Winston;
@@ -89,7 +89,7 @@ export class ARDataPriceChunkEstimator extends AbstractARDataPriceAndCapacityEst
 			return this.pricingInfo.baseWinstonPrice;
 		}
 
-		const numberOfChunksToUpload = Math.ceil(byteCount.valueOf() / byteCountOfChunk.valueOf());
+		const numberOfChunksToUpload = Math.ceil(byteCount.valueOf() / byteCountPerChunk.valueOf());
 
 		// Every 5th chunk, arweave.net pricing adds 1 Winston, which they define as a
 		// mining reward as a proportion of the estimated transaction storage costs
@@ -131,7 +131,7 @@ export class ARDataPriceChunkEstimator extends AbstractARDataPriceAndCapacityEst
 
 			const numChunks = actualWinstonToSpend.dividedBy(perChunkWinstonPrice.toString(), 'ROUND_DOWN');
 
-			return new ByteCount(+numChunks.times(byteCountOfChunk.toString()));
+			return new ByteCount(+numChunks.times(byteCountPerChunk.toString()));
 		}
 
 		// Return 0 if winston price given does not cover the base winston price for a 1 chunk transaction

--- a/src/pricing/ar_data_price_network_estimator.test.ts
+++ b/src/pricing/ar_data_price_network_estimator.test.ts
@@ -1,0 +1,159 @@
+import { GatewayOracle } from './gateway_oracle';
+import type { ArweaveOracle } from './arweave_oracle';
+import { expect } from 'chai';
+import { SinonStubbedInstance, stub } from 'sinon';
+import { W, AR, ByteCount, ArDriveCommunityTip } from '../types';
+import { ARDataPriceChunkEstimator } from './ar_data_price_chunk_estimator';
+import { ARDataPriceNetworkEstimator } from './ar_data_price_network_estimator';
+
+describe('ARDataPriceNetworkEstimator class', () => {
+	let spiedOracle: SinonStubbedInstance<ArweaveOracle>;
+	let calculator: ARDataPriceNetworkEstimator;
+	const chunkSize = 256 * Math.pow(2, 10);
+	const baseFee = 100;
+	const marginalFeePerChunk = 1000;
+
+	const arDriveCommunityTip: ArDriveCommunityTip = { minWinstonFee: W(10), tipPercentage: 0.15 };
+
+	beforeEach(() => {
+		// Simulate actual AR pricing
+		spiedOracle = stub(new GatewayOracle());
+		spiedOracle.getWinstonPriceForByteCount.callsFake((input) =>
+			Promise.resolve(W(Math.ceil(+input / chunkSize) * marginalFeePerChunk + baseFee))
+		);
+		calculator = new ARDataPriceNetworkEstimator(spiedOracle);
+	});
+
+	// This test is less trustworthy now that we don't use Promise.all on the batch of oracle requests
+	it('can be instantiated without making oracle calls', async () => {
+		const gatewayOracleStub = stub(new GatewayOracle());
+		gatewayOracleStub.getWinstonPriceForByteCount.callsFake(() => Promise.resolve(W(123)));
+		new ARDataPriceChunkEstimator(true, gatewayOracleStub);
+		expect(gatewayOracleStub.getWinstonPriceForByteCount.notCalled).to.be.true;
+	});
+
+	it('makes one oracle call after the first price estimation request', async () => {
+		await calculator.getBaseWinstonPriceForByteCount(new ByteCount(0));
+
+		console.log(spiedOracle.getWinstonPriceForByteCount.callCount);
+		expect(spiedOracle.getWinstonPriceForByteCount.calledOnce).to.be.true;
+	});
+
+	it('will return cached price if it matches the chunk size of a previous estimation', async () => {
+		const twoByteResult = await calculator.getBaseWinstonPriceForByteCount(new ByteCount(2));
+		expect(spiedOracle.getWinstonPriceForByteCount.calledOnce).to.be.true;
+
+		const nineByteResult = await calculator.getBaseWinstonPriceForByteCount(new ByteCount(9));
+
+		// Oracle was not called again
+		expect(spiedOracle.getWinstonPriceForByteCount.calledOnce).to.be.true;
+
+		// The results are expected to be the same, because they are both 1 chunk
+		expect(+twoByteResult).to.equal(+nineByteResult);
+	});
+
+	it('getWinstonPriceForByteCount function returns the expected value', async () => {
+		/* Validating that this works in the following scenarios:
+		• 0 bytes: base AR transmission fee
+		• 1 bytes: base fee + marginal chunk fee
+		• 1 chunk of bytes: base fee + marginal chunk fee
+		• 1 chunk of bytes plus 1 byte: base fee + (marginal chunk fee * 2)
+		• 2 chunks of bytes: base fee + (marginal chunk fee * 2)
+		• 5 chunks of bytes: base fee + (marginal chunk fee * 2) + 1
+		• 10 chunks of bytes: base fee + (marginal chunk fee * 2) + 2
+		 */
+		expect(`${await calculator.getBaseWinstonPriceForByteCount(new ByteCount(0))}`).to.equal('100');
+		expect(`${await calculator.getBaseWinstonPriceForByteCount(new ByteCount(1))}`).to.equal('1100');
+		expect(`${await calculator.getBaseWinstonPriceForByteCount(new ByteCount(chunkSize))}`).to.equal('1100');
+		expect(`${await calculator.getBaseWinstonPriceForByteCount(new ByteCount(chunkSize + 1))}`).to.equal('2100');
+		expect(`${await calculator.getBaseWinstonPriceForByteCount(new ByteCount(chunkSize * 2))}`).to.equal('2100');
+		// Extra winston for 5th chunk
+		expect(`${await calculator.getBaseWinstonPriceForByteCount(new ByteCount(chunkSize * 5))}`).to.equal('5100');
+		// Two extra winston for 10th chunk
+		expect(`${await calculator.getBaseWinstonPriceForByteCount(new ByteCount(chunkSize * 10))}`).to.equal('10100');
+	});
+
+	describe('getByteCountForWinston function', () => {
+		it('returns the expected value', async () => {
+			/* Validating that this works in the following scenarios:
+			• 0 Winston: 0 bytes
+			• 1 Winston: 0 bytes
+			• Base fee Winston: 0 bytes
+			• Base fee + 1 Winston: 0 bytes
+			• Base fee + marginal chunk price Winston: chunksize bytes
+			• Base fee + marginal chunk price + 1 Winston: chunksize bytes
+			• Base fee + (2 * marginal chunk price) Winston: 2 * chunksize bytes
+			• Base fee + (5 * marginal chunk price) + 1 Winston: 5 * chunksize bytes
+			• Base fee + (10 * marginal chunk price): 10 * chunksize bytes
+			• Base fee + (8000 * marginal chunk price) + 1600 Winston: 8000 * chunksize bytes
+			*/
+			expect((await calculator.getByteCountForWinston(W(0))).equals(new ByteCount(0))).to.be.true;
+			expect((await calculator.getByteCountForWinston(W(1))).equals(new ByteCount(0))).to.be.true;
+			expect((await calculator.getByteCountForWinston(W(baseFee))).equals(new ByteCount(0))).to.be.true;
+
+			expect(
+				(await calculator.getByteCountForWinston(W(baseFee + marginalFeePerChunk))).equals(
+					new ByteCount(chunkSize)
+				)
+			).to.be.true;
+			console.log(
+				'await calculator.getByteCountForWinston(W(baseFee + marginalFeePerChunk))',
+				await calculator.getByteCountForWinston(W(baseFee + marginalFeePerChunk + 1))
+			);
+			expect(
+				(await calculator.getByteCountForWinston(W(baseFee + marginalFeePerChunk + 1))).equals(
+					new ByteCount(chunkSize)
+				)
+			).to.be.true;
+			expect(
+				(await calculator.getByteCountForWinston(W(baseFee + 2 * marginalFeePerChunk))).equals(
+					new ByteCount(2 * chunkSize)
+				)
+			).to.be.true;
+			expect(
+				(await calculator.getByteCountForWinston(W(baseFee + 5 * marginalFeePerChunk))).equals(
+					new ByteCount(5 * chunkSize)
+				)
+			).to.be.true;
+
+			expect(
+				(await calculator.getByteCountForWinston(W(baseFee + 10 * marginalFeePerChunk))).equals(
+					new ByteCount(10 * chunkSize)
+				)
+			).to.be.true;
+
+			expect(
+				(await calculator.getByteCountForWinston(W(baseFee + 8000 * marginalFeePerChunk))).equals(
+					new ByteCount(8000 * chunkSize)
+				)
+			).to.be.true;
+		});
+	});
+
+	describe('getByteCountForAR function', () => {
+		it('returns the expected value', async () => {
+			const actualByteCountEstimation = await calculator.getByteCountForAR(
+				AR.from(0.000_000_001_265),
+				arDriveCommunityTip
+			);
+			expect(actualByteCountEstimation.equals(new ByteCount(chunkSize))).to.be.true;
+		});
+
+		it('returns 0 if estimation does not cover the minimum winston fee', async () => {
+			const actualByteCountEstimation = await calculator.getByteCountForAR(
+				AR.from(0.000_000_000_010),
+				arDriveCommunityTip
+			);
+			expect(+actualByteCountEstimation).to.equal(0);
+		});
+	});
+
+	it('getARPriceForByteCount function returns the expected value', async () => {
+		const actualARPriceEstimation = await calculator.getARPriceForByteCount(
+			new ByteCount(chunkSize),
+			arDriveCommunityTip
+		);
+
+		expect(`${actualARPriceEstimation}`).to.equal('0.000000001265');
+	});
+});

--- a/src/pricing/ar_data_price_network_estimator.test.ts
+++ b/src/pricing/ar_data_price_network_estimator.test.ts
@@ -35,7 +35,6 @@ describe('ARDataPriceNetworkEstimator class', () => {
 	it('makes one oracle call after the first price estimation request', async () => {
 		await calculator.getBaseWinstonPriceForByteCount(new ByteCount(0));
 
-		console.log(spiedOracle.getWinstonPriceForByteCount.callCount);
 		expect(spiedOracle.getWinstonPriceForByteCount.calledOnce).to.be.true;
 	});
 
@@ -96,10 +95,7 @@ describe('ARDataPriceNetworkEstimator class', () => {
 					new ByteCount(chunkSize)
 				)
 			).to.be.true;
-			console.log(
-				'await calculator.getByteCountForWinston(W(baseFee + marginalFeePerChunk))',
-				await calculator.getByteCountForWinston(W(baseFee + marginalFeePerChunk + 1))
-			);
+
 			expect(
 				(await calculator.getByteCountForWinston(W(baseFee + marginalFeePerChunk + 1))).equals(
 					new ByteCount(chunkSize)

--- a/src/pricing/ar_data_price_network_estimator.ts
+++ b/src/pricing/ar_data_price_network_estimator.ts
@@ -3,7 +3,7 @@ import type { ArweaveOracle } from './arweave_oracle';
 import { AbstractARDataPriceAndCapacityEstimator } from './ar_data_price_estimator';
 import { AR, ByteCount, Winston, ArDriveCommunityTip } from '../types';
 
-const byteCountOfChunk = new ByteCount(Math.pow(2, 10) * 256); // 256 KiB
+const byteCountPerChunk = new ByteCount(Math.pow(2, 10) * 256); // 256 KiB
 
 /**
  * A utility class for Arweave data pricing estimation.
@@ -11,7 +11,7 @@ const byteCountOfChunk = new ByteCount(Math.pow(2, 10) * 256); // 256 KiB
  */
 export class ARDataPriceNetworkEstimator extends AbstractARDataPriceAndCapacityEstimator {
 	private bytesToChunks(bytes: ByteCount): number {
-		return Math.ceil(+bytes / +byteCountOfChunk);
+		return Math.ceil(+bytes / +byteCountPerChunk);
 	}
 
 	private cachedPricePerChunk: { [chunks: string]: Promise<Winston> } = {};
@@ -65,7 +65,7 @@ export class ARDataPriceNetworkEstimator extends AbstractARDataPriceAndCapacityE
 				+winston.minus(baseWinstonPrice).dividedBy(+perChunkEstCost, 'ROUND_DOWN')
 			);
 
-			return new ByteCount(estimatedChunks * +byteCountOfChunk);
+			return new ByteCount(estimatedChunks * +byteCountPerChunk);
 		}
 
 		// Return 0 if winston price given does not cover the base winston price for a 1 chunk transaction

--- a/src/pricing/ar_data_price_network_estimator.ts
+++ b/src/pricing/ar_data_price_network_estimator.ts
@@ -1,0 +1,93 @@
+import { GatewayOracle } from './gateway_oracle';
+import type { ArweaveOracle } from './arweave_oracle';
+import { AbstractARDataPriceAndCapacityEstimator } from './ar_data_price_estimator';
+import { AR, ByteCount, Winston, ArDriveCommunityTip } from '../types';
+
+const byteCountOfChunk = new ByteCount(Math.pow(2, 10) * 256); // 256 KiB
+
+/**
+ * A utility class for Arweave data pricing estimation.
+ * Fetches Arweave pricing and caches results based on their chunk size
+ */
+export class ARDataPriceNetworkEstimator extends AbstractARDataPriceAndCapacityEstimator {
+	private bytesToChunks(bytes: ByteCount): number {
+		return Math.ceil(+bytes / +byteCountOfChunk);
+	}
+
+	private cachedPricePerChunk: { [chunks: string]: Winston } = {};
+
+	/**
+	 * Creates a new estimator.
+	 *
+	 * @param oracle a data source for Arweave data pricing
+	 */
+	constructor(private readonly oracle: ArweaveOracle = new GatewayOracle()) {
+		super();
+	}
+
+	/**
+	 * Generates a price estimate, in Winston, for an upload of size `byteCount`.
+	 *
+	 * @param byteCount the number of bytes for which a price estimate should be generated
+	 *
+	 * @returns Promise for the price of an upload of size `byteCount` in Winston
+	 *
+	 * @remarks Will use cached price first for a given chunk size
+	 *
+	 */
+	public async getBaseWinstonPriceForByteCount(byteCount: ByteCount): Promise<Winston> {
+		const chunks = this.bytesToChunks(byteCount);
+		const cachedPrice = this.cachedPricePerChunk[`${chunks}`];
+
+		if (cachedPrice) {
+			return cachedPrice;
+		}
+
+		const winstonPrice = await this.oracle.getWinstonPriceForByteCount(byteCount);
+		this.cachedPricePerChunk[`${chunks}`] = winstonPrice;
+
+		return winstonPrice;
+	}
+
+	/**
+	 * Estimates the number of bytes that can be stored for a given amount of Winston
+	 *
+	 * @remarks This method is meant to only be an estimation at this time, do not use to calculate real values!
+	 * @remarks The ArDrive community fee is not considered in this estimation
+	 */
+	public async getByteCountForWinston(winston: Winston): Promise<ByteCount> {
+		console.log('winston', winston);
+		const baseWinstonPrice = await this.getBaseWinstonPriceForByteCount(new ByteCount(0));
+		console.log('baseWinstonPrice', baseWinstonPrice);
+		const oneChunkWinstonPrice = await this.getBaseWinstonPriceForByteCount(new ByteCount(1));
+		console.log('oneChunkWinstonPrice', oneChunkWinstonPrice);
+
+		if (winston.isGreaterThanOrEqualTo(oneChunkWinstonPrice)) {
+			const perChunkEstCost = oneChunkWinstonPrice.minus(baseWinstonPrice);
+			console.log('perChunkEstCost', perChunkEstCost);
+			const estimatedChunks = Math.floor(
+				+winston.minus(baseWinstonPrice).dividedBy(+perChunkEstCost, 'ROUND_DOWN')
+			);
+			console.log('estimatedChunks', estimatedChunks);
+
+			// (price - base) / perChunkEst
+
+			return new ByteCount(estimatedChunks * +byteCountOfChunk);
+		}
+
+		// Return 0 if winston price given does not cover the base winston price for a 1 chunk transaction
+		return new ByteCount(0);
+	}
+
+	/**
+	 * Estimates the number of bytes that can be stored for a given amount of AR
+	 *
+	 * @remarks Returns 0 bytes when the price does not cover minimum ArDrive community fee
+	 */
+	public async getByteCountForAR(
+		arPrice: AR,
+		{ minWinstonFee, tipPercentage }: ArDriveCommunityTip
+	): Promise<ByteCount> {
+		return super.getByteCountForAR(arPrice, { minWinstonFee, tipPercentage });
+	}
+}

--- a/src/pricing/ar_data_price_network_estimator.ts
+++ b/src/pricing/ar_data_price_network_estimator.ts
@@ -14,7 +14,7 @@ export class ARDataPriceNetworkEstimator extends AbstractARDataPriceAndCapacityE
 		return Math.ceil(+bytes / +byteCountOfChunk);
 	}
 
-	private cachedPricePerChunk: { [chunks: string]: Winston } = {};
+	private cachedPricePerChunk: { [chunks: string]: Promise<Winston> } = {};
 
 	/**
 	 * Creates a new estimator.
@@ -43,10 +43,10 @@ export class ARDataPriceNetworkEstimator extends AbstractARDataPriceAndCapacityE
 			return cachedPrice;
 		}
 
-		const winstonPrice = await this.oracle.getWinstonPriceForByteCount(byteCount);
-		this.cachedPricePerChunk[`${chunks}`] = winstonPrice;
+		const winstonPricePromise = this.oracle.getWinstonPriceForByteCount(byteCount);
+		this.cachedPricePerChunk[`${chunks}`] = winstonPricePromise;
 
-		return winstonPrice;
+		return winstonPricePromise;
 	}
 
 	/**

--- a/src/pricing/ar_data_price_network_estimator.ts
+++ b/src/pricing/ar_data_price_network_estimator.ts
@@ -56,21 +56,14 @@ export class ARDataPriceNetworkEstimator extends AbstractARDataPriceAndCapacityE
 	 * @remarks The ArDrive community fee is not considered in this estimation
 	 */
 	public async getByteCountForWinston(winston: Winston): Promise<ByteCount> {
-		console.log('winston', winston);
 		const baseWinstonPrice = await this.getBaseWinstonPriceForByteCount(new ByteCount(0));
-		console.log('baseWinstonPrice', baseWinstonPrice);
 		const oneChunkWinstonPrice = await this.getBaseWinstonPriceForByteCount(new ByteCount(1));
-		console.log('oneChunkWinstonPrice', oneChunkWinstonPrice);
 
 		if (winston.isGreaterThanOrEqualTo(oneChunkWinstonPrice)) {
 			const perChunkEstCost = oneChunkWinstonPrice.minus(baseWinstonPrice);
-			console.log('perChunkEstCost', perChunkEstCost);
 			const estimatedChunks = Math.floor(
 				+winston.minus(baseWinstonPrice).dividedBy(+perChunkEstCost, 'ROUND_DOWN')
 			);
-			console.log('estimatedChunks', estimatedChunks);
-
-			// (price - base) / perChunkEst
 
 			return new ByteCount(estimatedChunks * +byteCountOfChunk);
 		}


### PR DESCRIPTION
This PR replaces the chunk estimator with a new `ARDataPriceNetworkEstimator`. Unfortunately, our assumptions with the arweave pricing algorithm have proven to be false. We are under funding rewards on production.

This new class will cache the pricing results based on how many chunks the byteCount would've been. With chunk based caching we can still be efficient when pricing metaData transactions and base fee transactions. It will get the cached value or simply call the gateway directly if a cached price is not found.

Since this is a hot-fix with the base branch of `master`, here are the proposed GitHub release notes:

- Price estimator now gathers and caches prices directly from the gateway