### PR TITLE
fix(contract reader): switch to a PDS managed default contract cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ardrive-core-js",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "ArDrive Core contains the essential back end application features to support the ArDrive CLI and Desktop apps, such as file management, Permaweb upload/download, wallet management and other common functions.",
 	"main": "./lib/exports.js",
 	"types": "./lib/exports.d.ts",

--- a/src/community/ardrive_community_oracle.ts
+++ b/src/community/ardrive_community_oracle.ts
@@ -4,7 +4,7 @@ import { CommunityOracle } from './community_oracle';
 import { ArDriveContractOracle } from './ardrive_contract_oracle';
 import Arweave from 'arweave';
 import { SmartweaveContractReader } from './smartweave_contract_oracle';
-import { ArNSMicroserviceContractReader } from './arns_microservice_contract_oracle';
+import { PDSContractCacheServiceContractReader } from './pds_contract_oracle';
 import { ADDR, ArweaveAddress, W, Winston } from '../types';
 
 /**
@@ -29,7 +29,7 @@ export class ArDriveCommunityOracle implements CommunityOracle {
 	private readonly contractOracle: ContractOracle;
 
 	private defaultContractReaders: ContractReader[] = [
-		new ArNSMicroserviceContractReader(),
+		new PDSContractCacheServiceContractReader(),
 		new SmartweaveContractReader(this.arweave)
 	];
 

--- a/src/community/ardrive_community_oracle.ts
+++ b/src/community/ardrive_community_oracle.ts
@@ -4,7 +4,7 @@ import { CommunityOracle } from './community_oracle';
 import { ArDriveContractOracle } from './ardrive_contract_oracle';
 import Arweave from 'arweave';
 import { SmartweaveContractReader } from './smartweave_contract_oracle';
-import { VertoContractReader } from './verto_contract_oracle';
+import { ArNSMicroserviceContractReader } from './arns_microservice_contract_oracle';
 import { ADDR, ArweaveAddress, W, Winston } from '../types';
 
 /**
@@ -29,7 +29,7 @@ export class ArDriveCommunityOracle implements CommunityOracle {
 	private readonly contractOracle: ContractOracle;
 
 	private defaultContractReaders: ContractReader[] = [
-		new VertoContractReader(),
+		new ArNSMicroserviceContractReader(),
 		new SmartweaveContractReader(this.arweave)
 	];
 

--- a/src/community/arns_microservice_contract_oracle.ts
+++ b/src/community/arns_microservice_contract_oracle.ts
@@ -4,12 +4,12 @@ import { ContractReader } from './contract_oracle';
 
 /**
  *  Oracle class responsible for retrieving and
- *  reading Smartweave Contracts from the Verto cache
+ *  reading Smartweave Contracts from the ArNS Microservice
  */
