### PR TITLE
fix: use milliseconds for manifest timestamps instead of seconds

### DIFF
--- a/src/arfs/arfs_file_wrapper.test.ts
+++ b/src/arfs/arfs_file_wrapper.test.ts
@@ -76,13 +76,14 @@ describe('ArFSManifestToUpload class', () => {
 	});
 
 	it('gatherFileInfo function returns the expected results', () => {
-		const currentUnixTimeMs = Math.round(Date.now() / 1000);
+		const currentUnixTimeMs = Date.now();
 		const manifest = new ArFSManifestToUpload(stubPublicEntitiesWithPaths, 'TestManifest.json');
 
 		const { dataContentType, lastModifiedDateMS, fileSize } = manifest.gatherFileInfo();
 
 		expect(dataContentType).to.equal('application/x.arweave-manifest+json');
-		expect(+lastModifiedDateMS).to.equal(currentUnixTimeMs);
+		// Allow small time difference due to execution time
+		expect(Math.abs(+lastModifiedDateMS - currentUnixTimeMs)).to.be.lessThan(1000);
 		expect(+fileSize).to.equal(336);
 	});
 

--- a/src/arfs/arfs_file_wrapper.ts
+++ b/src/arfs/arfs_file_wrapper.ts
@@ -179,7 +179,7 @@ export class ArFSManifestToUpload extends ArFSDataToUpload {
 		};
 
 		// Create new current unix, as we just created this manifest
