### PR TITLE
PE-1086: Progress callback on tx uploader

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,27 @@ And finally, to view the detailed error messages in your terminal:
 yarn power-assert -g 'My test case'
 ```
 
+### Progress Logging of Transaction Uploads
+
+Progress logging of transaction uploads to stderr can be enabled by setting the `ARDRIVE_PROGRESS_LOG` environment variable to `1`:
+
+```shell
+Uploading file transaction 1 of total 2 transactions...
+Transaction _GKQasQX194a364Hph8Oe-oku1AdfHwxWOw9_JC1yjc Upload Progress: 0%
+Transaction _GKQasQX194a364Hph8Oe-oku1AdfHwxWOw9_JC1yjc Upload Progress: 35%
+Transaction _GKQasQX194a364Hph8Oe-oku1AdfHwxWOw9_JC1yjc Upload Progress: 66%
+Transaction _GKQasQX194a364Hph8Oe-oku1AdfHwxWOw9_JC1yjc Upload Progress: 100%
+Uploading file transaction 2 of total 2 transactions...
+Transaction nA1stCdTkuf290k0qsqvmJ78isEC0bwgrAi3D8Cl1LU Upload Progress: 0%
+Transaction nA1stCdTkuf290k0qsqvmJ78isEC0bwgrAi3D8Cl1LU Upload Progress: 13%
+Transaction nA1stCdTkuf290k0qsqvmJ78isEC0bwgrAi3D8Cl1LU Upload Progress: 28%
+Transaction nA1stCdTkuf290k0qsqvmJ78isEC0bwgrAi3D8Cl1LU Upload Progress: 42%
+Transaction nA1stCdTkuf290k0qsqvmJ78isEC0bwgrAi3D8Cl1LU Upload Progress: 60%
+Transaction nA1stCdTkuf290k0qsqvmJ78isEC0bwgrAi3D8Cl1LU Upload Progress: 76%
+Transaction nA1stCdTkuf290k0qsqvmJ78isEC0bwgrAi3D8Cl1LU Upload Progress: 91%
+Transaction nA1stCdTkuf290k0qsqvmJ78isEC0bwgrAi3D8Cl1LU Upload Progress: 100%
+```
+
 [yarn-install]: https://yarnpkg.com/getting-started/install
 [nvm-install]: https://github.com/nvm-sh/nvm#installing-and-updating
 [wsl-install]: https://code.visualstudio.com/docs/remote/wsl

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -1118,7 +1118,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 
 									setTimeout(() => {
 										progressLogDebounce = false;
-									}, 250); // .25 sec debounce
+									}, 500); // .5 sec debounce
 								}
 						  }
 						: undefined

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -803,7 +803,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 
 		const logProgress = () => {
 			if (this.shouldProgressLog && totalFileAndBundleUploads > 1) {
-				console.info(
+				console.error(
 					`Uploading file transaction ${
 						uploadsCompleted + 1
 					} of total ${totalFileAndBundleUploads} transactions...`
@@ -1113,7 +1113,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 					progressCallback: shouldProgressLog
 						? (pct: number) => {
 								if (!progressLogDebounce || pct === 100) {
-									console.info(`Transaction ${transaction.id} Upload Progress: ${pct}%`);
+									console.error(`Transaction ${transaction.id} Upload Progress: ${pct}%`);
 									progressLogDebounce = true;
 
 									setTimeout(() => {

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -1112,8 +1112,8 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 					gatewayUrl: gatewayUrlForArweave(this.arweave),
 					progressCallback: shouldProgressLog
 						? (pct: number) => {
-								if (!debounce) {
-									console.info(`Transaction Upload Progress: ${pct}%`);
+								if (!debounce || pct === 100) {
+									console.info(`Transaction ${transaction.id} Upload Progress: ${pct}%`);
 									debounce = true;
 
 									setTimeout(() => {
@@ -1125,10 +1125,6 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 				});
 
 				await transactionUploader.batchUploadChunks();
-
-				if (shouldProgressLog) {
-					console.info('Transaction upload complete!');
-				}
 			}
 		}
 	}

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -1095,8 +1095,6 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 	}
 
 	async sendTransactionsAsChunks(transactions: Transaction[]): Promise<void> {
-		let debounce = false;
-
 		// Execute the uploads
 		if (!this.dryRun) {
 			for (const transaction of transactions) {
@@ -1107,17 +1105,19 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					this.shouldProgressLog && transaction.chunks!.chunks.length > defaultMaxConcurrentChunks;
 
+				let progressLogDebounce = false;
+
 				const transactionUploader = new MultiChunkTxUploader({
 					transaction,
 					gatewayUrl: gatewayUrlForArweave(this.arweave),
 					progressCallback: shouldProgressLog
 						? (pct: number) => {
-								if (!debounce || pct === 100) {
+								if (!progressLogDebounce || pct === 100) {
 									console.info(`Transaction ${transaction.id} Upload Progress: ${pct}%`);
-									debounce = true;
+									progressLogDebounce = true;
 
 									setTimeout(() => {
-										debounce = false;
+										progressLogDebounce = false;
 									}, 250); // .25 sec debounce
 								}
 						  }

--- a/src/arfs/multi_chunk_tx_uploader.ts
+++ b/src/arfs/multi_chunk_tx_uploader.ts
@@ -157,10 +157,7 @@ export class MultiChunkTxUploader {
 			}
 
 			this.uploadedChunks++;
-
-			if (this.progressCallback) {
-				this.progressCallback(this.pctComplete);
-			}
+			this.progressCallback?.(this.pctComplete);
 		}
 
 		return;

--- a/src/arfs/multi_chunk_tx_uploader.ts
+++ b/src/arfs/multi_chunk_tx_uploader.ts
@@ -1,5 +1,6 @@
 import Transaction from 'arweave/node/lib/transaction';
 import axios, { AxiosResponse } from 'axios';
+import { defaultMaxConcurrentChunks } from '../utils/constants';
 
 /** Maximum amount of chunks we will upload in the transaction body */
 const MAX_CHUNKS_IN_BODY = 1;
@@ -84,7 +85,7 @@ export class MultiChunkTxUploader {
 	constructor({
 		gatewayUrl,
 		transaction,
-		maxConcurrentChunks = 32,
+		maxConcurrentChunks = defaultMaxConcurrentChunks,
 		maxRetriesPerRequest = 8,
 		progressCallback
 	}: MultiChunkTxUploaderConstructorParams) {

--- a/src/arfs/multi_chunk_tx_uploader.ts
+++ b/src/arfs/multi_chunk_tx_uploader.ts
@@ -100,10 +100,7 @@ export class MultiChunkTxUploader {
 		this.transaction = transaction;
 		this.maxConcurrentChunks = maxConcurrentChunks;
 		this.maxRetriesPerRequest = maxRetriesPerRequest;
-
-		if (progressCallback) {
-			this.progressCallback = progressCallback;
-		}
+		this.progressCallback = progressCallback;
 	}
 
 	/**

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -45,3 +45,4 @@ export const privateCipherTag = { name: 'Cipher', value: defaultCipher };
 export const fakePrivateCipherIVTag = { name: 'Cipher-IV', value: 'qwertyuiopasdfgh' }; // Cipher-IV is always 16 characters
 
 export const authTagLength = 16;
+export const defaultMaxConcurrentChunks = 32;


### PR DESCRIPTION
This PR adds a debounced progress callback to the concurrent tx uploader which can currently be enabled with an ENV variable, similar to the persistent cache pattern