### PR TITLE
fix(list-folders)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ardrive-core-js",
-	"version": "2.0.5",
+	"version": "2.0.6",
 	"description": "ArDrive Core contains the essential back end application features to support the ArDrive CLI and Desktop apps, such as file management, Permaweb upload/download, wallet management and other common functions.",
 	"main": "./lib/exports.js",
 	"types": "./lib/exports.d.ts",

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -1539,8 +1539,12 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 					return this.caches.privateFolderCache.put(cacheKey, Promise.resolve(folder));
 				} catch (e) {
 					// If the folder is broken, skip it
-					console.error(`Error building folder: ${e}`);
-					return null;
+					if (e instanceof SyntaxError) {
+						console.error(`Error building folder. Skipping... Error: ${e}`);
+						return null;
+					}
+
+					throw e;
 				}
 			});
 

--- a/src/arfs/arfsdao_anonymous.ts
+++ b/src/arfs/arfsdao_anonymous.ts
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 /* eslint-disable no-console */
 import Arweave from 'arweave';
 import {
@@ -321,10 +320,10 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 				}
 			});
 
-        	const folders = await Promise.all(folderPromises);
+			const folders = await Promise.all(folderPromises);
 
 			// Filter out null values
-			const validFolders = folders.filter(folder => folder !== null) as ArFSPublicFolder[];
+			const validFolders = folders.filter((folder) => folder !== null) as ArFSPublicFolder[];
 
 			allFolders.push(...validFolders);
 		}

--- a/src/arfs/arfsdao_anonymous.ts
+++ b/src/arfs/arfsdao_anonymous.ts
@@ -315,8 +315,12 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 					return folder;
 				} catch (e) {
 					// If the folder is broken, skip it
-					console.error(`Error building folder: ${e}`);
-					return null;
+					if (e instanceof SyntaxError) {
+						console.error(`Error building folder. Skipping... Error: ${e}`);
+						return null;
+					}
+
+					throw e;
 				}
 			});
 

--- a/src/arfs/arfsdao_anonymous.ts
+++ b/src/arfs/arfsdao_anonymous.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 /* eslint-disable no-console */
 import Arweave from 'arweave';
 import {
@@ -304,15 +305,28 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 			const { edges } = transactions;
 
 			hasNextPage = transactions.pageInfo.hasNextPage;
-			const folders: Promise<ArFSPublicFolder>[] = edges.map(async (edge: GQLEdgeInterface) => {
+			const folderPromises = edges.map(async (edge: GQLEdgeInterface) => {
 				const { node } = edge;
 				cursor = edge.cursor;
-				const folderBuilder = ArFSPublicFolderBuilder.fromArweaveNode(node, this.gatewayApi);
-				const folder = await folderBuilder.build(node);
-				const cacheKey = { folderId: folder.entityId, owner };
-				return this.caches.publicFolderCache.put(cacheKey, Promise.resolve(folder));
+				try {
+					const folderBuilder = ArFSPublicFolderBuilder.fromArweaveNode(node, this.gatewayApi);
+					const folder = await folderBuilder.build(node);
+					const cacheKey = { folderId: folder.entityId, owner };
+					await this.caches.publicFolderCache.put(cacheKey, Promise.resolve(folder));
+					return folder;
+				} catch (e) {
+					// If the folder is broken, skip it
+					console.error(`Error building folder: ${e}`);
+					return null;
+				}
 			});
-			allFolders.push(...(await Promise.all(folders)));
+
+        	const folders = await Promise.all(folderPromises);
+
+			// Filter out null values
+			const validFolders = folders.filter(folder => folder !== null) as ArFSPublicFolder[];
+
+			allFolders.push(...validFolders);
 		}
 		return latestRevisionsOnly ? allFolders.filter(latestRevisionFilter) : allFolders;
 	}
@@ -338,6 +352,7 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 
 		// Fetch all of the folder entities within the drive
 		const driveIdOfFolder = folder.driveId;
+
 		const allFolderEntitiesOfDrive = await this.getAllFoldersOfPublicDrive({
 			driveId: driveIdOfFolder,
 			owner,
@@ -375,6 +390,7 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 		}
 
 		const entitiesWithPath = children.map((entity) => publicEntityWithPathsFactory(entity, hierarchy));
+
 		return entitiesWithPath;
 	}
 


### PR DESCRIPTION

### Description
This PR introduces a mechanism to skip entities that are broken due to an incorrect privacy state. When an entity is determined to be broken, a log entry will be created in the terminal to notify the user of the issue.

1. Added logging functionality to output broken entity information to the 
2. Example log entry:

![image](https://github.com/user-attachments/assets/ce78d009-ac02-4fe8-83d1-3d44acfdd2eb)
