### PR TITLE
refactor: restore factory-backwards-compat PE-4841

### DIFF
--- a/src/ardrive_factory.ts
+++ b/src/ardrive_factory.ts
@@ -98,12 +98,12 @@ export function arDriveFactory({
 			? new Turbo({
 					...defaultTurboSettings,
 					isDryRun: dryRun
-			  })
+				})
 			: new Turbo({
 					turboUploadUrl: turboSettings.turboUploadUrl,
 					turboPaymentUrl: turboSettings.turboPaymentUrl,
 					isDryRun: dryRun
-			  })
+				})
 	)
 }: ArDriveSettings): ArDrive {
 	return new ArDrive(

--- a/src/arfs/arfs_file_wrapper.ts
+++ b/src/arfs/arfs_file_wrapper.ts
@@ -411,7 +411,10 @@ export class ArFSPrivateFileToDownload extends ArFSFileToDownload {
 }
 
 export class ArFSFolderToDownload<P extends ArFSWithPath> {
-	constructor(readonly folderWithPaths: P, protected readonly customBaseName?: string) {}
+	constructor(
+		readonly folderWithPaths: P,
+		protected readonly customBaseName?: string
+	) {}
 
 	getRelativePathOf(childPath: string): string {
 		const treeRootPath = this.folderWithPaths.path;

--- a/src/arfs/turbo.ts
+++ b/src/arfs/turbo.ts
@@ -28,7 +28,7 @@ export class Turbo {
 		isDryRun = false
 	}: TurboSettings & { isDryRun?: boolean }) {
 		if (turboUrl) {
-			turboUploadUrl ??= new URL(turboUrl);
+			turboUploadUrl ??= turboUrl;
 		}
 		turboUploadUrl ??= defaultTurboUploadUrl;
 		this.isDryRun = isDryRun;

--- a/src/arfs/turbo.ts
+++ b/src/arfs/turbo.ts
@@ -5,8 +5,10 @@ import { TurboUnauthenticatedClient, TurboUploadDataItemResponse, TurboFactory }
 import { defaultTurboPaymentUrl, defaultTurboUploadUrl } from '../utils/constants';
 
 export interface TurboSettings {
-	turboUploadUrl: URL;
-	turboPaymentUrl: URL;
+	/** @deprecated Use turboUploadUrl instead */
+	turboUrl?: URL;
+	turboUploadUrl?: URL;
+	turboPaymentUrl?: URL;
 }
 
 export interface TurboCachesResponse {
@@ -20,10 +22,15 @@ export class Turbo {
 	private turbo: TurboUnauthenticatedClient;
 
 	constructor({
-		turboUploadUrl = defaultTurboUploadUrl,
+		turboUploadUrl,
 		turboPaymentUrl = defaultTurboPaymentUrl,
+		turboUrl,
 		isDryRun = false
-	}: Partial<TurboSettings> & { isDryRun?: boolean }) {
+	}: TurboSettings & { isDryRun?: boolean }) {
+		if (turboUrl) {
+			turboUploadUrl ??= new URL(turboUrl);
+		}
+		turboUploadUrl ??= defaultTurboUploadUrl;
 		this.isDryRun = isDryRun;
 		this.turbo = TurboFactory.unauthenticated({
 			uploadServiceConfig: {

--- a/src/pricing/ar_data_price_chunk_estimator.ts
+++ b/src/pricing/ar_data_price_chunk_estimator.ts
@@ -25,7 +25,10 @@ export class ARDataPriceChunkEstimator extends AbstractARDataPriceAndCapacityEst
 	 * @param skipSetup allows for instantiation without pre-fetching pricing data from the oracle
 	 * @param oracle a data source for Arweave data pricing
 	 */
-	constructor(skipSetup = false, private readonly oracle: ArweaveOracle = new GatewayOracle()) {
+	constructor(
+		skipSetup = false,
+		private readonly oracle: ArweaveOracle = new GatewayOracle()
+	) {
 		super();
 
 		if (!skipSetup) {

--- a/src/utils/bundle_packer.ts
+++ b/src/utils/bundle_packer.ts
@@ -16,7 +16,10 @@ interface DataItemPlan {
 }
 
 export abstract class BundlePacker {
-	constructor(protected readonly maxBundleSize: ByteCount, protected readonly maxDataItemLimit: number) {
+	constructor(
+		protected readonly maxBundleSize: ByteCount,
+		protected readonly maxDataItemLimit: number
+	) {
 		if (!Number.isFinite(maxDataItemLimit) || !Number.isInteger(maxDataItemLimit) || maxDataItemLimit < 2) {
 			throw new Error('Maximum data item limit must be an integer value of 2 or more!');
 		}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,6 +14,9 @@ export { DEFAULT_APP_VERSION };
 export const prodAppUrl = 'https://app.ardrive.io';
 export const stagingAppUrl = 'https://staging.ardrive.io';
 
+/** @deprecated use defaultTurboProdUploadUrl */
+export const turboProdUrl = new URL('https://upload.ardrive.io/');
+
 export const defaultTurboUploadUrl = new URL('https://upload.ardrive.io/');
 export const defaultTurboPaymentUrl = new URL('https://payment.ardrive.io/');
 


### PR DESCRIPTION
this PR restores exported vars for backwards compat:

- `turboProdUrl`
- `turboSettings.turbUrl`

and runs prettier format