-export class VertoContractReader implements ContractReader {
+export class ArNSMicroserviceContractReader implements ContractReader {
 	/** Fetches smartweave contracts from the Verto cache */
 	public async readContract(txId: TransactionID): Promise<unknown> {
-		const response: AxiosResponse = await axios.get(`https://v2.cache.verto.exchange/${txId}`);
+		const response: AxiosResponse = await axios.get(`https://api.arns.app/v1/contract/${txId}`);
 		const contract = response.data;
 		return contract.state;
 	}

--- a/src/community/pds_contract_oracle.ts
+++ b/src/community/pds_contract_oracle.ts
@@ -6,7 +6,7 @@ import { ContractReader } from './contract_oracle';
  *  Oracle class responsible for retrieving and
  *  reading Smartweave Contracts from the ArNS Microservice
  */
-export class ArNSMicroserviceContractReader implements ContractReader {
+export class PDSContractCacheServiceContractReader implements ContractReader {
 	/** Fetches smartweave contracts from the Verto cache */
 	public async readContract(txId: TransactionID): Promise<unknown> {
 		const response: AxiosResponse = await axios.get(`https://api.arns.app/v1/contract/${txId}`);

--- a/src/community/pds_contract_oracle.ts
+++ b/src/community/pds_contract_oracle.ts
@@ -4,7 +4,7 @@ import { ContractReader } from './contract_oracle';
 
 /**
  *  Oracle class responsible for retrieving and
- *  reading Smartweave Contracts from the ArNS Microservice
+ *  reading Smartweave Contracts from the PDS Contract Cache Microservice
  */
 export class PDSContractCacheServiceContractReader implements ContractReader {
 	/** Fetches smartweave contracts from the Verto cache */

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -35,7 +35,7 @@ export * from './community/community_oracle';
 export * from './community/contract_oracle';
 export * from './community/contract_types';
 export * from './community/smartweave_contract_oracle';
-export * from './community/arns_microservice_contract_oracle';
+export * from './community/pds_contract_oracle';
 
 // Pricing
 export * from './pricing/ar_data_price';

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -35,7 +35,7 @@ export * from './community/community_oracle';
 export * from './community/contract_oracle';
 export * from './community/contract_types';
 export * from './community/smartweave_contract_oracle';
-export * from './community/verto_contract_oracle';
+export * from './community/arns_microservice_contract_oracle';
 
 // Pricing
 export * from './pricing/ar_data_price';

--- a/tests/integration/arlocal.int.test.ts
+++ b/tests/integration/arlocal.int.test.ts
@@ -70,7 +70,7 @@ import {
 	assertFolderMetaDataJson,
 	assertFolderMetaDataGqlTags
 } from '../helpers/arlocal_test_assertions';
-import { CustomMetaData, CustomMetaDataJsonFields, ArNSMicroserviceContractReader } from '../../src/exports';
+import { CustomMetaData, CustomMetaDataJsonFields, PDSContractCacheServiceContractReader } from '../../src/exports';
 
 describe('ArLocal Integration Tests', function () {
 	const wallet = readJWKFile('./test_wallet.json');
@@ -84,7 +84,7 @@ describe('ArLocal Integration Tests', function () {
 	const fakeVersion = 'FAKE_VERSION';
 
 	const arweaveOracle = new GatewayOracle(gatewayUrlForArweave(arweave));
-	const fakeContractReader = new ArNSMicroserviceContractReader();
+	const fakeContractReader = new PDSContractCacheServiceContractReader();
 	stub(fakeContractReader, 'readContract').resolves(stubCommunityContract);
 
 	const communityOracle = new ArDriveCommunityOracle(arweave, [fakeContractReader]);

--- a/tests/integration/arlocal.int.test.ts
+++ b/tests/integration/arlocal.int.test.ts
@@ -70,7 +70,7 @@ import {
 	assertFolderMetaDataJson,
 	assertFolderMetaDataGqlTags
 } from '../helpers/arlocal_test_assertions';
-import { CustomMetaData, CustomMetaDataJsonFields, VertoContractReader } from '../../src/exports';
+import { CustomMetaData, CustomMetaDataJsonFields, ArNSMicroserviceContractReader } from '../../src/exports';
 
 describe('ArLocal Integration Tests', function () {
 	const wallet = readJWKFile('./test_wallet.json');
@@ -84,7 +84,7 @@ describe('ArLocal Integration Tests', function () {
 	const fakeVersion = 'FAKE_VERSION';
 
 	const arweaveOracle = new GatewayOracle(gatewayUrlForArweave(arweave));
-	const fakeContractReader = new VertoContractReader();
+	const fakeContractReader = new ArNSMicroserviceContractReader();
 	stub(fakeContractReader, 'readContract').resolves(stubCommunityContract);
 
 	const communityOracle = new ArDriveCommunityOracle(arweave, [fakeContractReader]);


### PR DESCRIPTION
this PR fixes an issue we're seeing with the default contract reader when fetching the ardrive contract when determining the community tip during uploads

as we were forewarned, it seems the Verto contract cache is no longer publicly available. fortunately PDS is now hosting our own contract cache, the ArNS Microservice -- here we switch to using that cache