### PR TITLE
PE-1913: cover json types

### DIFF
--- a/tests/helpers/arlocal_test_assertions.ts
+++ b/tests/helpers/arlocal_test_assertions.ts
@@ -295,11 +295,13 @@ export function assertFileMetaDataGqlTags(
 		driveId: DriveID;
 		fileId: FileID;
 		parentFolderId: DriveID;
-		customMetaData: CustomMetaDataGqlTags;
+		customMetaData?: CustomMetaDataGqlTags;
 	}
 ): void {
 	const { driveId, fileId, parentFolderId, customMetaData } = expectations;
-	const expectedMetaData: GQLTagInterface[] = mapMetaDataTagInterfaceToGqlTagInterface(customMetaData);
+	const expectedMetaData: GQLTagInterface[] = customMetaData
+		? mapMetaDataTagInterfaceToGqlTagInterface(customMetaData)
+		: [];
 
 	const metaDataTags = getDecodedTags(metaDataTx.tags);
 

--- a/tests/integration/arlocal.int.test.ts
+++ b/tests/integration/arlocal.int.test.ts
@@ -523,13 +523,14 @@ describe('ArLocal Integration Tests', function () {
 			const { dataTxId, metadataTxId, entityId: fileId }: Required<ArFSEntityData> = created[0];
 			const expectedFileSize = 12;
 			const expectedCustomMetaData = Object.assign(customMetaData, { ['NaN']: null, ['Infinity']: null });
+			const dataContentType = 'text/plain';
 
 			const metaDataJson = await getMetaDataJSONFromGateway(arweave, metadataTxId);
 			assertFileMetaDataJson(metaDataJson, {
 				name: fileName,
 				size: expectedFileSize,
 				dataTxId: `${dataTxId}`,
-				dataContentType: 'text/plain',
+				dataContentType,
 				customMetaData: expectedCustomMetaData
 			});
 
@@ -541,11 +542,9 @@ describe('ArLocal Integration Tests', function () {
 			});
 
 			const dataTx = new Transaction(await fakeGatewayApi.getTransaction(dataTxId));
-			assertFileDataTxGqlTags(dataTx, { contentType: 'text/plain' });
+			assertFileDataTxGqlTags(dataTx, { contentType: dataContentType });
 
 			const arFSFileEntity = await v2ArDrive.getPublicFile({ fileId });
-			console.log('arFSFileEntity', JSON.stringify(arFSFileEntity, null, 4));
-
 			assertPublicFileExpectations({
 				size: new ByteCount(expectedFileSize),
 				parentFolderId: rootFolderId,
@@ -555,8 +554,7 @@ describe('ArLocal Integration Tests', function () {
 				entity: arFSFileEntity,
 				driveId,
 				dataTxId,
-				dataContentType: 'text/plain',
-				/** We will expect these tags to be parsed back twice, once from dataJSON and once from GQL tags */
+				dataContentType,
 				customMetaData: expectedCustomMetaData
 			});
 		});

--- a/tests/integration/arlocal.int.test.ts
+++ b/tests/integration/arlocal.int.test.ts
@@ -35,7 +35,13 @@ import {
 } from '../../src/arfs/arfs_entities';
 import { GatewayAPI } from '../../src/utils/gateway_api';
 import { restore, stub } from 'sinon';
-import { stub258KiBFileToUpload, stub2ChunkFileToUpload, stub3ChunkFileToUpload, stubArweaveAddress } from '../stubs';
+import {
+	stub258KiBFileToUpload,
+	stub2ChunkFileToUpload,
+	stub3ChunkFileToUpload,
+	stubArweaveAddress,
+	stubCommunityContract
+} from '../stubs';
 import { assertRetryExpectations } from '../test_assertions';
 import {
 	expectAsyncErrorThrow,
@@ -64,6 +70,7 @@ import {
 	assertFolderMetaDataJson,
 	assertFolderMetaDataGqlTags
 } from '../helpers/arlocal_test_assertions';
+import { VertoContractReader } from '../../src/exports';
 
 describe('ArLocal Integration Tests', function () {
 	const wallet = readJWKFile('./test_wallet.json');
@@ -77,7 +84,10 @@ describe('ArLocal Integration Tests', function () {
 	const fakeVersion = 'FAKE_VERSION';
 
 	const arweaveOracle = new GatewayOracle(gatewayUrlForArweave(arweave));
-	const communityOracle = new ArDriveCommunityOracle(arweave);
+	const fakeContractReader = new VertoContractReader();
+	stub(fakeContractReader, 'readContract').resolves(stubCommunityContract);
+
+	const communityOracle = new ArDriveCommunityOracle(arweave, [fakeContractReader]);
 	const priceEstimator = new ARDataPriceNetworkEstimator(arweaveOracle);
 	const walletDao = new WalletDAO(arweave, 'ArLocal Integration Test', fakeVersion);
 
@@ -464,6 +474,90 @@ describe('ArLocal Integration Tests', function () {
 					['Custom Tag']: ['This Test Works', 'This Test Works'],
 					['Custom Tag Array']: ['This Test Works', 'As Well :)', 'This Test Works', 'As Well :)']
 				}
+			});
+		});
+
+		it('we can upload a file as a v2 transaction with custom metadata to the Data JSON containing all valid JSON shapes', async () => {
+			const fileName = 'json_shapes_unique_name';
+			const customMetaData = {
+				['boolean']: true,
+				['number']: 420,
+				['string']: 'value',
+				['null']: null,
+				['NaN']: NaN,
+				['Infinity']: Number.POSITIVE_INFINITY,
+				['array']: [
+					'containing',
+					'all',
+					'types',
+					1337,
+					false,
+					['not', 'too', 'deep'],
+					{ ['nested']: 'Object' }
+				],
+				['object']: {
+					['with']: 'very',
+					['many']: 42,
+					['types']: true,
+					['to']: [false],
+					['check']: { ['nest']: 'it' }
+				}
+			};
+
+			const { created } = await v2ArDrive.uploadAllEntities({
+				entitiesToUpload: [
+					{
+						destFolderId: rootFolderId,
+						wrappedEntity: wrapFileOrFolder(
+							'tests/stub_files/bulk_root_folder/file_in_root.txt',
+							undefined,
+							{ metaDataJson: customMetaData }
+						),
+						destName: fileName
+					}
+				]
+			});
+			await mineArLocalBlock(arweave);
+
+			// @ts-ignore
+			const { dataTxId, metadataTxId, entityId: fileId }: Required<ArFSEntityData> = created[0];
+			const expectedFileSize = 12;
+			const expectedCustomMetaData = Object.assign(customMetaData, { ['NaN']: null, ['Infinity']: null });
+
+			const metaDataJson = await getMetaDataJSONFromGateway(arweave, metadataTxId);
+			assertFileMetaDataJson(metaDataJson, {
+				name: fileName,
+				size: expectedFileSize,
+				dataTxId: `${dataTxId}`,
+				dataContentType: 'text/plain',
+				customMetaData: expectedCustomMetaData
+			});
+
+			const metaDataTx = new Transaction(await fakeGatewayApi.getTransaction(metadataTxId));
+			assertFileMetaDataGqlTags(metaDataTx, {
+				driveId,
+				fileId,
+				parentFolderId: rootFolderId
+			});
+
+			const dataTx = new Transaction(await fakeGatewayApi.getTransaction(dataTxId));
+			assertFileDataTxGqlTags(dataTx, { contentType: 'text/plain' });
+
+			const arFSFileEntity = await v2ArDrive.getPublicFile({ fileId });
+			console.log('arFSFileEntity', JSON.stringify(arFSFileEntity, null, 4));
+
+			assertPublicFileExpectations({
+				size: new ByteCount(expectedFileSize),
+				parentFolderId: rootFolderId,
+				metaDataTxId: metadataTxId,
+				fileId,
+				entityName: fileName,
+				entity: arFSFileEntity,
+				driveId,
+				dataTxId,
+				dataContentType: 'text/plain',
+				/** We will expect these tags to be parsed back twice, once from dataJSON and once from GQL tags */
+				customMetaData: expectedCustomMetaData
 			});
 		});
 


### PR DESCRIPTION
This PR covers the valid JSON types in arlocal integration and removes the ArLocal dependency to a Verto network request for the community contract