### PR TITLE
PE-1112: Gateway API refactor

### DIFF
--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -162,6 +162,7 @@ import { alphabeticalOrder } from '../utils/sort_functions';
 import { gatewayUrlForArweave } from '../utils/common';
 import { MultiChunkTxUploader } from './multi_chunk_tx_uploader';
 import { ArFSPrivateFileWithPaths, ArFSPrivateFolderWithPaths, privateEntityWithPathsKeylessFactory } from '../exports';
+import { GatewayAPI } from '../utils/gateway_api';
 
 /** Utility class for holding the driveId and driveKey of a new drive */
 export class PrivateDriveKeyData {
@@ -1109,7 +1110,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 
 				const transactionUploader = new MultiChunkTxUploader({
 					transaction,
-					gatewayUrl: gatewayUrlForArweave(this.arweave),
+					gatewayApi: new GatewayAPI({ gatewayUrl: gatewayUrlForArweave(this.arweave) }),
 					progressCallback: shouldProgressLog
 						? (pct: number) => {
 								if (!progressLogDebounce || pct === 100) {

--- a/src/arfs/multi_chunk_tx_uploader.ts
+++ b/src/arfs/multi_chunk_tx_uploader.ts
@@ -31,7 +31,7 @@ interface MultiChunkTxUploaderConstructorParams {
  *
  *		const transactionUploader = new MultiChunkTxUploader({
  *			transaction,
- *			gatewayUrl: new URL('https://arweave.net:443')
+ *			gatewayApi: new GatewayAPI({ gatewayUrl: new URL('https://arweave.net:443') })
  *		});
  *
  *		await transactionUploader.batchUploadChunks();

--- a/src/arfs/multi_chunk_tx_uploader.ts
+++ b/src/arfs/multi_chunk_tx_uploader.ts
@@ -1,42 +1,22 @@
 import Transaction from 'arweave/node/lib/transaction';
-import axios, { AxiosResponse } from 'axios';
 import { defaultMaxConcurrentChunks } from '../utils/constants';
+import { GatewayAPI } from '../utils/gateway_api';
+
+export interface Chunk {
+	chunk: string;
+	data_root: string;
+	data_size: string;
+	offset: string;
+	data_path: string;
+}
 
 /** Maximum amount of chunks we will upload in the transaction body */
 const MAX_CHUNKS_IN_BODY = 1;
 
-/**
- * Error delay for the first failed request for a transaction header post or chunk upload
- * Subsequent requests will delay longer with an exponential back off strategy
- */
-const INITIAL_ERROR_DELAY = 500; // 500ms
-
-// We assume these errors are intermittent and we can try again after a delay:
-// - not_joined
-// - timeout
-// - data_root_not_found (we may have hit a node that just hasn't seen it yet)
-// - exceeds_disk_pool_size_limit
-// We also try again after any kind of unexpected network errors
-
-/**
- *  These are errors from the `/chunk` endpoint on an Arweave
- *  node that we should never try to continue on
- */
-const FATAL_CHUNK_UPLOAD_ERRORS = [
-	'invalid_json',
-	'chunk_too_big',
-	'data_path_too_big',
-	'offset_too_big',
-	'data_size_too_big',
-	'chunk_proof_ratio_not_attractive',
-	'invalid_proof'
-];
-
 interface MultiChunkTxUploaderConstructorParams {
-	gatewayUrl: URL;
+	gatewayApi: GatewayAPI;
 	transaction: Transaction;
 	maxConcurrentChunks?: number;
-	maxRetriesPerRequest?: number;
 	progressCallback?: (pctComplete: number) => void;
 }
 
@@ -76,17 +56,15 @@ export class MultiChunkTxUploader {
 		return Math.trunc((this.uploadedChunks / this.totalChunks) * 100);
 	}
 
-	private gatewayUrl: URL;
+	private gatewayApi: GatewayAPI;
 	private transaction: Transaction;
 	private maxConcurrentChunks: number;
-	private maxRetriesPerRequest: number;
 	private progressCallback?: (pctComplete: number) => void;
 
 	constructor({
-		gatewayUrl,
+		gatewayApi,
 		transaction,
 		maxConcurrentChunks = defaultMaxConcurrentChunks,
-		maxRetriesPerRequest = 8,
 		progressCallback
 	}: MultiChunkTxUploaderConstructorParams) {
 		if (!transaction.id) {
@@ -96,10 +74,9 @@ export class MultiChunkTxUploader {
 			throw new Error(`Transaction chunks not prepared`);
 		}
 
-		this.gatewayUrl = gatewayUrl;
+		this.gatewayApi = gatewayApi;
 		this.transaction = transaction;
 		this.maxConcurrentChunks = maxConcurrentChunks;
-		this.maxRetriesPerRequest = maxRetriesPerRequest;
 		this.progressCallback = progressCallback;
 	}
 
@@ -147,8 +124,9 @@ export class MultiChunkTxUploader {
 			const chunk = this.transaction.getChunk(this.chunkOffset++, this.transaction.data);
 
 			try {
-				await this.retryRequestUntilMaxErrors(() => axios.post(`${this.gatewayUrl.href}chunk`, chunk));
+				await this.gatewayApi.postChunk(chunk);
 			} catch (err) {
+				this.hasFailedRequests = true;
 				throw new Error(`Too many errors encountered while posting chunks: ${err}`);
 			}
 
@@ -169,16 +147,17 @@ export class MultiChunkTxUploader {
 	private async postTransactionHeader(): Promise<void> {
 		const uploadInBody = this.totalChunks <= MAX_CHUNKS_IN_BODY;
 
-		// We will send the data with the headers if chunks will fit into transaction header body
-		// Otherwise we send the headers with no data
+		// We will send the data with the header if chunks will fit into transaction header body
+		// Otherwise we send the header with no data
 		const transactionToUpload = uploadInBody
 			? this.transaction
 			: new Transaction(Object.assign({}, this.transaction, { data: new Uint8Array(0) }));
 
 		try {
-			await this.retryRequestUntilMaxErrors(() => axios.post(`${this.gatewayUrl.href}tx`, transactionToUpload));
+			await this.gatewayApi.postTxHeader(transactionToUpload);
 		} catch (err) {
-			throw new Error(`Too many errors encountered while posting transaction headers:  ${err}`);
+			this.hasFailedRequests = true;
+			throw new Error(`Too many errors encountered while posting transaction header:  ${err}`);
 		}
 
 		this.txPosted = true;
@@ -189,60 +168,5 @@ export class MultiChunkTxUploader {
 		}
 
 		return;
-	}
-
-	/**
-	 * Retries the given request until the response returns a successful
-	 * status code of 200 or the maxRetries setting has been exceeded
-	 *
-	 * @throws when a fatal chunk error has been returned by an Arweave node
-	 * @throws when max retries have been exhausted
-	 */
-	private async retryRequestUntilMaxErrors(request: () => Promise<AxiosResponse<unknown>>) {
-		let resp: AxiosResponse<unknown>;
-		let retryNumber = 0;
-		let lastError = 'unknown error';
-		let lastRespStatus: number | undefined;
-
-		while (retryNumber < this.maxRetriesPerRequest && !this.hasFailedRequests) {
-			try {
-				resp = await request();
-				lastRespStatus = resp.status;
-
-				if (lastRespStatus === 200) {
-					// Request successful. All done.
-					return;
-				}
-
-				lastError = resp.statusText ?? resp;
-			} catch (err) {
-				lastError = err instanceof Error ? err.message : err;
-			}
-
-			// Throw in cases of unrecoverable errors
-			if (FATAL_CHUNK_UPLOAD_ERRORS.includes(lastError)) {
-				this.hasFailedRequests = true;
-				throw new Error(`Fatal error uploading chunk: (Status: ${lastRespStatus}) ${lastError}`);
-			}
-
-			// Use exponential back-off delay after failed requests. With the current
-			// default error delay and max retries, we expect the following wait times:
-
-			// Retry wait 1: 500ms
-			// Retry wait 2: 1,000ms
-			// Retry wait 3: 2,000ms
-			// Retry wait 4: 4,000ms
-			// Retry wait 5: 8,000ms
-			// Retry wait 6: 16,000ms
-			// Retry wait 7: 32,000ms
-			// Retry wait 8: 64,000ms
-
-			const delay = Math.pow(2, retryNumber) * INITIAL_ERROR_DELAY;
-			await new Promise((res) => setTimeout(res, delay));
-			retryNumber++;
-		}
-
-		this.hasFailedRequests = true;
-		throw new Error(`Request to gateway has failed: (Status: ${lastRespStatus}) ${lastError}`);
 	}
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -46,3 +46,23 @@ export const fakePrivateCipherIVTag = { name: 'Cipher-IV', value: 'qwertyuiopasd
 
 export const authTagLength = 16;
 export const defaultMaxConcurrentChunks = 32;
+
+/**
+ * Error delay for the first failed request for a transaction header post or chunk upload
+ * Subsequent requests will delay longer with an exponential back off strategy
+ */
+export const INITIAL_ERROR_DELAY = 500; // 500ms
+
+/**
+ *  These are errors from the `/chunk` endpoint on an Arweave
+ *  node that we should never try to continue on
+ */
+export const FATAL_CHUNK_UPLOAD_ERRORS = [
+	'invalid_json',
+	'chunk_too_big',
+	'data_path_too_big',
+	'offset_too_big',
+	'data_size_too_big',
+	'chunk_proof_ratio_not_attractive',
+	'invalid_proof'
+];

--- a/src/utils/gateway_api.test.ts
+++ b/src/utils/gateway_api.test.ts
@@ -1,125 +1,123 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import Arweave from 'arweave';
 import Transaction from 'arweave/node/lib/transaction';
-import axios, { AxiosResponse } from 'axios';
-import { Chunk } from '../arfs/multi_chunk_tx_uploader';
-import { FATAL_CHUNK_UPLOAD_ERRORS, INITIAL_ERROR_DELAY } from './constants';
+import axios from 'axios';
+import { expect } from 'chai';
+import { describe } from 'mocha';
+import { spy, stub } from 'sinon';
+import { expectAsyncErrorThrow } from '../../tests/test_helpers';
+import { GatewayAPI } from './gateway_api';
 
-interface GatewayAPIConstParams {
-	gatewayUrl: URL;
-	maxRetriesPerRequest?: number;
-	/** MS to wait after first failed request; uses exponential delay on subsequent retries */
-	initialErrorDelayMS?: number;
-	/** Errors returned by response.statusText that we should never continue on */
-	fatalErrors?: string[];
-	/** Status codes returned by response.status that we will consider a successful response */
-	validStatusCodes?: number[];
-}
+describe('GatewayAPI class', function () {
+	const arweave = Arweave.init({
+		host: 'fake',
+		port: 433,
+		protocol: 'http',
+		timeout: 600000
+	});
 
-// With the current default error delay and max retries, we expect the following wait times:
+	const gatewayUrl = new URL('http://fake');
 
-// First request: 0ms
-// Retry wait 1 : 500ms
-// Retry wait 2 : 1,000ms
-// Retry wait 3 : 2,000ms
-// Retry wait 4 : 4,000ms
-// Retry wait 5 : 8,000ms
-// Retry wait 6 : 16,000ms
-// Retry wait 7 : 32,000ms
-// Retry wait 8 : 64,000ms
+	let smallTx: Transaction;
 
-export class GatewayAPI {
-	private gatewayUrl: URL;
-	private maxRetriesPerRequest: number;
-	private initialErrorDelayMS: number;
-	private fatalErrors: string[];
-	private validStatusCodes: number[];
+	before(async () => {
+		const wallet = await arweave.wallets.generate();
 
-	constructor({
-		gatewayUrl,
-		maxRetriesPerRequest = 8,
-		initialErrorDelayMS = INITIAL_ERROR_DELAY,
-		fatalErrors = FATAL_CHUNK_UPLOAD_ERRORS,
-		validStatusCodes = [200]
-	}: GatewayAPIConstParams) {
-		this.gatewayUrl = gatewayUrl;
-		this.maxRetriesPerRequest = maxRetriesPerRequest;
-		this.initialErrorDelayMS = initialErrorDelayMS;
-		this.fatalErrors = fatalErrors;
-		this.validStatusCodes = validStatusCodes;
-	}
+		const oneChunkOfData = new Uint8Array(5);
 
-	private lastError = 'unknown error';
-	private lastRespStatus = 0;
+		smallTx = await arweave.createTransaction({ reward: '0', last_tx: 'STUB', data: oneChunkOfData }, wallet);
 
-	public async postChunk(chunk: Chunk): Promise<void> {
-		await this.postToEndpoint('chunk', chunk);
-	}
+		await arweave.transactions.sign(smallTx, wallet);
+		await smallTx.prepareChunks(oneChunkOfData);
+	});
 
-	public async postTxHeader(transaction: Transaction): Promise<void> {
-		await this.postToEndpoint('tx', transaction);
-	}
+	const axiosInstance = axios.create();
 
-	private async postToEndpoint(endpoint: string, data?: unknown): Promise<AxiosResponse<unknown>> {
-		return this.retryRequestUntilMaxRetries(() => axios.post(`${this.gatewayUrl.href}${endpoint}`, data));
-	}
+	describe('postToEndpoint method', () => {
+		it('succeeds without error when response contains the default successful status code', async () => {
+			const axiosSpy = stub(axiosInstance, 'post').resolves({ status: 200 });
+			const gatewayApi = new GatewayAPI({ gatewayUrl, axiosInstance });
 
-	/**
-	 * Retries the given request until the response returns a successful
-	 * status code of 200 or the maxRetries setting has been exceeded
-	 *
-	 * @throws when a fatal chunk error has been returned by an Arweave node
-	 * @throws when max retries have been exhausted
-	 */
-	private async retryRequestUntilMaxRetries(
-		request: () => Promise<AxiosResponse<unknown>>
-	): Promise<AxiosResponse<unknown>> {
-		let retryNumber = 0;
+			await gatewayApi.postToEndpoint('');
 
-		while (retryNumber < this.maxRetriesPerRequest) {
-			const response = await this.tryRequest(request);
+			expect(axiosSpy.callCount).to.equal(1);
+		});
 
-			if (response) {
-				return response;
-			}
-			this.throwIfFatalError();
+		it('succeeds without error when first response contains an error but a subsequent response contains a successful status code', async () => {
+			const axiosSpy = stub(axiosInstance, 'post')
+				.onCall(0)
+				.resolves({ status: 400 })
+				.onCall(1)
+				.resolves({ status: 400 })
+				.onCall(2)
+				.resolves({ status: 101 });
 
-			await this.exponentialBackOffAfterFailedRequest(retryNumber++);
-		}
+			const gatewayApi = new GatewayAPI({
+				gatewayUrl,
+				validStatusCodes: [101],
+				axiosInstance,
+				initialErrorDelayMS: 1
+			});
 
-		// Didn't succeed within number of allocated retries
-		throw new Error(`Request to gateway has failed: (Status: ${this.lastRespStatus}) ${this.lastError}`);
-	}
+			await gatewayApi.postToEndpoint('');
 
-	private async tryRequest(
-		request: () => Promise<AxiosResponse<unknown>>
-	): Promise<AxiosResponse<unknown> | undefined> {
-		try {
-			const resp = await request();
-			this.lastRespStatus = resp.status;
+			expect(axiosSpy.callCount).to.equal(3);
+		});
 
-			if (this.isRequestSuccessful()) {
-				return resp;
-			}
+		it('throws an error when response contains a fatal error', async () => {
+			const axiosSpy = stub(axiosInstance, 'post').resolves({ status: 400, statusText: 'Massive Error' });
+			const gatewayApi = new GatewayAPI({ gatewayUrl, fatalErrors: ['Massive Error'], axiosInstance });
 
-			this.lastError = resp.statusText ?? resp;
-		} catch (err) {
-			this.lastError = err instanceof Error ? err.message : err;
-		}
+			await expectAsyncErrorThrow({
+				promiseToError: gatewayApi.postToEndpoint(''),
+				errorMessage: 'Fatal error encountered: (Status: 400) Massive Error'
+			});
 
-		return undefined;
-	}
+			expect(axiosSpy.callCount).to.equal(1);
+		});
 
-	private isRequestSuccessful(): boolean {
-		return this.validStatusCodes.includes(this.lastRespStatus);
-	}
+		it('throws an error after max retries have been expended', async () => {
+			const axiosSpy = stub(axiosInstance, 'post').resolves({ status: 400, statusText: 'Total Error' });
+			const gatewayApi = new GatewayAPI({
+				gatewayUrl,
+				maxRetriesPerRequest: 3,
+				initialErrorDelayMS: 1,
+				axiosInstance
+			});
 
-	private throwIfFatalError() {
-		if (this.fatalErrors.includes(this.lastError)) {
-			throw new Error(`Fatal error uploading chunk: (Status: ${this.lastRespStatus}) ${this.lastError}`);
-		}
-	}
+			await expectAsyncErrorThrow({
+				promiseToError: gatewayApi.postToEndpoint(''),
+				errorMessage: 'Request to gateway has failed: (Status: 400) Total Error'
+			});
 
-	private async exponentialBackOffAfterFailedRequest(retryNumber: number): Promise<void> {
-		const delay = Math.pow(2, retryNumber) * this.initialErrorDelayMS;
-		await new Promise((res) => setTimeout(res, delay));
-	}
-}
+			// Expect 4 tries with maxRetries set to 3
+			expect(axiosSpy.callCount).to.equal(4);
+		});
+	});
+
+	describe('postChunk method', () => {
+		it('succeeds without error when response contains a successful status code', async () => {
+			const axiosSpy = stub(axiosInstance, 'post').resolves({ status: 101 });
+			const gatewayApi = new GatewayAPI({ gatewayUrl, validStatusCodes: [101], axiosInstance });
+			const endPointSpy = spy(gatewayApi as any, 'postToEndpoint');
+
+			await gatewayApi.postChunk(smallTx.getChunk(0, smallTx.data));
+
+			expect(axiosSpy.callCount).to.equal(1);
+			expect(endPointSpy.args[0][0]).to.equal('chunk');
+		});
+	});
+
+	describe('postTxHeader method', () => {
+		it('succeeds without error when response contains a successful status code', async () => {
+			const axiosSpy = stub(axiosInstance, 'post').resolves({ status: 200 });
+			const gatewayApi = new GatewayAPI({ gatewayUrl, axiosInstance });
+			const endPointSpy = spy(gatewayApi as any, 'postToEndpoint');
+
+			await gatewayApi.postTxHeader(smallTx);
+
+			expect(axiosSpy.callCount).to.equal(1);
+			expect(endPointSpy.args[0][0]).to.equal('tx');
+		});
+	});
+});

--- a/src/utils/gateway_api.test.ts
+++ b/src/utils/gateway_api.test.ts
@@ -1,0 +1,125 @@
+import Transaction from 'arweave/node/lib/transaction';
+import axios, { AxiosResponse } from 'axios';
+import { Chunk } from '../arfs/multi_chunk_tx_uploader';
+import { FATAL_CHUNK_UPLOAD_ERRORS, INITIAL_ERROR_DELAY } from './constants';
+
+interface GatewayAPIConstParams {
+	gatewayUrl: URL;
+	maxRetriesPerRequest?: number;
+	/** MS to wait after first failed request; uses exponential delay on subsequent retries */
+	initialErrorDelayMS?: number;
+	/** Errors returned by response.statusText that we should never continue on */
+	fatalErrors?: string[];
+	/** Status codes returned by response.status that we will consider a successful response */
+	validStatusCodes?: number[];
+}
+
+// With the current default error delay and max retries, we expect the following wait times:
+
+// First request: 0ms
+// Retry wait 1 : 500ms
+// Retry wait 2 : 1,000ms
+// Retry wait 3 : 2,000ms
+// Retry wait 4 : 4,000ms
+// Retry wait 5 : 8,000ms
+// Retry wait 6 : 16,000ms
+// Retry wait 7 : 32,000ms
+// Retry wait 8 : 64,000ms
+
+export class GatewayAPI {
+	private gatewayUrl: URL;
+	private maxRetriesPerRequest: number;
+	private initialErrorDelayMS: number;
+	private fatalErrors: string[];
+	private validStatusCodes: number[];
+
+	constructor({
+		gatewayUrl,
+		maxRetriesPerRequest = 8,
+		initialErrorDelayMS = INITIAL_ERROR_DELAY,
+		fatalErrors = FATAL_CHUNK_UPLOAD_ERRORS,
+		validStatusCodes = [200]
+	}: GatewayAPIConstParams) {
+		this.gatewayUrl = gatewayUrl;
+		this.maxRetriesPerRequest = maxRetriesPerRequest;
+		this.initialErrorDelayMS = initialErrorDelayMS;
+		this.fatalErrors = fatalErrors;
+		this.validStatusCodes = validStatusCodes;
+	}
+
+	private lastError = 'unknown error';
+	private lastRespStatus = 0;
+
+	public async postChunk(chunk: Chunk): Promise<void> {
+		await this.postToEndpoint('chunk', chunk);
+	}
+
+	public async postTxHeader(transaction: Transaction): Promise<void> {
+		await this.postToEndpoint('tx', transaction);
+	}
+
+	private async postToEndpoint(endpoint: string, data?: unknown): Promise<AxiosResponse<unknown>> {
+		return this.retryRequestUntilMaxRetries(() => axios.post(`${this.gatewayUrl.href}${endpoint}`, data));
+	}
+
+	/**
+	 * Retries the given request until the response returns a successful
+	 * status code of 200 or the maxRetries setting has been exceeded
+	 *
+	 * @throws when a fatal chunk error has been returned by an Arweave node
+	 * @throws when max retries have been exhausted
+	 */
+	private async retryRequestUntilMaxRetries(
+		request: () => Promise<AxiosResponse<unknown>>
+	): Promise<AxiosResponse<unknown>> {
+		let retryNumber = 0;
+
+		while (retryNumber < this.maxRetriesPerRequest) {
+			const response = await this.tryRequest(request);
+
+			if (response) {
+				return response;
+			}
+			this.throwIfFatalError();
+
+			await this.exponentialBackOffAfterFailedRequest(retryNumber++);
+		}
+
+		// Didn't succeed within number of allocated retries
+		throw new Error(`Request to gateway has failed: (Status: ${this.lastRespStatus}) ${this.lastError}`);
+	}
+
+	private async tryRequest(
+		request: () => Promise<AxiosResponse<unknown>>
+	): Promise<AxiosResponse<unknown> | undefined> {
+		try {
+			const resp = await request();
+			this.lastRespStatus = resp.status;
+
+			if (this.isRequestSuccessful()) {
+				return resp;
+			}
+
+			this.lastError = resp.statusText ?? resp;
+		} catch (err) {
+			this.lastError = err instanceof Error ? err.message : err;
+		}
+
+		return undefined;
+	}
+
+	private isRequestSuccessful(): boolean {
+		return this.validStatusCodes.includes(this.lastRespStatus);
+	}
+
+	private throwIfFatalError() {
+		if (this.fatalErrors.includes(this.lastError)) {
+			throw new Error(`Fatal error uploading chunk: (Status: ${this.lastRespStatus}) ${this.lastError}`);
+		}
+	}
+
+	private async exponentialBackOffAfterFailedRequest(retryNumber: number): Promise<void> {
+		const delay = Math.pow(2, retryNumber) * this.initialErrorDelayMS;
+		await new Promise((res) => setTimeout(res, delay));
+	}
+}

--- a/src/utils/gateway_api.ts
+++ b/src/utils/gateway_api.ts
@@ -1,30 +1,40 @@
 import Transaction from 'arweave/node/lib/transaction';
-import axios, { AxiosResponse } from 'axios';
+import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import { Chunk } from '../arfs/multi_chunk_tx_uploader';
 import { FATAL_CHUNK_UPLOAD_ERRORS, INITIAL_ERROR_DELAY } from './constants';
 
 interface GatewayAPIConstParams {
 	gatewayUrl: URL;
 	maxRetriesPerRequest?: number;
-	/** MS to wait after first failed request; uses exponential delay on subsequent retries */
 	initialErrorDelayMS?: number;
-	/** Errors returned by response.statusText that we should never continue on */
 	fatalErrors?: string[];
-	/** Status codes returned by response.status that we will consider a successful response */
 	validStatusCodes?: number[];
+	axiosInstance?: AxiosInstance;
 }
 
-// With the current default error delay and max retries, we expect the following wait times:
+// With the current default error delay and max retries, we expect the following wait times after each request sent:
 
-// First request: 0ms
-// Retry wait 1 : 500ms
-// Retry wait 2 : 1,000ms
-// Retry wait 3 : 2,000ms
-// Retry wait 4 : 4,000ms
-// Retry wait 5 : 8,000ms
-// Retry wait 6 : 16,000ms
-// Retry wait 7 : 32,000ms
-// Retry wait 8 : 64,000ms
+// 1st request attempt
+// Retry wait 1: 500ms
+// 2nd request attempt
+// Retry wait 2: 1,000ms
+// 3rd request attempt
+// Retry wait 3: 2,000ms
+// 4th request attempt
+// Retry wait 4: 4,000ms
+// 5th request attempt
+// Retry wait 5: 8,000ms
+// 6th request attempt
+// Retry wait 6: 16,000ms
+// 7th request attempt
+// Retry wait 7: 32,000ms
+// 8th request attempt
+// Retry wait 8: 64,000ms
+// 9th request attempt
+// Throw error if 9th request failure
+
+// Total wait time:
+// 127,500ms / 2 minutes and 7.5 seconds
 
 export class GatewayAPI {
 	private gatewayUrl: URL;
@@ -32,19 +42,22 @@ export class GatewayAPI {
 	private initialErrorDelayMS: number;
 	private fatalErrors: string[];
 	private validStatusCodes: number[];
+	private axiosInstance: AxiosInstance;
 
 	constructor({
 		gatewayUrl,
 		maxRetriesPerRequest = 8,
 		initialErrorDelayMS = INITIAL_ERROR_DELAY,
 		fatalErrors = FATAL_CHUNK_UPLOAD_ERRORS,
-		validStatusCodes = [200]
+		validStatusCodes = [200],
+		axiosInstance = axios.create()
 	}: GatewayAPIConstParams) {
 		this.gatewayUrl = gatewayUrl;
 		this.maxRetriesPerRequest = maxRetriesPerRequest;
 		this.initialErrorDelayMS = initialErrorDelayMS;
 		this.fatalErrors = fatalErrors;
 		this.validStatusCodes = validStatusCodes;
+		this.axiosInstance = axiosInstance;
 	}
 
 	private lastError = 'unknown error';
@@ -58,15 +71,17 @@ export class GatewayAPI {
 		await this.postToEndpoint('tx', transaction);
 	}
 
-	private async postToEndpoint(endpoint: string, data?: unknown): Promise<AxiosResponse<unknown>> {
-		return this.retryRequestUntilMaxRetries(() => axios.post(`${this.gatewayUrl.href}${endpoint}`, data));
+	public async postToEndpoint(endpoint: string, data?: unknown): Promise<AxiosResponse<unknown>> {
+		return this.retryRequestUntilMaxRetries(() =>
+			this.axiosInstance.post(`${this.gatewayUrl.href}${endpoint}`, data)
+		);
 	}
 
 	/**
 	 * Retries the given request until the response returns a successful
-	 * status code of 200 or the maxRetries setting has been exceeded
+	 * status code or the maxRetries setting has been exceeded
 	 *
-	 * @throws when a fatal chunk error has been returned by an Arweave node
+	 * @throws when a fatal error has been returned by request
 	 * @throws when max retries have been exhausted
 	 */
 	private async retryRequestUntilMaxRetries(
@@ -74,7 +89,7 @@ export class GatewayAPI {
 	): Promise<AxiosResponse<unknown>> {
 		let retryNumber = 0;
 
-		while (retryNumber < this.maxRetriesPerRequest) {
+		while (retryNumber <= this.maxRetriesPerRequest) {
 			const response = await this.tryRequest(request);
 
 			if (response) {
@@ -114,7 +129,7 @@ export class GatewayAPI {
 
 	private throwIfFatalError() {
 		if (this.fatalErrors.includes(this.lastError)) {
-			throw new Error(`Fatal error uploading chunk: (Status: ${this.lastRespStatus}) ${this.lastError}`);
+			throw new Error(`Fatal error encountered: (Status: ${this.lastRespStatus}) ${this.lastError}`);
 		}
 	}
 

--- a/src/utils/gateway_api.ts
+++ b/src/utils/gateway_api.ts
@@ -1,0 +1,125 @@
+import Transaction from 'arweave/node/lib/transaction';
+import axios, { AxiosResponse } from 'axios';
+import { Chunk } from '../arfs/multi_chunk_tx_uploader';
+import { FATAL_CHUNK_UPLOAD_ERRORS, INITIAL_ERROR_DELAY } from './constants';
+
+interface GatewayAPIConstParams {
+	gatewayUrl: URL;
+	maxRetriesPerRequest?: number;
+	/** MS to wait after first failed request; uses exponential delay on subsequent retries */
+	initialErrorDelayMS?: number;
+	/** Errors returned by response.statusText that we should never continue on */
+	fatalErrors?: string[];
+	/** Status codes returned by response.status that we will consider a successful response */
+	validStatusCodes?: number[];
+}
+
+// With the current default error delay and max retries, we expect the following wait times:
+
+// First request: 0ms
+// Retry wait 1 : 500ms
+// Retry wait 2 : 1,000ms
+// Retry wait 3 : 2,000ms
+// Retry wait 4 : 4,000ms
+// Retry wait 5 : 8,000ms
+// Retry wait 6 : 16,000ms
+// Retry wait 7 : 32,000ms
+// Retry wait 8 : 64,000ms
+
+export class GatewayAPI {
+	private gatewayUrl: URL;
+	private maxRetriesPerRequest: number;
+	private initialErrorDelayMS: number;
+	private fatalErrors: string[];
+	private validStatusCodes: number[];
+
+	constructor({
+		gatewayUrl,
+		maxRetriesPerRequest = 8,
+		initialErrorDelayMS = INITIAL_ERROR_DELAY,
+		fatalErrors = FATAL_CHUNK_UPLOAD_ERRORS,
+		validStatusCodes = [200]
+	}: GatewayAPIConstParams) {
+		this.gatewayUrl = gatewayUrl;
+		this.maxRetriesPerRequest = maxRetriesPerRequest;
+		this.initialErrorDelayMS = initialErrorDelayMS;
+		this.fatalErrors = fatalErrors;
+		this.validStatusCodes = validStatusCodes;
+	}
+
+	private lastError = 'unknown error';
+	private lastRespStatus = 0;
+
+	public async postChunk(chunk: Chunk): Promise<void> {
+		await this.postToEndpoint('chunk', chunk);
+	}
+
+	public async postTxHeader(transaction: Transaction): Promise<void> {
+		await this.postToEndpoint('tx', transaction);
+	}
+
+	private async postToEndpoint(endpoint: string, data?: unknown): Promise<AxiosResponse<unknown>> {
+		return this.retryRequestUntilMaxRetries(() => axios.post(`${this.gatewayUrl.href}${endpoint}`, data));
+	}
+
+	/**
+	 * Retries the given request until the response returns a successful
+	 * status code of 200 or the maxRetries setting has been exceeded
+	 *
+	 * @throws when a fatal chunk error has been returned by an Arweave node
+	 * @throws when max retries have been exhausted
+	 */
+	private async retryRequestUntilMaxRetries(
+		request: () => Promise<AxiosResponse<unknown>>
+	): Promise<AxiosResponse<unknown>> {
+		let retryNumber = 0;
+
+		while (retryNumber < this.maxRetriesPerRequest) {
+			const response = await this.tryRequest(request);
+
+			if (response) {
+				return response;
+			}
+			this.throwIfFatalError();
+
+			await this.exponentialBackOffAfterFailedRequest(retryNumber++);
+		}
+
+		// Didn't succeed within number of allocated retries
+		throw new Error(`Request to gateway has failed: (Status: ${this.lastRespStatus}) ${this.lastError}`);
+	}
+
+	private async tryRequest(
+		request: () => Promise<AxiosResponse<unknown>>
+	): Promise<AxiosResponse<unknown> | undefined> {
+		try {
+			const resp = await request();
+			this.lastRespStatus = resp.status;
+
+			if (this.isRequestSuccessful()) {
+				return resp;
+			}
+
+			this.lastError = resp.statusText ?? resp;
+		} catch (err) {
+			this.lastError = err instanceof Error ? err.message : err;
+		}
+
+		return undefined;
+	}
+
+	private isRequestSuccessful(): boolean {
+		return this.validStatusCodes.includes(this.lastRespStatus);
+	}
+
+	private throwIfFatalError() {
+		if (this.fatalErrors.includes(this.lastError)) {
+			throw new Error(`Fatal error uploading chunk: (Status: ${this.lastRespStatus}) ${this.lastError}`);
+		}
+	}
+
+	private async exponentialBackOffAfterFailedRequest(retryNumber: number): Promise<void> {
+		const delay = Math.pow(2, retryNumber) * this.initialErrorDelayMS;
+		await new Promise((res) => setTimeout(res, delay));
+	}
+}


### PR DESCRIPTION
This PR extracts the gateway retry logic into a central class that can be re-used for retrying all requests.