### PR TITLE
chore(deps): Lock arweave version PE-843

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"types": "./lib/exports.d.ts",
 	"dependencies": {
 		"arbundles": "^0.5.5",
-		"arweave": "^1.10.18",
+		"arweave": "1.10.18",
 		"arweave-mnemonic-keys": "^0.0.9",
 		"axios": "^0.21.1",
 		"base64-js": "^1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1582,7 +1582,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^4.18.0
     "@typescript-eslint/parser": ^4.18.0
     arbundles: ^0.5.5
-    arweave: ^1.10.18
+    arweave: 1.10.18
     arweave-mnemonic-keys: ^0.0.9
     axios: ^0.21.1
     base64-js: ^1.5.1
@@ -1697,7 +1697,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"arweave@npm:^1.10.0, arweave@npm:^1.10.13, arweave@npm:^1.10.15, arweave@npm:^1.10.16, arweave@npm:^1.10.18":
+"arweave@npm:1.10.18, arweave@npm:^1.10.0, arweave@npm:^1.10.13, arweave@npm:^1.10.15, arweave@npm:^1.10.16":
   version: 1.10.18
   resolution: "arweave@npm:1.10.18"
   dependencies:


### PR DESCRIPTION
GitHub Release:

- `arweave-js` version is now locked to `1.10.18`