### PR TITLE
 PE-929: validate folder name when creating new folders

### DIFF
--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -113,6 +113,7 @@ import {
 import { ArFSTagSettings } from './arfs/arfs_tag_settings';
 import { NameConflictInfo } from './utils/mapper_functions';
 import { ARDataPriceNetworkEstimator } from './pricing/ar_data_price_network_estimator';
+import { assertValidArFSFolderName } from './arfs/arfs_entity_name_validators';
 import { TipData } from './exports';
 
 export class ArDrive extends ArDriveAnonymous {
@@ -1059,6 +1060,8 @@ export class ArDrive extends ArDriveAnonymous {
 	}
 
 	public async createPublicFolder({ folderName, parentFolderId }: CreatePublicFolderParams): Promise<ArFSResult> {
+		assertValidArFSFolderName(folderName);
+
 		const driveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
 		const owner = await this.arFsDao.getOwnerAndAssertDrive(driveId);
 		await this.assertOwnerAddress(owner);
@@ -1107,6 +1110,8 @@ export class ArDrive extends ArDriveAnonymous {
 		driveKey,
 		parentFolderId
 	}: CreatePrivateFolderParams): Promise<ArFSResult> {
+		assertValidArFSFolderName(folderName);
+
 		const driveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
 		const owner = await this.arFsDao.getOwnerAndAssertDrive(driveId, driveKey);
 		await this.assertOwnerAddress(owner);

--- a/src/arfs/arfs_entity_name_validators.test.ts
+++ b/src/arfs/arfs_entity_name_validators.test.ts
@@ -2,153 +2,89 @@ import { expect } from 'chai';
 import { assertValidArFSFileName, assertValidArFSFolderName } from './arfs_entity_name_validators';
 
 describe('entity name validators', () => {
-	describe('assertValidArFSFileName method', () => {
-		const validNames = [
-			'.bashrc',
-			'===============================================================================================================================================================================================================================================================',
-			'abcdefghijklmnopqrstuvwxyz',
-			'ñññññññññññññññññ.png',
-			'valid name with     spaces.txt',
-			'valid.name.with.....dots.txt'
-		];
-		const tooLongName =
-			'+===============================================================================================================================================================================================================================================================';
-		const namesWithReservedCharacters = [
-			'\\\\\\\\\\\\\\\\\\\\.png',
-			'//////////.png',
-			'::::::::::.png',
-			'**********.png',
-			'??????????.png',
-			'"""""""""".png',
-			'<<<<<<<<<<.png',
-			'>>>>>>>>>>.png',
-			'||||||||||.png'
-		];
-		const namesWithLeadingSpaces = [
-			'  thisIsAFileNameWithTwoLeadingSpaces.doc',
-			' thisFilenameHasOneSingleSpace.doc'
-		];
-		const namesWithTrailingSpacesOrDots = [
-			'soWeHaveAFileNameThatEndsWithADot.',
-			'thenAFileNameWithMultipleDots...',
-			'aFileNameWithATrailingSpace ',
-			'anotherFileNameWithSpaces   '
-		];
+	const validNames = [
+		'.bashrc',
+		'===============================================================================================================================================================================================================================================================',
+		'abcdefghijklmnopqrstuvwxyz',
+		'ñññññññññññññññññ.png',
+		'valid name with     spaces.txt',
+		'valid.name.with.....dots.txt'
+	];
+	const tooLongName =
+		'+===============================================================================================================================================================================================================================================================';
+	const namesWithReservedCharacters = [
+		'\\\\\\\\\\\\\\\\\\\\.png',
+		'//////////.png',
+		'::::::::::.png',
+		'**********.png',
+		'??????????.png',
+		'"""""""""".png',
+		'<<<<<<<<<<.png',
+		'>>>>>>>>>>.png',
+		'||||||||||.png'
+	];
+	const namesWithLeadingSpaces = ['  thisIsAFileNameWithTwoLeadingSpaces.doc', ' thisFilenameHasOneSingleSpace.doc'];
+	const namesWithTrailingSpacesOrDots = [
+		'soWeHaveAFileNameThatEndsWithADot.',
+		'thenAFileNameWithMultipleDots...',
+		'aFileNameWithATrailingSpace ',
+		'anotherFileNameWithSpaces   '
+	];
 
-		it('returns true when fed with an ArFS compliant name', () => {
-			validNames.forEach((name) => {
-				expect(assertValidArFSFileName(name)).to.be.true;
+	const testsList = [
+		{
+			entity: 'file',
+			methodName: 'assertValidArFSFileName',
+			validationMethod: assertValidArFSFileName
+		},
+		{
+			entity: 'folder',
+			methodName: 'assertValidArFSFolderName',
+			validationMethod: assertValidArFSFolderName
+		}
+	];
+
+	testsList.forEach(({ entity, methodName, validationMethod }) => {
+		describe(`${methodName} method`, () => {
+			it('returns true when fed with an ArFS compliant name', () => {
+				validNames.forEach((name) => {
+					expect(validationMethod(name)).to.be.true;
+				});
 			});
-		});
 
-		it('throws when the name is too long', () => {
-			expect(() => assertValidArFSFileName(tooLongName)).to.throw(
-				'The file name must contain between 1 and 255 characters'
-			);
-		});
-
-		it('throws when the name is too short', () => {
-			expect(() => assertValidArFSFileName('')).to.throw(
-				'The file name must contain between 1 and 255 characters'
-			);
-		});
-
-		it('throws when the name contains reserved characters', () => {
-			namesWithReservedCharacters.forEach((invalidName) => {
-				expect(() => assertValidArFSFileName(invalidName)).to.throw(
-					"The file name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '\"', '<', '>', '|')"
+			it('throws when the name is too long', () => {
+				expect(() => validationMethod(tooLongName)).to.throw(
+					`The ${entity} name must contain between 1 and 255 characters`
 				);
 			});
-		});
 
-		it('throws when the name contains leading spaces', () => {
-			namesWithLeadingSpaces.forEach((invalidName) =>
-				expect(() => assertValidArFSFileName(invalidName)).to.throw('The file name cannot start with spaces')
-			);
-		});
-
-		it('throws when the name contains trailing dots or spaces', () => {
-			namesWithTrailingSpacesOrDots.forEach((invalidName) =>
-				expect(() => assertValidArFSFileName(invalidName)).to.throw(
-					'The file name cannot have trailing dots or spaces'
-				)
-			);
-		});
-	});
-
-	describe('assertValidArFSFolderName method', () => {
-		const validNames = [
-			'.bashrc',
-			'===============================================================================================================================================================================================================================================================',
-			'abcdefghijklmnopqrstuvwxyz',
-			'ñññññññññññññññññ.png',
-			'valid name with     spaces.txt',
-			'valid.name.with.....dots.txt'
-		];
-		const tooLongName =
-			'+===============================================================================================================================================================================================================================================================';
-		const namesWithReservedCharacters = [
-			'\\\\\\\\\\\\\\\\\\\\.png',
-			'//////////.png',
-			'::::::::::.png',
-			'**********.png',
-			'??????????.png',
-			'"""""""""".png',
-			'<<<<<<<<<<.png',
-			'>>>>>>>>>>.png',
-			'||||||||||.png'
-		];
-		const namesWithLeadingSpaces = [
-			'  thisIsAFileNameWithTwoLeadingSpaces.doc',
-			' thisFilenameHasOneSingleSpace.doc'
-		];
-		const namesWithTrailingSpacesOrDots = [
-			'soWeHaveAFileNameThatEndsWithADot.',
-			'thenAFileNameWithMultipleDots...',
-			'aFileNameWithATrailingSpace ',
-			'anotherFileNameWithSpaces   '
-		];
-
-		it('returns true when fed with an ArFS compliant name', () => {
-			validNames.forEach((name) => {
-				expect(assertValidArFSFolderName(name)).to.be.true;
-			});
-		});
-
-		it('throws when the name is too long', () => {
-			expect(() => assertValidArFSFolderName(tooLongName)).to.throw(
-				'The folder name must contain between 1 and 255 characters'
-			);
-		});
-
-		it('throws when the name is too short', () => {
-			expect(() => assertValidArFSFolderName('')).to.throw(
-				'The folder name must contain between 1 and 255 characters'
-			);
-		});
-
-		it('throws when the name contains reserved characters', () => {
-			namesWithReservedCharacters.forEach((invalidName) => {
-				expect(() => assertValidArFSFolderName(invalidName)).to.throw(
-					"The folder name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '\"', '<', '>', '|')"
+			it('throws when the name is too short', () => {
+				expect(() => validationMethod('')).to.throw(
+					`The ${entity} name must contain between 1 and 255 characters`
 				);
 			});
-		});
 
-		it('throws when the name contains leading spaces', () => {
-			namesWithLeadingSpaces.forEach((invalidName) =>
-				expect(() => assertValidArFSFolderName(invalidName)).to.throw(
-					'The folder name cannot start with spaces'
-				)
-			);
-		});
+			it('throws when the name contains reserved characters', () => {
+				namesWithReservedCharacters.forEach((invalidName) => {
+					expect(() => validationMethod(invalidName)).to.throw(
+						`The ${entity} name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '"', '<', '>', '|')`
+					);
+				});
+			});
 
-		it('throws when the name contains trailing dots or spaces', () => {
-			namesWithTrailingSpacesOrDots.forEach((invalidName) =>
-				expect(() => assertValidArFSFolderName(invalidName)).to.throw(
-					'The folder name cannot have trailing dots or spaces'
-				)
-			);
+			it('throws when the name contains leading spaces', () => {
+				namesWithLeadingSpaces.forEach((invalidName) =>
+					expect(() => validationMethod(invalidName)).to.throw(`The ${entity} name cannot start with spaces`)
+				);
+			});
+
+			it('throws when the name contains trailing dots or spaces', () => {
+				namesWithTrailingSpacesOrDots.forEach((invalidName) =>
+					expect(() => validationMethod(invalidName)).to.throw(
+						`The ${entity} name cannot have trailing dots or spaces`
+					)
+				);
+			});
 		});
 	});
 });

--- a/src/arfs/arfs_entity_name_validators.test.ts
+++ b/src/arfs/arfs_entity_name_validators.test.ts
@@ -1,0 +1,154 @@
+import { expect } from 'chai';
+import { assertValidArFSFileName, assertValidArFSFolderName } from './arfs_entity_name_validators';
+
+describe('entity name validators', () => {
+	describe('assertValidArFSFileName method', () => {
+		const validNames = [
+			'.bashrc',
+			'===============================================================================================================================================================================================================================================================',
+			'abcdefghijklmnopqrstuvwxyz',
+			'ñññññññññññññññññ.png',
+			'valid name with     spaces.txt',
+			'valid.name.with.....dots.txt'
+		];
+		const tooLongName =
+			'+===============================================================================================================================================================================================================================================================';
+		const namesWithReservedCharacters = [
+			'\\\\\\\\\\\\\\\\\\\\.png',
+			'//////////.png',
+			'::::::::::.png',
+			'**********.png',
+			'??????????.png',
+			'"""""""""".png',
+			'<<<<<<<<<<.png',
+			'>>>>>>>>>>.png',
+			'||||||||||.png'
+		];
+		const namesWithLeadingSpaces = [
+			'  thisIsAFileNameWithTwoLeadingSpaces.doc',
+			' thisFilenameHasOneSingleSpace.doc'
+		];
+		const namesWithTrailingSpacesOrDots = [
+			'soWeHaveAFileNameThatEndsWithADot.',
+			'thenAFileNameWithMultipleDots...',
+			'aFileNameWithATrailingSpace ',
+			'anotherFileNameWithSpaces   '
+		];
+
+		it('returns true when fed with an ArFS compliant name', () => {
+			validNames.forEach((name) => {
+				expect(assertValidArFSFileName(name)).to.be.true;
+			});
+		});
+
+		it('throws when the name is too long', () => {
+			expect(() => assertValidArFSFileName(tooLongName)).to.throw(
+				'The file name must contain between 1 and 255 characters'
+			);
+		});
+
+		it('throws when the name is too short', () => {
+			expect(() => assertValidArFSFileName('')).to.throw(
+				'The file name must contain between 1 and 255 characters'
+			);
+		});
+
+		it('throws when the name contains reserved characters', () => {
+			namesWithReservedCharacters.forEach((invalidName) => {
+				expect(() => assertValidArFSFileName(invalidName)).to.throw(
+					"The file name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '\"', '<', '>', '|')"
+				);
+			});
+		});
+
+		it('throws when the name contains leading spaces', () => {
+			namesWithLeadingSpaces.forEach((invalidName) =>
+				expect(() => assertValidArFSFileName(invalidName)).to.throw('The file name cannot start with spaces')
+			);
+		});
+
+		it('throws when the name contains trailing dots or spaces', () => {
+			namesWithTrailingSpacesOrDots.forEach((invalidName) =>
+				expect(() => assertValidArFSFileName(invalidName)).to.throw(
+					'The file name cannot have trailing dots or spaces'
+				)
+			);
+		});
+	});
+
+	describe('assertValidArFSFolderName method', () => {
+		const validNames = [
+			'.bashrc',
+			'===============================================================================================================================================================================================================================================================',
+			'abcdefghijklmnopqrstuvwxyz',
+			'ñññññññññññññññññ.png',
+			'valid name with     spaces.txt',
+			'valid.name.with.....dots.txt'
+		];
+		const tooLongName =
+			'+===============================================================================================================================================================================================================================================================';
+		const namesWithReservedCharacters = [
+			'\\\\\\\\\\\\\\\\\\\\.png',
+			'//////////.png',
+			'::::::::::.png',
+			'**********.png',
+			'??????????.png',
+			'"""""""""".png',
+			'<<<<<<<<<<.png',
+			'>>>>>>>>>>.png',
+			'||||||||||.png'
+		];
+		const namesWithLeadingSpaces = [
+			'  thisIsAFileNameWithTwoLeadingSpaces.doc',
+			' thisFilenameHasOneSingleSpace.doc'
+		];
+		const namesWithTrailingSpacesOrDots = [
+			'soWeHaveAFileNameThatEndsWithADot.',
+			'thenAFileNameWithMultipleDots...',
+			'aFileNameWithATrailingSpace ',
+			'anotherFileNameWithSpaces   '
+		];
+
+		it('returns true when fed with an ArFS compliant name', () => {
+			validNames.forEach((name) => {
+				expect(assertValidArFSFolderName(name)).to.be.true;
+			});
+		});
+
+		it('throws when the name is too long', () => {
+			expect(() => assertValidArFSFolderName(tooLongName)).to.throw(
+				'The folder name must contain between 1 and 255 characters'
+			);
+		});
+
+		it('throws when the name is too short', () => {
+			expect(() => assertValidArFSFolderName('')).to.throw(
+				'The folder name must contain between 1 and 255 characters'
+			);
+		});
+
+		it('throws when the name contains reserved characters', () => {
+			namesWithReservedCharacters.forEach((invalidName) => {
+				expect(() => assertValidArFSFolderName(invalidName)).to.throw(
+					"The folder name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '\"', '<', '>', '|')"
+				);
+			});
+		});
+
+		it('throws when the name contains leading spaces', () => {
+			namesWithLeadingSpaces.forEach((invalidName) =>
+				expect(() => assertValidArFSFolderName(invalidName)).to.throw(
+					'The folder name cannot start with spaces'
+				)
+			);
+		});
+
+		it('throws when the name contains trailing dots or spaces', () => {
+			namesWithTrailingSpacesOrDots.forEach((invalidName) =>
+				expect(() => assertValidArFSFolderName(invalidName)).to.throw(
+					'The folder name cannot have trailing dots or spaces'
+				)
+			);
+		});
+	});
+});

--- a/src/arfs/arfs_entity_name_validators.ts
+++ b/src/arfs/arfs_entity_name_validators.ts
@@ -1,0 +1,37 @@
+const RESERVED_CHARACTERS = ['\\\\', '/', ':', '*', '?', '"', '<', '>', '|'];
+const HUMAN_READABLE_RESERVED_CHARACTERS = RESERVED_CHARACTERS.map((char) => `'${char}'`).join(', ');
+
+const LEADING_SPACES_REGEXP = /^(\s+)/;
+const TRAILING_DOTS_OR_SPACES_REGEXP = /(\s|\.)+$/;
+const CONTAINS_RESERVED_CHARACTER_REGEXP = new RegExp(`[${RESERVED_CHARACTERS.join('')}]`, 'g');
+// From ArFS Standards
+const MAX_VALID_NAME_LENGTH = 255;
+
+export const assertValidArFSFileName = assertValidArFSEntityNameFactory('file');
+export const assertValidArFSFolderName = assertValidArFSEntityNameFactory('folder');
+
+export function assertValidArFSEntityNameFactory(entityType: 'file' | 'folder'): (name: string) => boolean {
+	return function (name: string) {
+		if (name.length > MAX_VALID_NAME_LENGTH || name.length === 0) {
+			throw new Error(`The ${entityType} name must contain between 1 and ${MAX_VALID_NAME_LENGTH} characters`);
+		}
+
+		const matchLeadingSpaces = name.match(LEADING_SPACES_REGEXP);
+		if (matchLeadingSpaces) {
+			throw new Error(`The ${entityType} name cannot start with spaces`);
+		}
+
+		const matchTrailingDotsOrSpaces = name.match(TRAILING_DOTS_OR_SPACES_REGEXP);
+		if (matchTrailingDotsOrSpaces) {
+			throw new Error(`The ${entityType} name cannot have trailing dots or spaces`);
+		}
+
+		const matchReservedCharacters = name.match(CONTAINS_RESERVED_CHARACTER_REGEXP);
+		if (matchReservedCharacters) {
+			throw new Error(
+				`The ${entityType} name cannot contain reserved characters (i.e. ${HUMAN_READABLE_RESERVED_CHARACTERS})`
+			);
+		}
+		return true;
+	};
+}

--- a/tests/integration/ardrive.int.test.ts
+++ b/tests/integration/ardrive.int.test.ts
@@ -114,6 +114,9 @@ describe('ArDrive class - integrated', () => {
 	const unexpectedDriveId = EID(stubEntityIDAlt.toString());
 	const existingFileId = EID(stubEntityIDAlt.toString());
 
+	const invalidEntityName = '*\\/:*?:<>|_invalidName.png';
+	const validEntityName = 'some happy file name which is valid.txt';
+
 	beforeEach(() => {
 		// Set pricing algo up as x = y (bytes = Winston)
 		stub(arweaveOracle, 'getWinstonPriceForByteCount').callsFake((input) => Promise.resolve(W(+input)));
@@ -193,12 +196,25 @@ describe('ArDrive class - integrated', () => {
 				stub(arfsDao, 'getPublicEntityNamesInFolder').resolves(['CONFLICTING_NAME']);
 			});
 
+			it('throws if the given name is invalid', () => {
+				stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
+
+				return expectAsyncErrorThrow({
+					promiseToError: arDrive.createPublicFolder({
+						folderName: invalidEntityName,
+						driveId: stubEntityID,
+						parentFolderId: stubEntityID
+					}),
+					errorMessage: `The folder name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '"', '<', '>', '|')`
+				});
+			});
+
 			it('throws an error if the owner of the drive conflicts with supplied wallet', async () => {
 				stub(arfsDao, 'getOwnerAndAssertDrive').resolves(unexpectedOwner);
 
 				await expectAsyncErrorThrow({
 					promiseToError: arDrive.createPublicFolder({
-						folderName: 'TEST_FOLDER',
+						folderName: validEntityName,
 						driveId: stubEntityID,
 						parentFolderId: stubEntityID
 					}),
@@ -224,11 +240,11 @@ describe('ArDrive class - integrated', () => {
 				stub(arfsDao, 'getPublicDrive').resolves(stubPublicDrive());
 
 				const result = await arDrive.createPublicFolder({
-					folderName: 'TEST_FOLDER',
+					folderName: validEntityName,
 					driveId: stubEntityID,
 					parentFolderId: stubEntityID
 				});
-				assertCreateFolderExpectations(result, W(22));
+				assertCreateFolderExpectations(result, W(50));
 			});
 		});
 
@@ -237,12 +253,26 @@ describe('ArDrive class - integrated', () => {
 				stub(arfsDao, 'getPrivateEntityNamesInFolder').resolves(['CONFLICTING_NAME']);
 			});
 
+			it('throws if the given name is invalid', async () => {
+				stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
+
+				return expectAsyncErrorThrow({
+					promiseToError: arDrive.createPrivateFolder({
+						folderName: invalidEntityName,
+						driveId: stubEntityID,
+						parentFolderId: stubEntityID,
+						driveKey: await getStubDriveKey()
+					}),
+					errorMessage: `The folder name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '"', '<', '>', '|')`
+				});
+			});
+
 			it('throws an error if the owner of the drive conflicts with supplied wallet', async () => {
 				stub(arfsDao, 'getOwnerAndAssertDrive').resolves(unexpectedOwner);
 
 				await expectAsyncErrorThrow({
 					promiseToError: arDrive.createPrivateFolder({
-						folderName: 'TEST_FOLDER',
+						folderName: validEntityName,
 						driveId: stubEntityID,
 						parentFolderId: stubEntityID,
 						driveKey: await getStubDriveKey()
@@ -271,12 +301,12 @@ describe('ArDrive class - integrated', () => {
 
 				const stubDriveKey = await getStubDriveKey();
 				const result = await arDrive.createPrivateFolder({
-					folderName: 'TEST_FOLDER',
+					folderName: validEntityName,
 					driveId: stubEntityID,
 					parentFolderId: stubEntityID,
 					driveKey: stubDriveKey
 				});
-				assertCreateFolderExpectations(result, W(38), urlEncodeHashKey(stubDriveKey));
+				assertCreateFolderExpectations(result, W(66), urlEncodeHashKey(stubDriveKey));
 			});
 		});
 


### PR DESCRIPTION
This PR is heavily based on @matibat work on rename files, folders and drives feature and #143 

- improves ArFS entity name validators tests making them parameterized
- add drive name validation to `createPublicFolder` and `createPrivateFolder` integration tests
- add drive name validation to folder creation methods