### PR TITLE
PE-7146: skip files missing data content type while listing folders and drives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ardrive-core-js",
-	"version": "2.0.6",
+	"version": "2.0.7",
 	"description": "ArDrive Core contains the essential back end application features to support the ArDrive CLI and Desktop apps, such as file management, Permaweb upload/download, wallet management and other common functions.",
 	"main": "./lib/exports.js",
 	"types": "./lib/exports.d.ts",

--- a/src/arfs/arfs_builders/arfs_file_builders.test.ts
+++ b/src/arfs/arfs_builders/arfs_file_builders.test.ts
@@ -1,11 +1,14 @@
 import { expect } from 'chai';
 import { stub } from 'sinon';
-import { fakeArweave, stubTxID } from '../../../tests/stubs';
+import { fakeArweave, stubTxID, stubTxIDAlt } from '../../../tests/stubs';
 import { expectAsyncErrorThrow } from '../../../tests/test_helpers';
-import { EntityKey, GQLNodeInterface } from '../../types';
+import { EID, EntityKey, GQLNodeInterface } from '../../types';
 import { gatewayUrlForArweave } from '../../utils/common';
 import { GatewayAPI } from '../../utils/gateway_api';
 import { ArFSPrivateFileBuilder, ArFSPublicFileBuilder } from './arfs_file_builders';
