### PR TITLE
PE-930: validate names within folder

### DIFF
--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -116,7 +116,8 @@ import { ARDataPriceNetworkEstimator } from './pricing/ar_data_price_network_est
 import {
 	assertValidArFSDriveName,
 	assertValidArFSFileName,
-	assertValidArFSFolderName
+	assertValidArFSFolderName,
+	assertNamesWithinFolder
 } from './arfs/arfs_entity_name_validators';
 import { TipData } from './exports';
 
@@ -591,6 +592,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Derive destination name and names already within provided destination folder
 		destParentFolderName ??= wrappedFolder.getBaseFileName();
+		assertNamesWithinFolder(wrappedFolder, destParentFolderName);
 		const nameConflictInfo = await this.arFsDao.getPublicNameConflictInfoInFolder(parentFolderId);
 
 		await resolveFolderNameConflicts({
@@ -783,6 +785,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Derive destination name and names already within provided destination folder
 		destParentFolderName ??= wrappedFolder.getBaseFileName();
+		assertNamesWithinFolder(wrappedFolder, destParentFolderName);
 		const nameConflictInfo = await this.arFsDao.getPrivateNameConflictInfoInFolder(parentFolderId, driveKey);
 
 		await resolveFolderNameConflicts({

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -117,7 +117,7 @@ import {
 	assertValidArFSDriveName,
 	assertValidArFSFileName,
 	assertValidArFSFolderName,
-	assertNamesWithinFolder
+	assertArFSCompliantNamesWithinFolder
 } from './arfs/arfs_entity_name_validators';
 import { TipData } from './exports';
 
@@ -592,7 +592,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Derive destination name and names already within provided destination folder
 		destParentFolderName ??= wrappedFolder.getBaseFileName();
-		assertNamesWithinFolder(wrappedFolder, destParentFolderName);
+		assertArFSCompliantNamesWithinFolder(wrappedFolder, destParentFolderName);
 		const nameConflictInfo = await this.arFsDao.getPublicNameConflictInfoInFolder(parentFolderId);
 
 		await resolveFolderNameConflicts({
@@ -785,7 +785,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Derive destination name and names already within provided destination folder
 		destParentFolderName ??= wrappedFolder.getBaseFileName();
-		assertNamesWithinFolder(wrappedFolder, destParentFolderName);
+		assertArFSCompliantNamesWithinFolder(wrappedFolder, destParentFolderName);
 		const nameConflictInfo = await this.arFsDao.getPrivateNameConflictInfoInFolder(parentFolderId, driveKey);
 
 		await resolveFolderNameConflicts({

--- a/src/arfs/arfs_entity_name_validators.test.ts
+++ b/src/arfs/arfs_entity_name_validators.test.ts
@@ -4,7 +4,7 @@ import { statSync } from 'fs';
 import { ArFSFolderToUpload } from '../arfs/arfs_file_wrapper';
 
 import {
-	assertNamesWithinFolder,
+	assertArFSCompliantNamesWithinFolder,
 	assertValidArFSDriveName,
 	assertValidArFSFileName,
 	assertValidArFSFolderName
@@ -51,7 +51,7 @@ describe('entity name validators', () => {
 	} & Test;
 
 	type FolderWithChildrenTest = {
-		validationMethod: typeof assertNamesWithinFolder;
+		validationMethod: typeof assertArFSCompliantNamesWithinFolder;
 	} & Test;
 
 	function isFolderWithChildren(test: EntityTest | FolderWithChildrenTest): test is FolderWithChildrenTest {
@@ -79,8 +79,8 @@ describe('entity name validators', () => {
 		},
 		{
 			entity: 'folder',
-			methodName: 'assertNamesWithinFolder',
-			validationMethod: assertNamesWithinFolder,
+			methodName: 'assertArFSCompliantNamesWithinFolder',
+			validationMethod: assertArFSCompliantNamesWithinFolder,
 			isFolderWithChildren: true
 		}
 	];

--- a/src/arfs/arfs_entity_name_validators.test.ts
+++ b/src/arfs/arfs_entity_name_validators.test.ts
@@ -1,6 +1,10 @@
 import { expect } from 'chai';
+import { stub } from 'sinon';
+import { statSync } from 'fs';
+import { ArFSFolderToUpload } from '../arfs/arfs_file_wrapper';
 
 import {
+	assertNamesWithinFolder,
 	assertValidArFSDriveName,
 	assertValidArFSFileName,
 	assertValidArFSFolderName
@@ -36,64 +40,157 @@ describe('entity name validators', () => {
 		'anotherFileNameWithSpaces   '
 	];
 
-	const testsList = [
+	type Test = {
+		entity: string;
+		methodName: string;
+		isFolderWithChildren: boolean;
+	};
+
+	type EntityTest = {
+		validationMethod: typeof assertValidArFSFileName;
+	} & Test;
+
+	type FolderWithChildrenTest = {
+		validationMethod: typeof assertNamesWithinFolder;
+	} & Test;
+
+	function isFolderWithChildren(test: EntityTest | FolderWithChildrenTest): test is FolderWithChildrenTest {
+		return (test as FolderWithChildrenTest).isFolderWithChildren;
+	}
+
+	const testsList: (EntityTest | FolderWithChildrenTest)[] = [
 		{
 			entity: 'file',
 			methodName: 'assertValidArFSFileName',
-			validationMethod: assertValidArFSFileName
+			validationMethod: assertValidArFSFileName,
+			isFolderWithChildren: false
 		},
 		{
 			entity: 'folder',
 			methodName: 'assertValidArFSFolderName',
-			validationMethod: assertValidArFSFolderName
+			validationMethod: assertValidArFSFolderName,
+			isFolderWithChildren: false
 		},
 		{
 			entity: 'drive',
 			methodName: 'assertValidArFSDriveName',
-			validationMethod: assertValidArFSDriveName
+			validationMethod: assertValidArFSDriveName,
+			isFolderWithChildren: false
+		},
+		{
+			entity: 'folder',
+			methodName: 'assertNamesWithinFolder',
+			validationMethod: assertNamesWithinFolder,
+			isFolderWithChildren: true
 		}
 	];
 
-	testsList.forEach(({ entity, methodName, validationMethod }) => {
+	const fileStats = statSync('tests/stub_files');
+	const wrappedFolderWithValidName = new ArFSFolderToUpload('tests/stub_files', fileStats);
+
+	testsList.forEach((test) => {
+		const { entity, methodName } = test;
+
 		describe(`${methodName} method`, () => {
 			it('returns true when fed with an ArFS compliant name', () => {
 				validNames.forEach((name) => {
-					expect(validationMethod(name)).to.be.true;
+					if (isFolderWithChildren(test)) {
+						const { validationMethod } = test;
+						const wrappedFolderStub = stub(wrappedFolderWithValidName, 'getBaseFileName').returns(name);
+
+						expect(validationMethod(wrappedFolderWithValidName)).to.be.true;
+						wrappedFolderStub.restore();
+					} else {
+						const { validationMethod } = test;
+						expect(validationMethod(name)).to.be.true;
+					}
 				});
 			});
 
 			it('throws when the name is too long', () => {
-				expect(() => validationMethod(tooLongName)).to.throw(
-					`The ${entity} name must contain between 1 and 255 characters`
-				);
+				const expectedError = `The ${entity} name must contain between 1 and 255 characters`;
+
+				if (isFolderWithChildren(test)) {
+					const { validationMethod } = test;
+					const wrappedFolderStub = stub(wrappedFolderWithValidName, 'getBaseFileName').returns(tooLongName);
+
+					expect(() => validationMethod(wrappedFolderWithValidName)).to.throw(expectedError);
+					wrappedFolderStub.restore();
+				} else {
+					const { validationMethod } = test;
+					expect(() => validationMethod(tooLongName)).to.throw(expectedError);
+				}
 			});
 
 			it('throws when the name is too short', () => {
-				expect(() => validationMethod('')).to.throw(
-					`The ${entity} name must contain between 1 and 255 characters`
-				);
+				const expectedError = `The ${entity} name must contain between 1 and 255 characters`;
+
+				if (isFolderWithChildren(test)) {
+					const { validationMethod } = test;
+					const wrappedFolderStub = stub(wrappedFolderWithValidName, 'getBaseFileName').returns('');
+
+					expect(() => validationMethod(wrappedFolderWithValidName)).to.throw(expectedError);
+					wrappedFolderStub.restore();
+				} else {
+					const { validationMethod } = test;
+					expect(() => validationMethod('')).to.throw(expectedError);
+				}
 			});
 
 			it('throws when the name contains reserved characters', () => {
+				const expectedError = `The ${entity} name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '"', '<', '>', '|')`;
+
 				namesWithReservedCharacters.forEach((invalidName) => {
-					expect(() => validationMethod(invalidName)).to.throw(
-						`The ${entity} name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '"', '<', '>', '|')`
-					);
+					if (isFolderWithChildren(test)) {
+						const { validationMethod } = test;
+						const wrappedFolderStub = stub(wrappedFolderWithValidName, 'getBaseFileName').returns(
+							invalidName
+						);
+
+						expect(() => validationMethod(wrappedFolderWithValidName)).to.throw(expectedError);
+						wrappedFolderStub.restore();
+					} else {
+						const { validationMethod } = test;
+						expect(() => validationMethod(invalidName)).to.throw(expectedError);
+					}
 				});
 			});
 
 			it('throws when the name contains leading spaces', () => {
-				namesWithLeadingSpaces.forEach((invalidName) =>
-					expect(() => validationMethod(invalidName)).to.throw(`The ${entity} name cannot start with spaces`)
-				);
+				const expectedError = `The ${entity} name cannot start with spaces`;
+
+				namesWithLeadingSpaces.forEach((invalidName) => {
+					if (isFolderWithChildren(test)) {
+						const { validationMethod } = test;
+						const wrappedFolderStub = stub(wrappedFolderWithValidName, 'getBaseFileName').returns(
+							invalidName
+						);
+
+						expect(() => validationMethod(wrappedFolderWithValidName)).to.throw(expectedError);
+						wrappedFolderStub.restore();
+					} else {
+						const { validationMethod } = test;
+						expect(() => validationMethod(invalidName)).to.throw(expectedError);
+					}
+				});
 			});
 
 			it('throws when the name contains trailing dots or spaces', () => {
-				namesWithTrailingSpacesOrDots.forEach((invalidName) =>
-					expect(() => validationMethod(invalidName)).to.throw(
-						`The ${entity} name cannot have trailing dots or spaces`
-					)
-				);
+				const expectedError = `The ${entity} name cannot have trailing dots or spaces`;
+				namesWithTrailingSpacesOrDots.forEach((invalidName) => {
+					if (isFolderWithChildren(test)) {
+						const { validationMethod } = test;
+						const wrappedFolderStub = stub(wrappedFolderWithValidName, 'getBaseFileName').returns(
+							invalidName
+						);
+
+						expect(() => validationMethod(wrappedFolderWithValidName)).to.throw(expectedError);
+						wrappedFolderStub.restore();
+					} else {
+						const { validationMethod } = test;
+						expect(() => validationMethod(invalidName)).to.throw(expectedError);
+					}
+				});
 			});
 		});
 	});

--- a/src/arfs/arfs_entity_name_validators.ts
+++ b/src/arfs/arfs_entity_name_validators.ts
@@ -1,4 +1,5 @@
 import { EntityType } from '../types';
+import { ArFSFolderToUpload } from '../arfs/arfs_file_wrapper';
 
 const RESERVED_CHARACTERS = ['\\\\', '/', ':', '*', '?', '"', '<', '>', '|'];
 const HUMAN_READABLE_RESERVED_CHARACTERS = RESERVED_CHARACTERS.map((char) => `'${char}'`).join(', ');
@@ -37,4 +38,20 @@ export function assertValidArFSEntityNameFactory(entityType: EntityType): (name:
 		}
 		return true;
 	};
+}
+
+export function assertNamesWithinFolder(rootFolder: ArFSFolderToUpload, rootFolderDestName?: string): boolean {
+	assertValidArFSFolderName(rootFolderDestName ?? rootFolder.getBaseFileName());
+
+	for (const file of rootFolder.files) {
+		assertValidArFSFileName(file.destinationBaseName);
+	}
+
+	for (const folder of rootFolder.folders) {
+		assertValidArFSFolderName(folder.getBaseFileName());
+
+		assertNamesWithinFolder(folder);
+	}
+
+	return true;
 }

--- a/src/arfs/arfs_entity_name_validators.ts
+++ b/src/arfs/arfs_entity_name_validators.ts
@@ -40,7 +40,10 @@ export function assertValidArFSEntityNameFactory(entityType: EntityType): (name:
 	};
 }
 
-export function assertNamesWithinFolder(rootFolder: ArFSFolderToUpload, rootFolderDestName?: string): boolean {
+export function assertArFSCompliantNamesWithinFolder(
+	rootFolder: ArFSFolderToUpload,
+	rootFolderDestName?: string
+): boolean {
 	assertValidArFSFolderName(rootFolderDestName ?? rootFolder.getBaseFileName());
 
 	for (const file of rootFolder.files) {
@@ -50,7 +53,7 @@ export function assertNamesWithinFolder(rootFolder: ArFSFolderToUpload, rootFold
 	for (const folder of rootFolder.folders) {
 		assertValidArFSFolderName(folder.getBaseFileName());
 
-		assertNamesWithinFolder(folder);
+		assertArFSCompliantNamesWithinFolder(folder);
 	}
 
 	return true;

--- a/tests/integration/ardrive.int.test.ts
+++ b/tests/integration/ardrive.int.test.ts
@@ -4,7 +4,7 @@ import { stub } from 'sinon';
 import { statSync } from 'fs';
 import { ArDrive } from '../../src/ardrive';
 import { RootFolderID } from '../../src/arfs/arfs_builders/arfs_folder_builders';
-import { wrapFileOrFolder, ArFSFileToUpload } from '../../src/arfs/arfs_file_wrapper';
+import { wrapFileOrFolder, ArFSFileToUpload, ArFSFolderToUpload } from '../../src/arfs/arfs_file_wrapper';
 import { ArFSDAO, PrivateDriveKeyData } from '../../src/arfs/arfsdao';
 import { ArDriveCommunityOracle } from '../../src/community/ardrive_community_oracle';
 import { deriveDriveKey } from '../../src/utils/crypto';
@@ -1145,6 +1145,75 @@ describe('ArDrive class - integrated', () => {
 						driveKey: await getStubDriveKey()
 					});
 					assertMoveFileExpectations(result, W(169), 'private');
+				});
+			});
+		});
+	});
+
+	describe('folder and children function', () => {
+		const fileStats = statSync('tests/stub_files');
+		const wrappedFolderWithInvalidName = new ArFSFolderToUpload('tests/stub_files', fileStats);
+
+		beforeEach(() => {
+			stub(arfsDao, 'getDriveIdForFolderId').resolves(stubEntityID);
+			stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+			stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
+		});
+
+		describe('createPublicFolderAndUploadChildren', () => {
+			it('throws if an folder name is invalid', () => {
+				stub(wrappedFolderWithInvalidName, 'getBaseFileName').returns(invalidEntityName);
+
+				return expectAsyncErrorThrow({
+					promiseToError: arDrive.createPublicFolderAndUploadChildren({
+						parentFolderId: stubEntityID,
+						wrappedFolder: wrappedFolderWithInvalidName
+					}),
+					errorMessage: `The folder name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '"', '<', '>', '|')`
+				});
+			});
+
+			it('throws if an file name is invalid', () => {
+				stub(wrappedFolderWithInvalidName.folders[0].files[0], 'getBaseFileName').returns(invalidEntityName);
+
+				return expectAsyncErrorThrow({
+					promiseToError: arDrive.createPublicFolderAndUploadChildren({
+						parentFolderId: stubEntityID,
+						wrappedFolder: wrappedFolderWithInvalidName
+					}),
+					errorMessage: `The file name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '"', '<', '>', '|')`
+				});
+			});
+		});
+
+		describe('createPrivateFolderAndUploadChildren', () => {
+			it('throws if an folder name is invalid', async () => {
+				const stubDriveKey = await getStubDriveKey();
+
+				stub(wrappedFolderWithInvalidName, 'getBaseFileName').returns(invalidEntityName);
+
+				return expectAsyncErrorThrow({
+					promiseToError: arDrive.createPrivateFolderAndUploadChildren({
+						parentFolderId: stubEntityID,
+						wrappedFolder: wrappedFolderWithInvalidName,
+						driveKey: stubDriveKey
+					}),
+					errorMessage: `The folder name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '"', '<', '>', '|')`
+				});
+			});
+
+			it('throws if an file name is invalid', async () => {
+				const stubDriveKey = await getStubDriveKey();
+
+				stub(wrappedFolderWithInvalidName.folders[0].files[0], 'getBaseFileName').returns(invalidEntityName);
+
+				return expectAsyncErrorThrow({
+					promiseToError: arDrive.createPrivateFolderAndUploadChildren({
+						parentFolderId: stubEntityID,
+						wrappedFolder: wrappedFolderWithInvalidName,
+						driveKey: stubDriveKey
+					}),
+					errorMessage: `The file name cannot contain reserved characters (i.e. '\\\\', '/', ':', '*', '?', '"', '<', '>', '|')`
 				});
 			});
 		});


### PR DESCRIPTION
This PR is based on #145 

- add `assertNamesWithinFolder` helper function and update unit tests
- add folder and file name validation to `createPublicFolderAndUploadChildren` and `createPrivateFolderAndUploadChildren` and create integration tests for both methods (just testing folder and name validation as they will be deprecated)