-		this.lastModifiedDateMS = new UnixTime(Math.round(Date.now() / 1000));
+		this.lastModifiedDateMS = new UnixTime(Date.now());
 	}
 
 	public getLinksOutput(dataTxId: TransactionID, gateway = new URL(defaultArweaveGatewayPath)): string[] {

--- a/src/arfs/arfs_upload_planner.test.ts
+++ b/src/arfs/arfs_upload_planner.test.ts
@@ -45,7 +45,7 @@ describe('The ArFSUploadPlanner class', () => {
 			const { uploadStats, totalByteCount } = bundlePlans[0];
 
 			expect(uploadStats.length).to.equal(1);
-			expect(+totalByteCount).to.equal(5953);
+			expect(+totalByteCount).to.equal(5956);
 		});
 
 		it('returns the expected uploadPlan for a single wrappedFolder', async () => {
@@ -62,7 +62,7 @@ describe('The ArFSUploadPlanner class', () => {
 			const { uploadStats, totalByteCount } = bundlePlans[0];
 
 			expect(uploadStats.length).to.equal(8);
-			expect(+totalByteCount).to.equal(16295);
+			expect(+totalByteCount).to.equal(16319);
 		});
 
 		it('returns the expected uploadPlan for a folder with an existing folder id', async () => {
@@ -86,7 +86,7 @@ describe('The ArFSUploadPlanner class', () => {
 			const { uploadStats, totalByteCount } = bundlePlans[0];
 
 			expect(uploadStats.length).to.equal(7);
-			expect(+totalByteCount).to.equal(14946);
+			expect(+totalByteCount).to.equal(14967);
 
 			// Expect first upload stat to have our existing stub folder id
 			expect(`${uploadStats[0].destFolderId}`).to.equal(`${stubEntityIDAlt}`);
@@ -109,7 +109,7 @@ describe('The ArFSUploadPlanner class', () => {
 			const { uploadStats, totalByteCount } = bundlePlans[0];
 
 			expect(uploadStats.length).to.equal(2);
-			expect(+totalByteCount).to.equal(11874);
+			expect(+totalByteCount).to.equal(11880);
 		});
 
 		it('returns the expected uploadPlan for a single file that is over the size limit', async () => {

--- a/src/arfs/arfs_upload_planner.test.ts
+++ b/src/arfs/arfs_upload_planner.test.ts
@@ -148,7 +148,7 @@ describe('The ArFSUploadPlanner class', () => {
 			expect(bundlePlans.length).to.equal(1);
 
 			const { uploadStats, totalByteCount: bundleByteCount } = bundlePlans[0];
-			expect(+bundleByteCount).to.equal(3108);
+			expect(+bundleByteCount).to.equal(3114);
 			expect(uploadStats.length).to.equal(0);
 
 			const { fileAndMetaDataPlans, fileDataOnlyPlans, folderMetaDataPlans } = v2TxPlans;
@@ -263,7 +263,7 @@ describe('The ArFSUploadPlanner class', () => {
 				const { totalBundledByteCount } = uploadPlan as CreateDriveBundlePlan;
 
 				// Expected ByteCount for this create drive Bundle is 2832
-				expect(+totalBundledByteCount).to.equal(2832);
+				expect(+totalBundledByteCount).to.equal(2838);
 			});
 
 			it('returns correct rewardSetting and totalWinstonPrice for a v2 transaction', async () => {
@@ -291,7 +291,7 @@ describe('The ArFSUploadPlanner class', () => {
 				const { totalBundledByteCount } = uploadPlan as CreateDriveBundlePlan;
 
 				// Expected ByteCount for this private drive Bundle is 2998
-				expect(+totalBundledByteCount).to.equal(3015);
+				expect(+totalBundledByteCount).to.equal(3021);
 			});
 
 			it('returns correct rewardSetting and totalWinstonPrice for a v2 transaction', async () => {

--- a/src/arfs/tx/arfs_prototypes.ts
+++ b/src/arfs/tx/arfs_prototypes.ts
@@ -89,7 +89,7 @@ export abstract class ArFSEntityMetaDataPrototype extends ArFSObjectMetadataProt
 		super(customMetaDataTags);
 
 		// Get the current time so the app can display the "created" data later on
-		this.unixTime = new UnixTime(Math.round(Date.now() / 1000));
+		this.unixTime = new UnixTime(Date.now());
 	}
 
 	protected get protectedTags(): GQLTagInterface[] {

--- a/tests/integration/ardrive.int.test.ts
+++ b/tests/integration/ardrive.int.test.ts
@@ -324,7 +324,7 @@ describe('ArDrive class - integrated', () => {
 
 				assertCreateDriveExpectations({
 					result,
-					driveFee: W(2809),
+					driveFee: W(2815),
 					expectedEntityName: validEntityName,
 					folderFee: W(37),
 					isBundled: true
@@ -440,7 +440,7 @@ describe('ArDrive class - integrated', () => {
 
 				assertCreateDriveExpectations({
 					result,
-					driveFee: W(2990),
+					driveFee: W(2996),
 					expectedEntityName: validEntityName,
 					folderFee: W(37),
 					isBundled: true,
@@ -1504,7 +1504,7 @@ describe('ArDrive class - integrated', () => {
 
 				assertUploadFileExpectations({
 					result,
-					fileFee: W(5959),
+					fileFee: W(5962),
 					metadataFee: W(166),
 					expectedTip: W(1),
 					expectedEntityName: 'test_wallet.json',
@@ -1786,7 +1786,7 @@ describe('ArDrive class - integrated', () => {
 				});
 				assertUploadFileExpectations({
 					result,
-					fileFee: W(6097),
+					fileFee: W(6100),
 					metadataFee: W(187),
 					expectedTip: W(1),
 					expectPrivateKey: true,
@@ -2792,7 +2792,7 @@ describe('ArDrive class - integrated', () => {
 				conflictResolution: 'replace'
 			});
 
-			assertUploadManifestExpectations(result, W(336), W(186), W(1), existingFileId);
+			assertUploadManifestExpectations(result, W(336), W(189), W(1), existingFileId);
 		});
 
 		it('returns the correct ArFSManifestResult revision if destination folder has a conflicting FILE name and conflictResolution is set to upsert', async () => {
@@ -2804,7 +2804,7 @@ describe('ArDrive class - integrated', () => {
 				conflictResolution: 'upsert'
 			});
 
-			assertUploadManifestExpectations(result, W(336), W(186), W(1), existingFileId);
+			assertUploadManifestExpectations(result, W(336), W(189), W(1), existingFileId);
 		});
 
 		it('returns an empty ArFSManifestResult if destination folder has a conflicting FILE name and conflictResolution is set to skip', async () => {
@@ -2844,7 +2844,7 @@ describe('ArDrive class - integrated', () => {
 				folderId: stubEntityID
 			});
 
-			assertUploadManifestExpectations(result, W(336), W(183), W(1));
+			assertUploadManifestExpectations(result, W(336), W(186), W(1));
 		});
 
 		it('returns the correct bundled ArFSManifestResult', async () => {
@@ -2854,7 +2854,7 @@ describe('ArDrive class - integrated', () => {
 				folderId: stubEntityID
 			});
 
-			assertUploadManifestExpectations(result, W(3127), W(183), W(1), undefined, undefined, true);
+			assertUploadManifestExpectations(result, W(3133), W(186), W(1), undefined, undefined, true);
 		});
 
 		it('returns the correct turbo ArFSResult for manifest', async () => {
@@ -2874,7 +2874,7 @@ describe('ArDrive class - integrated', () => {
 				folderId: stubEntityID
 			});
 
-			assertUploadManifestExpectations(result, W(475), W(183), W(1), undefined, true);
+			assertUploadManifestExpectations(result, W(475), W(186), W(1), undefined, true);
 		});
 
 		it('throws an error if target folder has no files to put in the manifest', async () => {
@@ -2940,7 +2940,7 @@ describe('ArDrive class - integrated', () => {
 
 			assertUploadFileExpectations({
 				result,
-				fileFee: W(5959),
+				fileFee: W(5962),
 				metadataFee: W(166),
 				expectedTip: W(1),
 				expectedEntityName: 'test_wallet.json',
@@ -3022,7 +3022,7 @@ describe('ArDrive class - integrated', () => {
 
 			const bundleTxId = created[2].bundleTxId!;
 			expect(feeKeys[2]).to.equal(`${bundleTxId}`);
-			expect(+fees[`${bundleTxId}`]).to.equal(3116);
+			expect(+fees[`${bundleTxId}`]).to.equal(3122);
 		});
 
 		it('throws an error if two files with the same destination name are sent to the same destination folder', async () => {
@@ -3112,7 +3112,7 @@ describe('ArDrive class - integrated', () => {
 			expect(+fees[`${file2DataTxId}`]).to.equal(+MAX_BUNDLE_SIZE + 1);
 
 			expect(feeKeys[2]).to.equal(`${bundleTxId}`);
-			expect(+fees[`${bundleTxId}`]).to.equal(4471);
+			expect(+fees[`${bundleTxId}`]).to.equal(4480);
 		});
 
 		it('returns an empty result if a folder name conflicts with a folder name and use chooses to skip the folder via an ask prompt', async () => {
@@ -3156,7 +3156,7 @@ describe('ArDrive class - integrated', () => {
 			assertBundleCreatedResult(created[8]);
 
 			expect(feeKeys[0]).to.equal(`${bundleTxId}`);
-			expect(+fees[`${bundleTxId}`]).to.equal(16331);
+			expect(+fees[`${bundleTxId}`]).to.equal(16355);
 		});
 
 		// Legacy bulk method test for to confirm backwards compatibility and coverage
@@ -3179,7 +3179,7 @@ describe('ArDrive class - integrated', () => {
 			assertBundleCreatedResult(created[8]);
 
 			expect(feeKeys[0]).to.equal(`${created[8].bundleTxId!}`);
-			expect(+fees[`${created[8].bundleTxId}`]).to.equal(17183);
+			expect(+fees[`${created[8].bundleTxId}`]).to.equal(17207);
 		});
 
 		it('returns the expected ArFSResult with a folder that has conflicting names within its tree and uses --skip conflictResolution', async () => {
@@ -3299,7 +3299,7 @@ describe('ArDrive class - integrated', () => {
 			assertBundleCreatedResult(created[3]);
 
 			expect(feeKeys[0]).to.equal(`${bundleTxId}`);
-			expect(+fees[`${bundleTxId}`]).to.equal(17803);
+			expect(+fees[`${bundleTxId}`]).to.equal(17812);
 
 			assertTipSetting(tips[0], bundleTxId!);
 		});
@@ -3359,7 +3359,7 @@ describe('ArDrive class - integrated', () => {
 			assertBundleCreatedResult(created[3]);
 
 			expect(feeKeys[0]).to.equal(`${bundleTxId}`);
-			expect(+fees[`${bundleTxId}`]).to.equal(17828);
+			expect(+fees[`${bundleTxId}`]).to.equal(17837);
 
 			assertTipSetting(tips[0], bundleTxId!);
 		});
@@ -3420,7 +3420,7 @@ describe('ArDrive class - integrated', () => {
 			assertBundleCreatedResult(created[2]);
 
 			expect(feeKeys[0]).to.equal(`${bundleTxId}`);
-			expect(+fees[`${bundleTxId}`]).to.equal(11904);
+			expect(+fees[`${bundleTxId}`]).to.equal(11910);
 
 			assertTipSetting(tips[0], bundleTxId!);
 		});
@@ -3475,7 +3475,7 @@ describe('ArDrive class - integrated', () => {
 			assertBundleCreatedResult(created[2]);
 
 			expect(feeKeys[0]).to.equal(`${bundleTxId}`);
-			expect(+fees[`${bundleTxId}`]).to.equal(2731);
+			expect(+fees[`${bundleTxId}`]).to.equal(2737);
 		});
 
 		it('throws an error if a folder name conflicts with a file name', async () => {
@@ -3512,7 +3512,7 @@ describe('ArDrive class - integrated', () => {
 
 			assertUploadFileExpectations({
 				result,
-				fileFee: W(6097),
+				fileFee: W(6100),
 				metadataFee: W(182),
 				expectedTip: W(1),
 				expectPrivateKey: true,
@@ -3641,7 +3641,7 @@ describe('ArDrive class - integrated', () => {
 
 			assertUploadFileExpectations({
 				result,
-				fileFee: W(2756),
+				fileFee: W(2759),
 				metadataFee: W(159),
 				expectedTip: W(1),
 				isBundled: true,
@@ -3661,7 +3661,7 @@ describe('ArDrive class - integrated', () => {
 
 			assertUploadFileExpectations({
 				result,
-				fileFee: W(2764),
+				fileFee: W(2767),
 				metadataFee: W(163),
 				expectedTip: W(1),
 				isBundled: true,
@@ -3682,7 +3682,7 @@ describe('ArDrive class - integrated', () => {
 
 			assertUploadFileExpectations({
 				result,
-				fileFee: W(2900),
+				fileFee: W(2903),
 				metadataFee: W(179),
 				expectedTip: W(1),
 				expectPrivateKey: true,
@@ -3709,7 +3709,7 @@ describe('ArDrive class - integrated', () => {
 
 			assertUploadFileExpectations({
 				result,
-				fileFee: W(2904),
+				fileFee: W(2907),
 				metadataFee: W(179),
 				expectedTip: W(1),
 				expectPrivateKey: true,

--- a/tests/integration/arlocal.int.test.ts
+++ b/tests/integration/arlocal.int.test.ts
@@ -922,7 +922,7 @@ describe('ArLocal Integration Tests', function () {
 					expectedCommunityTip: W(154_544_268_902),
 					expectedDataTxReward: W(1_030_295_126_016),
 					// We expect a metaData reward to exist
-					expectedMetaDataTxReward: W(5_504_334_732)
+					expectedMetaDataTxReward: W(5_516_125_524)
 				});
 
 				// File MetaData should now be valid


### PR DESCRIPTION
  Fixes bug where lastModifiedDate was divided by 1000, causing dates to display as Jan 21, 1970. ArFS spec expects timestamps in milliseconds.