+import { ArFSDAOAnonymous } from '../arfsdao_anonymous';
+import { ADDR, DriveID, FolderID } from '../../types';
+import { stub, SinonStub } from 'sinon';
 
 const gatewayApi = new GatewayAPI({
 	gatewayUrl: gatewayUrlForArweave(fakeArweave),

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -1584,7 +1584,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 			const transactions = await this.gatewayApi.gqlRequest(gqlQuery);
 			const { edges } = transactions;
 			hasNextPage = transactions.pageInfo.hasNextPage;
-			const files: Promise<ArFSPrivateFile | null	>[] = edges.map(async (edge: GQLEdgeInterface) => {
+			const files: Promise<ArFSPrivateFile | null>[] = edges.map(async (edge: GQLEdgeInterface) => {
 				try {
 					const { node } = edge;
 					cursor = edge.cursor;

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -179,6 +179,7 @@ import { assertDataRootsMatch, rePrepareV2Tx } from '../utils/arfsdao_utils';
 import { ArFSDataToUpload, ArFSFolderToUpload, DrivePrivacy, errorMessage } from '../exports';
 import { Turbo, TurboCachesResponse } from './turbo';
 import { ArweaveSigner } from 'arbundles/src/signing';
+import { InvalidFileStateException } from '../types/exceptions';
 
 /** Utility class for holding the driveId and driveKey of a new drive */
 export class PrivateDriveKeyData {
@@ -1583,21 +1584,31 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 			const transactions = await this.gatewayApi.gqlRequest(gqlQuery);
 			const { edges } = transactions;
 			hasNextPage = transactions.pageInfo.hasNextPage;
-			const files: Promise<ArFSPrivateFile>[] = edges.map(async (edge: GQLEdgeInterface) => {
-				const { node } = edge;
-				cursor = edge.cursor;
-				const fileBuilder = ArFSPrivateFileBuilder.fromArweaveNode(node, this.gatewayApi, driveKey);
-				// Build the file so that we don't add something invalid to the cache
-				const file = await fileBuilder.build(node);
-				const fileKey: FileKey = await deriveFileKey(`${file.fileId}`, driveKey);
-				const cacheKey = {
-					fileId: file.fileId,
-					owner,
-					fileKey
-				};
-				return this.caches.privateFileCache.put(cacheKey, Promise.resolve(file));
+			const files: Promise<ArFSPrivateFile | null	>[] = edges.map(async (edge: GQLEdgeInterface) => {
+				try {
+					const { node } = edge;
+					cursor = edge.cursor;
+					const fileBuilder = ArFSPrivateFileBuilder.fromArweaveNode(node, this.gatewayApi, driveKey);
+					// Build the file so that we don't add something invalid to the cache
+					const file = await fileBuilder.build(node);
+					const fileKey: FileKey = await deriveFileKey(`${file.fileId}`, driveKey);
+					const cacheKey = {
+						fileId: file.fileId,
+						owner,
+						fileKey
+					};
+					return this.caches.privateFileCache.put(cacheKey, Promise.resolve(file));
+				} catch (e) {
+					if (e instanceof InvalidFileStateException) {
+						console.error(`Error building file. Skipping... Error: ${e}`);
+						return null;
+					}
+
+					throw e;
+				}
 			});
-			allFiles.push(...(await Promise.all(files)));
+			const validFiles = (await Promise.all(files)).filter((f) => f !== null) as ArFSPrivateFile[];
+			allFiles.push(...validFiles);
 		}
 		return latestRevisionsOnly ? allFiles.filter(latestRevisionFilter) : allFiles;
 	}

--- a/src/arfs/arfsdao_anonymous.test.ts
+++ b/src/arfs/arfsdao_anonymous.test.ts
@@ -1,15 +1,19 @@
+/* eslint-disable prettier/prettier */
 import Arweave from 'arweave';
 import { expect } from 'chai';
-import { stub } from 'sinon';
+import { stub, SinonStub } from 'sinon';
 import {
 	stubArweaveAddress,
 	stubEntityID,
 	stubEntityIDAlt,
 	stubPublicDrive,
 	stubPublicFile,
-	stubPublicFolder
+	stubPublicFolder,
+	stubTxID,
+	stubTxIDAlt,
+	stubTxIDAltTwo
 } from '../../tests/stubs';
-import { ArweaveAddress, DriveID, EntityID } from '../types';
+import { ADDR, ArweaveAddress, DriveID, EID, EntityID } from '../types';
 import {
 	ArFSAnonymousCache,
 	ArFSDAOAnonymous,
@@ -19,6 +23,7 @@ import {
 } from './arfsdao_anonymous';
 import { ArFSPublicDrive, ArFSPublicFile, ArFSPublicFolder } from './arfs_entities';
 import { ArFSEntityCache } from './arfs_entity_cache';
+import { ArFSPublicFileBuilder } from './arfs_builders/arfs_file_builders';
 
 const fakeArweave = Arweave.init({
 	host: 'localhost',
@@ -224,6 +229,282 @@ describe('ArFSDAOAnonymous class', () => {
 			// 	stub(publicFileCache, 'put').returns(promise);
 			// 	expect(await arfsDaoAnonymous.getPublicFile(stubEntityID, stubArweaveAddress())).to.equal(cachedFile);
 			// });
+		});
+	});
+
+	describe('getPublicFilesWithParentFolderIds', () => {
+		let dao: ArFSDAOAnonymous;
+		let gqlRequestStub: SinonStub;
+		let ArFSPublicFileBuilderStub: SinonStub;
+
+		beforeEach(() => {
+			dao = new ArFSDAOAnonymous(fakeArweave);
+			gqlRequestStub = stub(dao['gatewayApi'], 'gqlRequest');
+			ArFSPublicFileBuilderStub = stub(ArFSPublicFileBuilder.prototype, 'getDataForTxID');
+		});
+
+		afterEach(() => {
+			gqlRequestStub.restore();
+			ArFSPublicFileBuilderStub.restore();
+		});
+
+		it('returns expected files for given folder IDs', async () => {
+			// Mock GQL response
+			const mockGQLResponse = {
+				edges: [
+					{
+					cursor: 'cursor1',
+					node: {
+						id: `${stubTxID}`,
+						tags: [
+							{ name: 'App-Name', value: 'ArDrive-CLI' },
+							{ name: 'App-Version', value: '1.2.0' },
+							{ name: 'ArFS', value: '0.11' },
+							{ name: 'Content-Type', value: 'application/json' },
+							{ name: 'Drive-Id', value: 'e93cf9c4-5f20-4d7a-87c4-034777cbb51e' },
+							{ name: 'Entity-Type', value: 'file' },
+							{ name: 'Unix-Time', value: '1639073846' },
+							{ name: 'Parent-Folder-Id', value: '6c312b3e-4778-4a18-8243-f2b346f5e7cb' },
+							{ name: 'File-Id', value: '9f7038c7-26bd-4856-a843-8de24b828d4e' }
+						],
+						owner: { address: 'vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI' }
+						}
+					}
+				],
+				pageInfo: {
+					hasNextPage: false
+				}
+			};
+
+			gqlRequestStub.resolves(mockGQLResponse);
+
+			// Add stub for getDataForTxID
+			const stubFileGetDataResult = Buffer.from(
+				JSON.stringify({
+					name: '2',
+					size: 2048,
+					lastModifiedDate: 1639073634269,
+					dataTxId: 'yAogaGWWYgWO5xWZevb45Y7YRp7E9iDsvkJvfR7To9c',
+					dataContentType: 'unknown'
+				})
+			);
+
+			// Stub the getDataForTxID method on the builder
+			ArFSPublicFileBuilderStub.resolves(stubFileGetDataResult);
+
+			const folderIds = [EID('6c312b3e-4778-4a18-8243-f2b346f5e7cb')];
+			const owner = ADDR('vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI');
+			const driveId = EID('e93cf9c4-5f20-4d7a-87c4-034777cbb51e');
+
+			const files = await dao.getPublicFilesWithParentFolderIds(folderIds, owner, driveId, true);
+
+			expect(files).to.have.lengthOf(1);
+			expect(`${files[0].fileId}`).to.equal('9f7038c7-26bd-4856-a843-8de24b828d4e');
+			expect(`${files[0].driveId}`).to.equal('e93cf9c4-5f20-4d7a-87c4-034777cbb51e');
+			expect(`${files[0].parentFolderId}`).to.equal('6c312b3e-4778-4a18-8243-f2b346f5e7cb');
+		});
+
+		it('handles pagination correctly', async () => {
+			const fileId1 = '9f7038c7-26bd-4856-a843-8de24b828d4e';
+			const fileId2 = '1f7038c7-26bd-4856-a843-8de24b828d4e';
+
+			// Mock two pages of GQL responses
+			const mockGQLResponse1 = {
+				edges: [
+					{
+						cursor: 'cursor1',
+						node: {
+							id: `${stubTxID}`,
+							tags: [
+								{ name: 'App-Name', value: 'ArDrive-CLI' },
+								{ name: 'App-Version', value: '1.2.0' },
+								{ name: 'ArFS', value: '0.11' },
+								{ name: 'Content-Type', value: 'application/json' },
+								{ name: 'Drive-Id', value: 'e93cf9c4-5f20-4d7a-87c4-034777cbb51e' },
+								{ name: 'Entity-Type', value: 'file' },
+								{ name: 'Unix-Time', value: '1639073846' },
+								{ name: 'Parent-Folder-Id', value: '6c312b3e-4778-4a18-8243-f2b346f5e7cb' },
+								{ name: 'File-Id', value: fileId1 }
+							],
+							owner: { address: 'vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI' }
+						}
+					}
+				],
+				pageInfo: {
+					hasNextPage: true
+				}
+			};
+
+			const mockGQLResponse2 = {
+				edges: [
+					{
+						cursor: 'cursor2',
+						node: {
+							id: `${stubTxIDAlt}`,
+							tags: [
+								{ name: 'App-Name', value: 'ArDrive-CLI' },
+								{ name: 'App-Version', value: '1.2.0' },
+								{ name: 'ArFS', value: '0.11' },
+								{ name: 'Content-Type', value: 'application/json' },
+								{ name: 'Drive-Id', value: 'e93cf9c4-5f20-4d7a-87c4-034777cbb51e' },
+								{ name: 'Entity-Type', value: 'file' },
+								{ name: 'Unix-Time', value: '1639073846' },
+								{ name: 'Parent-Folder-Id', value: '6c312b3e-4778-4a18-8243-f2b346f5e7cb' },
+								{ name: 'File-Id', value: fileId2 }
+							],
+							owner: { address: 'vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI' }
+						}
+					}
+				],
+				pageInfo: {
+					hasNextPage: false
+				}
+			};
+
+			gqlRequestStub.onFirstCall().resolves(mockGQLResponse1);
+			gqlRequestStub.onSecondCall().resolves(mockGQLResponse2);
+
+			const folderIds = [EID('6c312b3e-4778-4a18-8243-f2b346f5e7cb')];
+			const owner = ADDR('vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI');
+			const driveId = EID('e93cf9c4-5f20-4d7a-87c4-034777cbb51e');
+
+			// Add stub for getDataForTxID
+			const stubFileGetDataResult = Buffer.from(
+				JSON.stringify({
+					name: '2',
+					size: 2048,
+					lastModifiedDate: 1639073634269,
+					dataTxId: 'yAogaGWWYgWO5xWZevb45Y7YRp7E9iDsvkJvfR7To9c',
+					dataContentType: 'unknown'
+				})
+			);
+
+			ArFSPublicFileBuilderStub.withArgs(stubTxID).resolves(stubFileGetDataResult);
+			ArFSPublicFileBuilderStub.withArgs(stubTxIDAlt).resolves(stubFileGetDataResult);
+
+			const files = await dao.getPublicFilesWithParentFolderIds(folderIds, owner, driveId, true);
+
+			expect(files).to.have.lengthOf(2);
+			expect(`${files[0].fileId}`).to.equal(fileId1);
+			expect(`${files[1].fileId}`).to.equal(fileId2);
+			expect(gqlRequestStub.callCount).to.equal(2);
+		});
+
+		it('skips invalid files and continues processing', async () => {
+			const fileId1 = '9f7038c7-26bd-4856-a843-8de24b828d4e';
+			const fileId2 = '1f7038c7-26bd-4856-a843-8de24b828d4e';
+			const fileId3 = '2f7038c7-26bd-4856-a843-8de24b828d4e';
+
+			const mockGQLResponse = {
+				edges: [
+					{
+						cursor: 'cursor1',
+						node: {
+							id: `${stubTxID}`,
+							tags: [
+								{ name: 'App-Name', value: 'ArDrive-CLI' },
+								{ name: 'App-Version', value: '1.2.0' },
+								{ name: 'ArFS', value: '0.11' },
+								{ name: 'Content-Type', value: 'application/json' },
+								{ name: 'Drive-Id', value: 'e93cf9c4-5f20-4d7a-87c4-034777cbb51e' },
+								{ name: 'Entity-Type', value: 'file' },
+								{ name: 'Unix-Time', value: '1639073846' },
+								{ name: 'Parent-Folder-Id', value: '6c312b3e-4778-4a18-8243-f2b346f5e7cb' },
+								{ name: 'File-Id', value: fileId1 }
+							],
+							owner: { address: 'vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI' }
+						}
+					},
+					{
+						cursor: 'cursor2',
+						node: {
+							id: `${stubTxIDAlt}`,
+							tags: [
+								{ name: 'App-Name', value: 'ArDrive-CLI' },
+								{ name: 'App-Version', value: '1.2.0' },
+								{ name: 'ArFS', value: '0.11' },
+								{ name: 'Content-Type', value: 'application/json' },
+								{ name: 'Drive-Id', value: 'e93cf9c4-5f20-4d7a-87c4-034777cbb51e' },
+								{ name: 'Entity-Type', value: 'file' },
+								{ name: 'Unix-Time', value: '1639073846' },
+								{ name: 'Parent-Folder-Id', value: '1c312b3e-4778-4a18-8243-f2b346f5e7cb' },
+								{ name: 'File-Id', value: fileId2 }
+						],
+						owner: { address: 'vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI' }
+						}
+					},
+					{
+						cursor: 'cursor3',
+						node: {
+							id: `${stubTxIDAltTwo}`,
+							tags: [
+								{ name: 'App-Name', value: 'ArDrive-CLI' },
+								{ name: 'App-Version', value: '1.2.0' },
+								{ name: 'ArFS', value: '0.11' },
+								{ name: 'Content-Type', value: 'application/json' },
+								{ name: 'Drive-Id', value: 'e93cf9c4-5f20-4d7a-87c4-034777cbb51e' },
+								{ name: 'Entity-Type', value: 'file' },
+								{ name: 'Unix-Time', value: '1639073846' },
+								{ name: 'Parent-Folder-Id', value: '1c312b3e-4778-4a18-8243-f2b346f5e7cb' },
+								{ name: 'File-Id', value: fileId3 }
+						],
+						owner: { address: 'vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI' }
+						}
+					}
+				],
+				pageInfo: {
+					hasNextPage: false
+				}
+			};
+			gqlRequestStub.resolves(mockGQLResponse);
+			// Mock the getDataForTxID method to return valid metadata for the second file
+			const stubFileGetDataResultValid1 = Buffer.from(
+				JSON.stringify({
+					name: '2',
+					size: 2048,
+					lastModifiedDate: 1639073634269,
+					dataTxId: 'yAogaGWWYgWO5xWZevb45Y7YRp7E9iDsvkJvfR7To9c',
+					dataContentType: 'application/json'
+				})
+			);
+			// Invalid file metadata missing dataContentType
+			const stubFileGetDataResultWithEmptyContentType = Buffer.from(
+				JSON.stringify({
+					name: '2',
+					size: 2048,
+					lastModifiedDate: 1639073634269,
+					dataTxId: 'yAogaGWWYgWO5xWZevb45Y7YRp7E9iDsvkJvfR7To9c',
+					dataContentType: ''
+				})
+			);
+			// Valid file metadata
+			const stubFileGetDataResultValid2 = Buffer.from(
+				JSON.stringify({
+					name: '2',
+					size: 2048,
+					lastModifiedDate: 1639073634269,
+					dataTxId: 'yAogaGWWYgWO5xWZevb45Y7YRp7E9iDsvkJvfR7To9c',
+					dataContentType: 'text/plain'
+				})
+			);
+
+			// Valid file metadata
+			ArFSPublicFileBuilderStub.withArgs(stubTxID).resolves(stubFileGetDataResultValid1);
+			// Invalid file metadata missing dataContentType
+			ArFSPublicFileBuilderStub.withArgs(stubTxIDAlt).resolves(stubFileGetDataResultWithEmptyContentType);
+			// Valid file metadata
+			ArFSPublicFileBuilderStub.withArgs(stubTxIDAltTwo).resolves(stubFileGetDataResultValid2);
+
+			const folderIds = [EID('6c312b3e-4778-4a18-8243-f2b346f5e7cb')];
+			const owner = ADDR('vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI');
+			const driveId = EID('e93cf9c4-5f20-4d7a-87c4-034777cbb51e');
+
+			const files = await dao.getPublicFilesWithParentFolderIds(folderIds, owner, driveId, true);
+
+			// Verify that the invalid file was skipped
+			expect(files).to.have.lengthOf(2);
+			expect(`${files[0].fileId}`).to.equal(fileId1);
+			expect(`${files[1].fileId}`).to.equal(fileId3);
 		});
 	});
 });

--- a/src/arfs/arfsdao_anonymous.ts
+++ b/src/arfs/arfsdao_anonymous.ts
@@ -275,7 +275,6 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 					const fileBuilder = ArFSPublicFileBuilder.fromArweaveNode(node, this.gatewayApi);
 					const file = await fileBuilder.build(node);
 					const cacheKey = { fileId: file.fileId, owner };
-					allFiles.push(file);
 					return this.caches.publicFileCache.put(cacheKey, Promise.resolve(file));
 				} catch (e) {
 					// If the file is broken, skip it

--- a/src/arfs/arfsdao_anonymous.ts
+++ b/src/arfs/arfsdao_anonymous.ts
@@ -27,6 +27,7 @@ import { alphabeticalOrder } from '../utils/sort_functions';
 import { ArFSPublicFileWithPaths, ArFSPublicFolderWithPaths, publicEntityWithPathsFactory } from '../exports';
 import { gatewayUrlForArweave } from '../utils/common';
 import { GatewayAPI } from '../utils/gateway_api';
+import { InvalidFileStateException } from '../types/exceptions';
 
 export abstract class ArFSDAOType {
 	protected abstract readonly arweave: Arweave;
@@ -267,16 +268,34 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 			const transactions = await this.gatewayApi.gqlRequest(gqlQuery);
 			const { edges } = transactions;
 			hasNextPage = transactions.pageInfo.hasNextPage;
-			const files: Promise<ArFSPublicFile>[] = edges.map(async (edge: GQLEdgeInterface) => {
-				const { node } = edge;
-				cursor = edge.cursor;
-				const fileBuilder = ArFSPublicFileBuilder.fromArweaveNode(node, this.gatewayApi);
-				const file = await fileBuilder.build(node);
-				const cacheKey = { fileId: file.fileId, owner };
-				allFiles.push(file);
-				return this.caches.publicFileCache.put(cacheKey, Promise.resolve(file));
+			const files: Promise<ArFSPublicFile | null>[] = edges.map(async (edge: GQLEdgeInterface) => {
+				try {
+					const { node } = edge;
+					cursor = edge.cursor;
+					const fileBuilder = ArFSPublicFileBuilder.fromArweaveNode(node, this.gatewayApi);
+					const file = await fileBuilder.build(node);
+					const cacheKey = { fileId: file.fileId, owner };
+					allFiles.push(file);
+					return this.caches.publicFileCache.put(cacheKey, Promise.resolve(file));
+				} catch (e) {
+					// If the file is broken, skip it
+					if (e instanceof SyntaxError) {
+						console.error(`Error building file. Skipping... Error: ${e}`);
+						return null;
+					}
+
+					if (e instanceof InvalidFileStateException) {
+						console.error(`Error building file. Skipping... Error: ${e}`);
+						return null;
+					}
+
+					throw e;
+				}
 			});
-			await Promise.all(files);
+
+			const validFiles = (await Promise.all(files)).filter((f) => f !== null) as ArFSPublicFile[];
+
+			allFiles.push(...validFiles);
 		}
 		return latestRevisionsOnly ? allFiles.filter(latestRevisionFilter) : allFiles;
 	}

--- a/src/types/exceptions.ts
+++ b/src/types/exceptions.ts
@@ -1,0 +1,36 @@
+import { ArFSPrivateFileBuilder, ArFSPublicFileBuilder } from '../exports';
+
+// InvalidFileStateException
+export class InvalidFileStateException extends Error {
+	readonly missingProperties: string[];
+
+	constructor(missingProperties: string[]) {
+		const message = `Invalid file state. Missing required properties: ${missingProperties.join(', ')}`;
+		super(message);
+		this.missingProperties = missingProperties;
+		this.name = 'InvalidFileStateException';
+	}
+}
+
+export class FileBuilderValidation {
+	private missingProperties: string[] = [];
+
+	validateFileProperties(builder: ArFSPublicFileBuilder | ArFSPrivateFileBuilder) {
+		if (!builder.name) this.missingProperties.push('name');
+		if (builder.size === undefined) this.missingProperties.push('size');
+		if (!builder.lastModifiedDate) this.missingProperties.push('lastModifiedDate');
+		if (!builder.dataTxId) this.missingProperties.push('dataTxId');
+		if (!builder.dataContentType) this.missingProperties.push('dataContentType');
+		if (builder.entityType !== 'file') this.missingProperties.push('entityType');
+	}
+
+	throwIfMissingProperties() {
+		if (this.missingProperties.length > 0) {
+			throw new InvalidFileStateException(this.missingProperties);
+		}
+	}
+
+	reset() {
+		this.missingProperties = [];
+	}
+}


### PR DESCRIPTION
- Introduced `FileBuilderValidation` Class: This class throws an error listing all missing file properties, ensuring thorough validation.
- Updated Folder Mounting: Files with any missing property are now skipped when mounting the folder, improving reliability.