### PR TITLE
PE-967: Fix priv folder uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ardrive-core-js",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"description": "ArDrive Core contains the essential back end application features to support the ArDrive CLI and Desktop apps, such as file management, Permaweb upload/download, wallet management and other common functions.",
 	"main": "./lib/exports.js",
 	"types": "./lib/exports.d.ts",

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -902,10 +902,11 @@ export class ArDrive extends ArDriveAnonymous {
 				feeMultiple: this.feeMultiple
 			};
 
-			const uploadFileResult = (await this.arFsDao.uploadPublicFile({
+			const uploadFileResult = (await this.arFsDao.uploadPrivateFile({
 				wrappedFile,
 				driveId,
 				parentFolderId,
+				driveKey,
 				rewardSettings: {
 					dataTxRewardSettings,
 					metaDataRewardSettings


### PR DESCRIPTION
This PR fixes private folder uploads that contain files within them.

GH Release Notes:

- Bulk folder uploads to a private drive will no longer throw errors