### PR TITLE
PE-1534: custom metadata (CORE only)

### DIFF
--- a/src/arfs/arfs_meta_data_factory.ts
+++ b/src/arfs/arfs_meta_data_factory.ts
@@ -74,7 +74,8 @@ export function getPrepFileParams({
 			wrappedFile,
 			dataPrototypeFactoryFn: async (fileData, fileId) =>
 				new ArFSPrivateFileDataPrototype(
-					await ArFSPrivateFileDataTransactionData.from(fileData, fileId, driveKey)
+					await ArFSPrivateFileDataTransactionData.from(fileData, fileId, driveKey),
+					wrappedFile.customMetaData?.dataGqlTags
 				),
 			metadataTxDataFactoryFn: async (fileId, dataTxId) => {
 				return ArFSPrivateFileMetaDataPrototype.fromFile({
@@ -96,7 +97,8 @@ export function getPrepFileParams({
 			Promise.resolve(
 				new ArFSPublicFileDataPrototype(
 					new ArFSPublicFileDataTransactionData(fileData),
-					wrappedFile.contentType
+					wrappedFile.contentType,
+					wrappedFile.customMetaData?.dataGqlTags
 				)
 			),
 		metadataTxDataFactoryFn: (fileId, dataTxId) =>

--- a/src/types/custom_metadata_types.ts
+++ b/src/types/custom_metadata_types.ts
@@ -6,14 +6,16 @@ const invalidSchemaErrorMessage = `Invalid custom metadata schema. Please submit
 const customMetaDataGqlTagShapeOne = '{ "TAG_NAME": "TAG_VALUE" }';
 const customMetaDataGqlTagShapeTwo = '{ "TAG_NAME": ["VAL 1", "VAL 2" ] }';
 const customMetaDataJsonShape = '{ "TAG_NAME": { "Any": [ "Valid", "JSON" ] } }';
-const customMetaDataShape = `{ metaDataJson?: ${customMetaDataGqlTagShapeOne}, metaDataGql?: ${customMetaDataGqlTagShapeTwo} }`;
+const customMetaDataShape = `{ metaDataJson?: ${customMetaDataGqlTagShapeOne}, metaDataGql?: ${customMetaDataGqlTagShapeTwo}, dataGqlTags?: ${customMetaDataGqlTagShapeTwo} }`;
 
 export const invalidCustomMetaDataGqlTagErrorMessage = `${invalidSchemaErrorMessage}${customMetaDataGqlTagShapeOne} or ${customMetaDataGqlTagShapeTwo}`;
+export const invalidCustomDataGqlTagErrorMessage = `${invalidSchemaErrorMessage}${customMetaDataGqlTagShapeOne} or ${customMetaDataGqlTagShapeTwo}`;
 export const invalidCustomMetaDataJsonErrorMessage = `${invalidSchemaErrorMessage}${customMetaDataJsonShape}`;
 export const invalidCustomMetaDataErrorMessage = `${invalidSchemaErrorMessage}${customMetaDataShape}`;
 
 export type CustomMetaDataGqlTags = Record<string, string | string[]>;
 export type CustomMetaDataJsonFields = EntityMetaDataTransactionData;
+export type CustomMetaDataTagInterface = CustomMetaDataGqlTags;
 
 export interface CustomMetaData {
 	/** Include custom metadata on MetaData Tx Data JSON */
@@ -24,7 +26,7 @@ export interface CustomMetaData {
 
 	// TODO: Include dataTx GQL tags as an option (PE-1534)
 	/** Include custom metadata on File Data Tx GQL Tags */
-	// dataGqlTags?: CustomMetaDataTagInterface;
+	dataGqlTags?: CustomMetaDataTagInterface;
 }
 
 export function isCustomMetaDataJsonFields(customDataJson: unknown): customDataJson is CustomMetaDataJsonFields {
@@ -91,10 +93,14 @@ export function isCustomMetaData(tags: unknown): tags is CustomMetaData {
 	}
 
 	for (const [key, metaData] of Object.entries(tags)) {
+		// consider using a sqwitch..case
 		if (key === 'metaDataJson' && !isCustomMetaDataJsonFields(metaData)) {
 			return false;
 		}
 		if (key === 'metaDataGqlTags' && !isCustomMetaDataGqlTags(metaData)) {
+			return false;
+		}
+		if (key === 'dataGqlTags' && !isCustomMetaDataGqlTags(metaData)) {
 			return false;
 		}
 	}
@@ -117,6 +123,7 @@ export function assertCustomMetaDataJsonFields(tags: unknown): tags is CustomMet
 
 export function assertCustomMetaData(tags: unknown): tags is CustomMetaData {
 	if (!isCustomMetaData(tags)) {
+		// TODO: throw the error for data ones as well.
 		throw Error(invalidCustomMetaDataErrorMessage);
 	}
 	return true;

--- a/src/types/custom_metadata_types.ts
+++ b/src/types/custom_metadata_types.ts
@@ -24,7 +24,6 @@ export interface CustomMetaData {
 	/** Include custom metadata on MetaData Tx GQL Tags */
 	metaDataGqlTags?: CustomMetaDataGqlTags;
 
-	// TODO: Include dataTx GQL tags as an option (PE-1534)
 	/** Include custom metadata on File Data Tx GQL Tags */
 	dataGqlTags?: CustomMetaDataTagInterface;
 }

--- a/src/types/custom_metadata_types.ts
+++ b/src/types/custom_metadata_types.ts
@@ -92,15 +92,17 @@ export function isCustomMetaData(tags: unknown): tags is CustomMetaData {
 	}
 
 	for (const [key, metaData] of Object.entries(tags)) {
-		// consider using a sqwitch..case
-		if (key === 'metaDataJson' && !isCustomMetaDataJsonFields(metaData)) {
-			return false;
-		}
-		if (key === 'metaDataGqlTags' && !isCustomMetaDataGqlTags(metaData)) {
-			return false;
-		}
-		if (key === 'dataGqlTags' && !isCustomMetaDataGqlTags(metaData)) {
-			return false;
+		switch (key) {
+			case 'metaDataJson':
+				if (!isCustomMetaDataJsonFields(metaData)) {
+					return false;
+				}
+				break;
+			case 'metaDataGqlTags':
+			case 'dataGqlTags':
+				if (!isCustomMetaDataGqlTags(metaData)) {
+					return false;
+				}
 		}
 	}
 	return true;

--- a/src/types/custom_metadata_types.ts
+++ b/src/types/custom_metadata_types.ts
@@ -103,6 +103,9 @@ export function isCustomMetaData(tags: unknown): tags is CustomMetaData {
 				if (!isCustomMetaDataGqlTags(metaData)) {
 					return false;
 				}
+				break;
+			default:
+				break;
 		}
 	}
 	return true;

--- a/tests/helpers/arlocal_test_assertions.ts
+++ b/tests/helpers/arlocal_test_assertions.ts
@@ -374,7 +374,6 @@ export function assertFileDataTxGqlTags(
 			{ name: 'Tip-Type', value: 'data upload' }
 		]);
 	} else {
-		expect(cipherIv!.length).to.equal(16);
 		expect(dataTxTags).to.deep.equal([
 			...expectedCustomTags,
 			{ name: 'Content-Type', value: contentType ?? defaultPrivateDataContentType },

--- a/tests/helpers/arlocal_test_assertions.ts
+++ b/tests/helpers/arlocal_test_assertions.ts
@@ -30,6 +30,8 @@ import {
 } from '../../src/types';
 import { getDecodedTags } from '../test_helpers';
 
+const defaultDataContentType = 'text/plain';
+
 interface AssertEntityExpectationsParams<T = ArFSEntity> {
 	entity: T;
 	driveId: DriveID;
@@ -361,7 +363,7 @@ export function assertFileDataTxGqlTags(
 
 	expect(dataTxTags).to.deep.equal([
 		...expectedData,
-		{ name: 'Content-Type', value: contentType },
+		{ name: 'Content-Type', value: contentType ?? defaultDataContentType },
 		{ name: 'App-Name', value: 'ArLocal Integration Test' },
 		{ name: 'App-Version', value: 'FAKE_VERSION' },
 		{ name: 'Tip-Type', value: 'data upload' }

--- a/tests/helpers/arlocal_test_assertions.ts
+++ b/tests/helpers/arlocal_test_assertions.ts
@@ -359,10 +359,10 @@ export function assertFileDataTxGqlTags(
 	const { contentType, customMetaData } = expectations;
 	const dataTxTags = getDecodedTags(dataTx.tags);
 
-	const expectedData: GQLTagInterface[] = mapMetaDataTagInterfaceToGqlTagInterface(customMetaData);
+	const expectedCustomTags: GQLTagInterface[] = mapMetaDataTagInterfaceToGqlTagInterface(customMetaData);
 
 	expect(dataTxTags).to.deep.equal([
-		...expectedData,
+		...expectedCustomTags,
 		{ name: 'Content-Type', value: contentType ?? defaultDataContentType },
 		{ name: 'App-Name', value: 'ArLocal Integration Test' },
 		{ name: 'App-Version', value: 'FAKE_VERSION' },

--- a/tests/helpers/arlocal_test_assertions.ts
+++ b/tests/helpers/arlocal_test_assertions.ts
@@ -363,7 +363,7 @@ export function assertFileDataTxGqlTags(
 
 	const expectedCustomTags: GQLTagInterface[] = mapMetaDataTagInterfaceToGqlTagInterface(customMetaData);
 
-	const cipherIv = dataTxTags.find((tag) => tag.name === 'Cipher')?.value;
+	const cipherIv = dataTxTags.find((tag) => tag.name === 'Cipher-IV')?.value;
 	const isPublic = !cipherIv;
 	if (isPublic) {
 		expect(dataTxTags).to.deep.equal([

--- a/tests/helpers/arlocal_test_assertions.ts
+++ b/tests/helpers/arlocal_test_assertions.ts
@@ -350,13 +350,17 @@ export function assertFolderMetaDataGqlTags(
 export function assertFileDataTxGqlTags(
 	dataTx: Transaction,
 	expectations: {
-		contentType: DataContentType;
+		contentType?: DataContentType;
+		customMetaData?: CustomMetaDataGqlTags;
 	}
 ): void {
-	const { contentType } = expectations;
+	const { contentType, customMetaData } = expectations;
 	const dataTxTags = getDecodedTags(dataTx.tags);
 
+	const expectedData: GQLTagInterface[] = mapMetaDataTagInterfaceToGqlTagInterface(customMetaData);
+
 	expect(dataTxTags).to.deep.equal([
+		...expectedData,
 		{ name: 'Content-Type', value: contentType },
 		{ name: 'App-Name', value: 'ArLocal Integration Test' },
 		{ name: 'App-Version', value: 'FAKE_VERSION' },

--- a/tests/integration/arlocal.int.test.ts
+++ b/tests/integration/arlocal.int.test.ts
@@ -486,6 +486,37 @@ describe('ArLocal Integration Tests', function () {
 			});
 		});
 
+		it('upload a public file as a v2 transaction with custom data gql tags', async () => {
+			const fileName = 'custom_content_unique_stub';
+			const customMetaData: CustomMetaData = {
+				dataGqlTags: {
+					'My-Tag-1': 'My awesome value',
+					'My-Tag-2': ['hello', 'world!']
+				}
+			};
+
+			const { created } = await v2ArDrive.uploadAllEntities({
+				entitiesToUpload: [
+					{
+						destFolderId: rootFolderId,
+						wrappedEntity: wrapFileOrFolder(
+							'tests/stub_files/bulk_root_folder/file_in_root.txt',
+							undefined,
+							customMetaData
+						),
+						destName: fileName
+					}
+				]
+			});
+			await mineArLocalBlock(arweave);
+
+			// @ts-ignore
+			const { dataTxId }: Required<ArFSEntityData> = created[0];
+
+			const dataTx = new Transaction(await fakeGatewayApi.getTransaction(dataTxId));
+			assertFileDataTxGqlTags(dataTx, { customMetaData: customMetaData.dataGqlTags });
+		});
+
 		it('we can upload a file as a v2 transaction with custom metadata to the Data JSON containing all valid JSON shapes', async () => {
 			const fileName = 'json_shapes_unique_name';
 			const customMetaDataJson: CustomMetaDataJsonFields = {

--- a/tests/integration/arlocal.int.test.ts
+++ b/tests/integration/arlocal.int.test.ts
@@ -487,7 +487,6 @@ describe('ArLocal Integration Tests', function () {
 		});
 
 		it('we can upload a public file as a v2 transaction with custom data gql tags', async () => {
-			const fileName = 'custom_content_unique_stub';
 			const customMetaData: CustomMetaData = {
 				dataGqlTags: {
 					'My-Tag-1': 'My awesome value',
@@ -503,8 +502,7 @@ describe('ArLocal Integration Tests', function () {
 							'tests/stub_files/bulk_root_folder/file_in_root.txt',
 							undefined,
 							customMetaData
-						),
-						destName: fileName
+						)
 					}
 				]
 			});
@@ -1252,11 +1250,10 @@ describe('ArLocal Integration Tests', function () {
 		});
 
 		it('we can upload a private file as a v2 transaction with custom data gql tags', async () => {
-			const fileName = 'custom_content_unique_stub';
 			const customMetaData: CustomMetaData = {
 				dataGqlTags: {
-					'My-Tag-1': 'My awesome value',
-					'My-Tag-2': ['hello', 'world!']
+					'My-Tag-1': 'The best value ever for a tag',
+					'My-Tag-2': ['foo', 'var']
 				}
 			};
 
@@ -1265,11 +1262,10 @@ describe('ArLocal Integration Tests', function () {
 					{
 						destFolderId: rootFolderId,
 						wrappedEntity: wrapFileOrFolder(
-							'tests/stub_files/bulk_root_folder/file_in_root.txt',
+							'tests/stub_files/bulk_root_folder/parent_folder/file_in_parent.txt',
 							undefined,
 							customMetaData
 						),
-						destName: fileName,
 						driveKey
 					}
 				]

--- a/tests/integration/arlocal.int.test.ts
+++ b/tests/integration/arlocal.int.test.ts
@@ -486,7 +486,7 @@ describe('ArLocal Integration Tests', function () {
 			});
 		});
 
-		it('upload a public file as a v2 transaction with custom data gql tags', async () => {
+		it('we can upload a public file as a v2 transaction with custom data gql tags', async () => {
 			const fileName = 'custom_content_unique_stub';
 			const customMetaData: CustomMetaData = {
 				dataGqlTags: {
@@ -1249,6 +1249,38 @@ describe('ArLocal Integration Tests', function () {
 				/** We will expect these tags to be parsed back twice, once from dataJSON and once from GQL tags */
 				customMetaData
 			});
+		});
+
+		it('we can upload a private file as a v2 transaction with custom data gql tags', async () => {
+			const fileName = 'custom_content_unique_stub';
+			const customMetaData: CustomMetaData = {
+				dataGqlTags: {
+					'My-Tag-1': 'My awesome value',
+					'My-Tag-2': ['hello', 'world!']
+				}
+			};
+
+			const { created } = await v2ArDrive.uploadAllEntities({
+				entitiesToUpload: [
+					{
+						destFolderId: rootFolderId,
+						wrappedEntity: wrapFileOrFolder(
+							'tests/stub_files/bulk_root_folder/file_in_root.txt',
+							undefined,
+							customMetaData
+						),
+						destName: fileName,
+						driveKey
+					}
+				]
+			});
+			await mineArLocalBlock(arweave);
+
+			// @ts-ignore
+			const { dataTxId }: Required<ArFSEntityData> = created[0];
+
+			const dataTx = new Transaction(await fakeGatewayApi.getTransaction(dataTxId));
+			assertFileDataTxGqlTags(dataTx, { customMetaData: customMetaData.dataGqlTags });
 		});
 
 		it('we can upload a private folder as a v2 transaction with custom metadata', async () => {


### PR DESCRIPTION
Changes:

- Follows up the work of Custom Metadata by implementing the WRITE-only side at CORE

Note: Read-only and CLI side will be implemented in another Story