### PR TITLE
PE-928: validate drive name when creating new drives

### DIFF
--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -113,6 +113,7 @@ import {
 import { ArFSTagSettings } from './arfs/arfs_tag_settings';
 import { NameConflictInfo } from './utils/mapper_functions';
 import { ARDataPriceNetworkEstimator } from './pricing/ar_data_price_network_estimator';
+import { assertValidArFSDriveName } from './arfs/arfs_entity_name_validators';
 import { TipData } from './exports';
 
 export class ArDrive extends ArDriveAnonymous {
@@ -1204,13 +1205,19 @@ export class ArDrive extends ArDriveAnonymous {
 	}
 
 	public async createPublicDrive(params: CreatePublicDriveParams): Promise<ArFSResult> {
+		const { driveName } = params;
+
+		assertValidArFSDriveName(driveName);
+
 		return this.createDrive(getPublicCreateDriveEstimationPrototypes(params), (rewardSettings) =>
-			this.arFsDao.createPublicDrive({ driveName: params.driveName, rewardSettings })
+			this.arFsDao.createPublicDrive({ driveName, rewardSettings })
 		);
 	}
 
 	public async createPrivateDrive(params: CreatePrivateDriveParams): Promise<ArFSResult> {
 		const { driveName, newPrivateDriveData: newDriveData } = params;
+
+		assertValidArFSDriveName(driveName);
 
 		const createDriveResult = await this.createDrive(
 			await getPrivateCreateDriveEstimationPrototypes(params),

--- a/src/arfs/arfs_entity_name_validators.test.ts
+++ b/src/arfs/arfs_entity_name_validators.test.ts
@@ -1,5 +1,9 @@
 import { expect } from 'chai';
-import { assertValidArFSFileName, assertValidArFSFolderName } from './arfs_entity_name_validators';
+import {
+	assertValidArFSDriveName,
+	assertValidArFSFileName,
+	assertValidArFSFolderName
+} from './arfs_entity_name_validators';
 
 describe('entity name validators', () => {
 	const validNames = [
@@ -41,6 +45,11 @@ describe('entity name validators', () => {
 			entity: 'folder',
 			methodName: 'assertValidArFSFolderName',
 			validationMethod: assertValidArFSFolderName
+		},
+		{
+			entity: 'drive',
+			methodName: 'assertValidArFSDriveName',
+			validationMethod: assertValidArFSDriveName
 		}
 	];
 

--- a/src/arfs/arfs_entity_name_validators.test.ts
+++ b/src/arfs/arfs_entity_name_validators.test.ts
@@ -2,153 +2,89 @@ import { expect } from 'chai';
 import { assertValidArFSFileName, assertValidArFSFolderName } from './arfs_entity_name_validators';
 
 describe('entity name validators', () => {
-	describe('assertValidArFSFileName method', () => {
-		const validNames = [
-			'.bashrc',
-			'===============================================================================================================================================================================================================================================================',
-			'abcdefghijklmnopqrstuvwxyz',
-			'ñññññññññññññññññ.png',
-			'valid name with     spaces.txt',
-			'valid.name.with.....dots.txt'
-		];
-		const tooLongName =
-			'+===============================================================================================================================================================================================================================================================';
-		const namesWithReservedCharacters = [
-			'\\\\\\\\\\\\\\\\\\\\.png',
-			'//////////.png',
-			'::::::::::.png',
-			'**********.png',
-			'??????????.png',
-			'"""""""""".png',
-			'<<<<<<<<<<.png',
-			'>>>>>>>>>>.png',
-			'||||||||||.png'
-		];
-		const namesWithLeadingSpaces = [
-			'  thisIsAFileNameWithTwoLeadingSpaces.doc',
-			' thisFilenameHasOneSingleSpace.doc'
-		];
-		const namesWithTrailingSpacesOrDots = [
-			'soWeHaveAFileNameThatEndsWithADot.',
-			'thenAFileNameWithMultipleDots...',
-			'aFileNameWithATrailingSpace ',
-			'anotherFileNameWithSpaces   '
-		];
+	const validNames = [
+		'.bashrc',
+		'===============================================================================================================================================================================================================================================================',
+		'abcdefghijklmnopqrstuvwxyz',
+		'ñññññññññññññññññ.png',
+		'valid name with     spaces.txt',
+		'valid.name.with.....dots.txt'
+	];
+	const tooLongName =
+		'+===============================================================================================================================================================================================================================================================';
+	const namesWithReservedCharacters = [
+		'\\\\\\\\\\\\\\\\\\\\.png',
+		'//////////.png',
+		'::::::::::.png',
+		'**********.png',
+		'??????????.png',
+		'"""""""""".png',
+		'<<<<<<<<<<.png',
+		'>>>>>>>>>>.png',
+		'||||||||||.png'
+	];
+	const namesWithLeadingSpaces = ['  thisIsAFileNameWithTwoLeadingSpaces.doc', ' thisFilenameHasOneSingleSpace.doc'];
+	const namesWithTrailingSpacesOrDots = [
+		'soWeHaveAFileNameThatEndsWithADot.',
+		'thenAFileNameWithMultipleDots...',
+		'aFileNameWithATrailingSpace ',
+		'anotherFileNameWithSpaces   '
+	];
 
-		it('returns true when fed with an ArFS compliant name', () => {
-			validNames.forEach((name) => {
-				expect(assertValidArFSFileName(name)).to.be.true;
+	const testsList = [
+		{
+			entity: 'file',
+			methodName: 'assertValidArFSFileName',
+			validationMethod: assertValidArFSFileName
+		},
+		{
+			entity: 'folder',
+			methodName: 'assertValidArFSFolderName',
+			validationMethod: assertValidArFSFolderName
+		}
+	];
+
+	testsList.forEach(({ entity, methodName, validationMethod }) => {
+		describe(`${methodName} method`, () => {
+			it('returns true when fed with an ArFS compliant name', () => {
+				validNames.forEach((name) => {
+					expect(validationMethod(name)).to.be.true;
+				});
 			});
-		});
 
-		it('throws when the name is too long', () => {
-			expect(() => assertValidArFSFileName(tooLongName)).to.throw(
-				'The file name must contain between 1 and 255 characters'
-			);
-		});
-
-		it('throws when the name is too short', () => {
-			expect(() => assertValidArFSFileName('')).to.throw(
-				'The file name must contain between 1 and 255 characters'
-			);
-		});
-
-		it('throws when the name contains reserved characters', () => {
-			namesWithReservedCharacters.forEach((invalidName) => {
-				expect(() => assertValidArFSFileName(invalidName)).to.throw(
-					"The file name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '\"', '<', '>', '|')"
+			it('throws when the name is too long', () => {
+				expect(() => validationMethod(tooLongName)).to.throw(
+					`The ${entity} name must contain between 1 and 255 characters`
 				);
 			});
-		});
 
-		it('throws when the name contains leading spaces', () => {
-			namesWithLeadingSpaces.forEach((invalidName) =>
-				expect(() => assertValidArFSFileName(invalidName)).to.throw('The file name cannot start with spaces')
-			);
-		});
-
-		it('throws when the name contains trailing dots or spaces', () => {
-			namesWithTrailingSpacesOrDots.forEach((invalidName) =>
-				expect(() => assertValidArFSFileName(invalidName)).to.throw(
-					'The file name cannot have trailing dots or spaces'
-				)
-			);
-		});
-	});
-
-	describe('assertValidArFSFolderName method', () => {
-		const validNames = [
-			'.bashrc',
-			'===============================================================================================================================================================================================================================================================',
-			'abcdefghijklmnopqrstuvwxyz',
-			'ñññññññññññññññññ.png',
-			'valid name with     spaces.txt',
-			'valid.name.with.....dots.txt'
-		];
-		const tooLongName =
-			'+===============================================================================================================================================================================================================================================================';
-		const namesWithReservedCharacters = [
-			'\\\\\\\\\\\\\\\\\\\\.png',
-			'//////////.png',
-			'::::::::::.png',
-			'**********.png',
-			'??????????.png',
-			'"""""""""".png',
-			'<<<<<<<<<<.png',
-			'>>>>>>>>>>.png',
-			'||||||||||.png'
-		];
-		const namesWithLeadingSpaces = [
-			'  thisIsAFileNameWithTwoLeadingSpaces.doc',
-			' thisFilenameHasOneSingleSpace.doc'
-		];
-		const namesWithTrailingSpacesOrDots = [
-			'soWeHaveAFileNameThatEndsWithADot.',
-			'thenAFileNameWithMultipleDots...',
-			'aFileNameWithATrailingSpace ',
-			'anotherFileNameWithSpaces   '
-		];
-
-		it('returns true when fed with an ArFS compliant name', () => {
-			validNames.forEach((name) => {
-				expect(assertValidArFSFolderName(name)).to.be.true;
-			});
-		});
-
-		it('throws when the name is too long', () => {
-			expect(() => assertValidArFSFolderName(tooLongName)).to.throw(
-				'The folder name must contain between 1 and 255 characters'
-			);
-		});
-
-		it('throws when the name is too short', () => {
-			expect(() => assertValidArFSFolderName('')).to.throw(
-				'The folder name must contain between 1 and 255 characters'
-			);
-		});
-
-		it('throws when the name contains reserved characters', () => {
-			namesWithReservedCharacters.forEach((invalidName) => {
-				expect(() => assertValidArFSFolderName(invalidName)).to.throw(
-					"The folder name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '\"', '<', '>', '|')"
+			it('throws when the name is too short', () => {
+				expect(() => validationMethod('')).to.throw(
+					`The ${entity} name must contain between 1 and 255 characters`
 				);
 			});
-		});
 
-		it('throws when the name contains leading spaces', () => {
-			namesWithLeadingSpaces.forEach((invalidName) =>
-				expect(() => assertValidArFSFolderName(invalidName)).to.throw(
-					'The folder name cannot start with spaces'
-				)
-			);
-		});
+			it('throws when the name contains reserved characters', () => {
+				namesWithReservedCharacters.forEach((invalidName) => {
+					expect(() => validationMethod(invalidName)).to.throw(
+						`The ${entity} name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '"', '<', '>', '|')`
+					);
+				});
+			});
 
-		it('throws when the name contains trailing dots or spaces', () => {
-			namesWithTrailingSpacesOrDots.forEach((invalidName) =>
-				expect(() => assertValidArFSFolderName(invalidName)).to.throw(
-					'The folder name cannot have trailing dots or spaces'
-				)
-			);
+			it('throws when the name contains leading spaces', () => {
+				namesWithLeadingSpaces.forEach((invalidName) =>
+					expect(() => validationMethod(invalidName)).to.throw(`The ${entity} name cannot start with spaces`)
+				);
+			});
+
+			it('throws when the name contains trailing dots or spaces', () => {
+				namesWithTrailingSpacesOrDots.forEach((invalidName) =>
+					expect(() => validationMethod(invalidName)).to.throw(
+						`The ${entity} name cannot have trailing dots or spaces`
+					)
+				);
+			});
 		});
 	});
 });

--- a/src/arfs/arfs_entity_name_validators.test.ts
+++ b/src/arfs/arfs_entity_name_validators.test.ts
@@ -1,0 +1,154 @@
+import { expect } from 'chai';
+import { assertValidArFSFileName, assertValidArFSFolderName } from './arfs_entity_name_validators';
+
+describe('entity name validators', () => {
+	describe('assertValidArFSFileName method', () => {
+		const validNames = [
+			'.bashrc',
+			'===============================================================================================================================================================================================================================================================',
+			'abcdefghijklmnopqrstuvwxyz',
+			'ñññññññññññññññññ.png',
+			'valid name with     spaces.txt',
+			'valid.name.with.....dots.txt'
+		];
+		const tooLongName =
+			'+===============================================================================================================================================================================================================================================================';
+		const namesWithReservedCharacters = [
+			'\\\\\\\\\\\\\\\\\\\\.png',
+			'//////////.png',
+			'::::::::::.png',
+			'**********.png',
+			'??????????.png',
+			'"""""""""".png',
+			'<<<<<<<<<<.png',
+			'>>>>>>>>>>.png',
+			'||||||||||.png'
+		];
+		const namesWithLeadingSpaces = [
+			'  thisIsAFileNameWithTwoLeadingSpaces.doc',
+			' thisFilenameHasOneSingleSpace.doc'
+		];
+		const namesWithTrailingSpacesOrDots = [
+			'soWeHaveAFileNameThatEndsWithADot.',
+			'thenAFileNameWithMultipleDots...',
+			'aFileNameWithATrailingSpace ',
+			'anotherFileNameWithSpaces   '
+		];
+
+		it('returns true when fed with an ArFS compliant name', () => {
+			validNames.forEach((name) => {
+				expect(assertValidArFSFileName(name)).to.be.true;
+			});
+		});
+
+		it('throws when the name is too long', () => {
+			expect(() => assertValidArFSFileName(tooLongName)).to.throw(
+				'The file name must contain between 1 and 255 characters'
+			);
+		});
+
+		it('throws when the name is too short', () => {
+			expect(() => assertValidArFSFileName('')).to.throw(
+				'The file name must contain between 1 and 255 characters'
+			);
+		});
+
+		it('throws when the name contains reserved characters', () => {
+			namesWithReservedCharacters.forEach((invalidName) => {
+				expect(() => assertValidArFSFileName(invalidName)).to.throw(
+					"The file name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '\"', '<', '>', '|')"
+				);
+			});
+		});
+
+		it('throws when the name contains leading spaces', () => {
+			namesWithLeadingSpaces.forEach((invalidName) =>
+				expect(() => assertValidArFSFileName(invalidName)).to.throw('The file name cannot start with spaces')
+			);
+		});
+
+		it('throws when the name contains trailing dots or spaces', () => {
+			namesWithTrailingSpacesOrDots.forEach((invalidName) =>
+				expect(() => assertValidArFSFileName(invalidName)).to.throw(
+					'The file name cannot have trailing dots or spaces'
+				)
+			);
+		});
+	});
+
+	describe('assertValidArFSFolderName method', () => {
+		const validNames = [
+			'.bashrc',
+			'===============================================================================================================================================================================================================================================================',
+			'abcdefghijklmnopqrstuvwxyz',
+			'ñññññññññññññññññ.png',
+			'valid name with     spaces.txt',
+			'valid.name.with.....dots.txt'
+		];
+		const tooLongName =
+			'+===============================================================================================================================================================================================================================================================';
+		const namesWithReservedCharacters = [
+			'\\\\\\\\\\\\\\\\\\\\.png',
+			'//////////.png',
+			'::::::::::.png',
+			'**********.png',
+			'??????????.png',
+			'"""""""""".png',
+			'<<<<<<<<<<.png',
+			'>>>>>>>>>>.png',
+			'||||||||||.png'
+		];
+		const namesWithLeadingSpaces = [
+			'  thisIsAFileNameWithTwoLeadingSpaces.doc',
+			' thisFilenameHasOneSingleSpace.doc'
+		];
+		const namesWithTrailingSpacesOrDots = [
+			'soWeHaveAFileNameThatEndsWithADot.',
+			'thenAFileNameWithMultipleDots...',
+			'aFileNameWithATrailingSpace ',
+			'anotherFileNameWithSpaces   '
+		];
+
+		it('returns true when fed with an ArFS compliant name', () => {
+			validNames.forEach((name) => {
+				expect(assertValidArFSFolderName(name)).to.be.true;
+			});
+		});
+
+		it('throws when the name is too long', () => {
+			expect(() => assertValidArFSFolderName(tooLongName)).to.throw(
+				'The folder name must contain between 1 and 255 characters'
+			);
+		});
+
+		it('throws when the name is too short', () => {
+			expect(() => assertValidArFSFolderName('')).to.throw(
+				'The folder name must contain between 1 and 255 characters'
+			);
+		});
+
+		it('throws when the name contains reserved characters', () => {
+			namesWithReservedCharacters.forEach((invalidName) => {
+				expect(() => assertValidArFSFolderName(invalidName)).to.throw(
+					"The folder name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '\"', '<', '>', '|')"
+				);
+			});
+		});
+
+		it('throws when the name contains leading spaces', () => {
+			namesWithLeadingSpaces.forEach((invalidName) =>
+				expect(() => assertValidArFSFolderName(invalidName)).to.throw(
+					'The folder name cannot start with spaces'
+				)
+			);
+		});
+
+		it('throws when the name contains trailing dots or spaces', () => {
+			namesWithTrailingSpacesOrDots.forEach((invalidName) =>
+				expect(() => assertValidArFSFolderName(invalidName)).to.throw(
+					'The folder name cannot have trailing dots or spaces'
+				)
+			);
+		});
+	});
+});

--- a/src/arfs/arfs_entity_name_validators.ts
+++ b/src/arfs/arfs_entity_name_validators.ts
@@ -1,3 +1,5 @@
+import { EntityType } from '../types';
+
 const RESERVED_CHARACTERS = ['\\\\', '/', ':', '*', '?', '"', '<', '>', '|'];
 const HUMAN_READABLE_RESERVED_CHARACTERS = RESERVED_CHARACTERS.map((char) => `'${char}'`).join(', ');
 
@@ -9,8 +11,9 @@ const MAX_VALID_NAME_LENGTH = 255;
 
 export const assertValidArFSFileName = assertValidArFSEntityNameFactory('file');
 export const assertValidArFSFolderName = assertValidArFSEntityNameFactory('folder');
+export const assertValidArFSDriveName = assertValidArFSEntityNameFactory('drive');
 
-export function assertValidArFSEntityNameFactory(entityType: 'file' | 'folder'): (name: string) => boolean {
+export function assertValidArFSEntityNameFactory(entityType: EntityType): (name: string) => boolean {
 	return function (name: string) {
 		if (name.length > MAX_VALID_NAME_LENGTH || name.length === 0) {
 			throw new Error(`The ${entityType} name must contain between 1 and ${MAX_VALID_NAME_LENGTH} characters`);

--- a/src/arfs/arfs_entity_name_validators.ts
+++ b/src/arfs/arfs_entity_name_validators.ts
@@ -1,0 +1,37 @@
+const RESERVED_CHARACTERS = ['\\\\', '/', ':', '*', '?', '"', '<', '>', '|'];
+const HUMAN_READABLE_RESERVED_CHARACTERS = RESERVED_CHARACTERS.map((char) => `'${char}'`).join(', ');
+
+const LEADING_SPACES_REGEXP = /^(\s+)/;
+const TRAILING_DOTS_OR_SPACES_REGEXP = /(\s|\.)+$/;
+const CONTAINS_RESERVED_CHARACTER_REGEXP = new RegExp(`[${RESERVED_CHARACTERS.join('')}]`, 'g');
+// From ArFS Standards
+const MAX_VALID_NAME_LENGTH = 255;
+
+export const assertValidArFSFileName = assertValidArFSEntityNameFactory('file');
+export const assertValidArFSFolderName = assertValidArFSEntityNameFactory('folder');
+
+export function assertValidArFSEntityNameFactory(entityType: 'file' | 'folder'): (name: string) => boolean {
+	return function (name: string) {
+		if (name.length > MAX_VALID_NAME_LENGTH || name.length === 0) {
+			throw new Error(`The ${entityType} name must contain between 1 and ${MAX_VALID_NAME_LENGTH} characters`);
+		}
+
+		const matchLeadingSpaces = name.match(LEADING_SPACES_REGEXP);
+		if (matchLeadingSpaces) {
+			throw new Error(`The ${entityType} name cannot start with spaces`);
+		}
+
+		const matchTrailingDotsOrSpaces = name.match(TRAILING_DOTS_OR_SPACES_REGEXP);
+		if (matchTrailingDotsOrSpaces) {
+			throw new Error(`The ${entityType} name cannot have trailing dots or spaces`);
+		}
+
+		const matchReservedCharacters = name.match(CONTAINS_RESERVED_CHARACTER_REGEXP);
+		if (matchReservedCharacters) {
+			throw new Error(
+				`The ${entityType} name cannot contain reserved characters (i.e. ${HUMAN_READABLE_RESERVED_CHARACTERS})`
+			);
+		}
+		return true;
+	};
+}

--- a/tests/integration/ardrive.int.test.ts
+++ b/tests/integration/ardrive.int.test.ts
@@ -114,6 +114,9 @@ describe('ArDrive class - integrated', () => {
 	const unexpectedDriveId = EID(stubEntityIDAlt.toString());
 	const existingFileId = EID(stubEntityIDAlt.toString());
 
+	const invalidEntityName = '*\\/:*?:<>|_invalidName.png';
+	const validEntityName = 'some happy file name which is valid.txt';
+
 	beforeEach(() => {
 		// Set pricing algo up as x = y (bytes = Winston)
 		stub(arweaveOracle, 'getWinstonPriceForByteCount').callsFake((input) => Promise.resolve(W(+input)));
@@ -142,21 +145,47 @@ describe('ArDrive class - integrated', () => {
 
 	describe('drive function', () => {
 		describe('createPublicDrive', () => {
+			it('throws if the given name is invalid', () => {
+				return expectAsyncErrorThrow({
+					promiseToError: arDrive.createPublicDrive({
+						driveName: invalidEntityName
+					}),
+					errorMessage: `The drive name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '"', '<', '>', '|')`
+				});
+			});
+
 			it('returns the correct ArFSResult', async () => {
-				const result = await arDrive.createPublicDrive({ driveName: 'TEST_DRIVE' });
-				assertCreateDriveExpectations(result, W(75), W(21));
+				const result = await arDrive.createPublicDrive({ driveName: validEntityName });
+
+				assertCreateDriveExpectations(result, W(104), W(50));
 			});
 
 			it('returns the correct bundled ArFSResult', async () => {
 				const result = await bundledArDrive.createPublicDrive({
-					driveName: 'TEST_DRIVE'
+					driveName: validEntityName
 				});
 
-				assertCreateDriveExpectations(result, W(2751), W(37), undefined, true);
+				assertCreateDriveExpectations(result, W(2809), W(37), undefined, true);
 			});
 		});
 
 		describe('createPrivateDrive', () => {
+			it('throws if the given name is invalid', async () => {
+				const stubDriveKey = await getStubDriveKey();
+				const stubPrivateDriveData: PrivateDriveKeyData = {
+					driveId: stubEntityID,
+					driveKey: stubDriveKey
+				};
+
+				return expectAsyncErrorThrow({
+					promiseToError: arDrive.createPrivateDrive({
+						driveName: invalidEntityName,
+						newPrivateDriveData: stubPrivateDriveData
+					}),
+					errorMessage: `The drive name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '"', '<', '>', '|')`
+				});
+			});
+
 			it('returns the correct ArFSResult', async () => {
 				const stubDriveKey = await getStubDriveKey();
 				const stubPrivateDriveData: PrivateDriveKeyData = {
@@ -165,10 +194,11 @@ describe('ArDrive class - integrated', () => {
 				};
 
 				const result = await arDrive.createPrivateDrive({
-					driveName: 'TEST_DRIVE',
+					driveName: validEntityName,
 					newPrivateDriveData: stubPrivateDriveData
 				});
-				assertCreateDriveExpectations(result, W(91), W(37), urlEncodeHashKey(stubDriveKey));
+
+				assertCreateDriveExpectations(result, W(120), W(66), urlEncodeHashKey(stubDriveKey));
 			});
 
 			it('returns the correct bundled ArFSResult', async () => {
@@ -179,10 +209,11 @@ describe('ArDrive class - integrated', () => {
 				};
 
 				const result = await bundledArDrive.createPrivateDrive({
-					driveName: 'TEST_DRIVE',
+					driveName: validEntityName,
 					newPrivateDriveData: stubPrivateDriveData
 				});
-				assertCreateDriveExpectations(result, W(2915), W(37), urlEncodeHashKey(stubDriveKey), true);
+
+				assertCreateDriveExpectations(result, W(2973), W(37), urlEncodeHashKey(stubDriveKey), true);
 			});
 		});
 	});


### PR DESCRIPTION
This PR is heavily based on @matibat work on rename files, folders and drives feature.

- improves ArFS entity name validators tests making them parameterized
- add drive name validation to `createPublicDrive` and `createPrivateDrive` integration tests
- add drive name validation to drive creation methods