### PR TITLE
PE-979: fix folder upload contents target

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ardrive-core-js",
-	"version": "1.6.1",
+	"version": "1.6.2",
 	"description": "ArDrive Core contains the essential back end application features to support the ArDrive CLI and Desktop apps, such as file management, Permaweb upload/download, wallet management and other common functions.",
 	"main": "./lib/exports.js",
 	"types": "./lib/exports.d.ts",

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -710,7 +710,7 @@ export class ArDrive extends ArDriveAnonymous {
 			const uploadFileResult = (await this.arFsDao.uploadPublicFile({
 				wrappedFile,
 				driveId,
-				parentFolderId,
+				parentFolderId: folderId,
 				rewardSettings: {
 					dataTxRewardSettings,
 					metaDataRewardSettings
@@ -905,7 +905,7 @@ export class ArDrive extends ArDriveAnonymous {
 			const uploadFileResult = (await this.arFsDao.uploadPrivateFile({
 				wrappedFile,
 				driveId,
-				parentFolderId,
+				parentFolderId: folderId,
 				driveKey,
 				rewardSettings: {
 					dataTxRewardSettings,


### PR DESCRIPTION
This PR sends the contents of a folder upload to the correct destination folder.

GitHub Release Notes:

- File contents of a folder upload will now correctly be uploaded inside of that folder on chain