### PR TITLE
PE-8969: update arweave.net references to ardrive.net

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ardrive-core-js",
-	"version": "3.1.0",
+	"version": "4.0.0",
 	"description": "ArDrive Core contains the essential back end application features to support the ArDrive CLI and Desktop apps, such as file management, Permaweb upload/download, wallet management and other common functions.",
 	"main": "./lib/exports.js",
 	"types": "./lib/exports.d.ts",

--- a/src/arfs/arfs_file_wrapper.test.ts
+++ b/src/arfs/arfs_file_wrapper.test.ts
@@ -100,12 +100,12 @@ describe('ArFSManifestToUpload class', () => {
 			const linksOutput = manifest.getLinksOutput(stubTransactionID);
 
 			expect(linksOutput.length).to.equal(4);
-			expect(linksOutput[0]).to.equal(`https://arweave.net/${stubTransactionID}`);
-			expect(linksOutput[1]).to.equal(`https://arweave.net/${stubTransactionID}/file-in-root`);
+			expect(linksOutput[0]).to.equal(`https://ardrive.net/${stubTransactionID}`);
+			expect(linksOutput[1]).to.equal(`https://ardrive.net/${stubTransactionID}/file-in-root`);
 			expect(linksOutput[2]).to.equal(
-				`https://arweave.net/${stubTransactionID}/parent-folder/child-folder/file-in-child`
+				`https://ardrive.net/${stubTransactionID}/parent-folder/child-folder/file-in-child`
 			);
-			expect(linksOutput[3]).to.equal(`https://arweave.net/${stubTransactionID}/parent-folder/file-in-parent`);
+			expect(linksOutput[3]).to.equal(`https://ardrive.net/${stubTransactionID}/parent-folder/file-in-parent`);
 		});
 
 		it('produces compatible links with a hierarchy of one single file', () => {
@@ -114,8 +114,8 @@ describe('ArFSManifestToUpload class', () => {
 			const linksOutput = manifest.getLinksOutput(stubTransactionID);
 
 			expect(linksOutput.length).to.equal(2);
-			expect(linksOutput[0]).to.equal(`https://arweave.net/${stubTransactionID}`);
-			expect(linksOutput[1]).to.equal(`https://arweave.net/${stubTransactionID}/file-in-root`);
+			expect(linksOutput[0]).to.equal(`https://ardrive.net/${stubTransactionID}`);
+			expect(linksOutput[1]).to.equal(`https://ardrive.net/${stubTransactionID}/file-in-root`);
 		});
 
 		it('produces compatible links with a hierarchy of one nested file', () => {
@@ -124,9 +124,9 @@ describe('ArFSManifestToUpload class', () => {
 			const linksOutput = manifest.getLinksOutput(stubTransactionID);
 
 			expect(linksOutput.length).to.equal(2);
-			expect(linksOutput[0]).to.equal(`https://arweave.net/${stubTransactionID}`);
+			expect(linksOutput[0]).to.equal(`https://ardrive.net/${stubTransactionID}`);
 			expect(linksOutput[1]).to.equal(
-				`https://arweave.net/${stubTransactionID}/parent-folder/child-folder/file-in-child`
+				`https://ardrive.net/${stubTransactionID}/parent-folder/child-folder/file-in-child`
 			);
 		});
 
@@ -136,15 +136,15 @@ describe('ArFSManifestToUpload class', () => {
 			const linksOutput = manifest.getLinksOutput(stubTransactionID);
 
 			expect(linksOutput.length).to.equal(4);
-			expect(linksOutput[0]).to.equal(`https://arweave.net/${stubTransactionID}`);
+			expect(linksOutput[0]).to.equal(`https://ardrive.net/${stubTransactionID}`);
 			expect(linksOutput[1]).to.equal(
-				`https://arweave.net/${stubTransactionID}/%25%26%40*(%25%26(%40*%3A%22%3E%3F%7B%7D%5B%5D`
+				`https://ardrive.net/${stubTransactionID}/%25%26%40*(%25%26(%40*%3A%22%3E%3F%7B%7D%5B%5D`
 			);
 			expect(linksOutput[2]).to.equal(
-				`https://arweave.net/${stubTransactionID}/~!%40%23%24%25%5E%26*()_%2B%7B%7D%7C%5B%5D%3A%22%3B%3C%3E%3F%2C./%60/'/''_%5C___''_'__/'___'''_/QWERTYUIOPASDFGHJKLZXCVBNM!%40%23%24%25%5E%26*()_%2B%7B%7D%3A%22%3E%3F`
+				`https://ardrive.net/${stubTransactionID}/~!%40%23%24%25%5E%26*()_%2B%7B%7D%7C%5B%5D%3A%22%3B%3C%3E%3F%2C./%60/'/''_%5C___''_'__/'___'''_/QWERTYUIOPASDFGHJKLZXCVBNM!%40%23%24%25%5E%26*()_%2B%7B%7D%3A%22%3E%3F`
 			);
 			expect(linksOutput[3]).to.equal(
-				`https://arweave.net/${stubTransactionID}/~!%40%23%24%25%5E%26*()_%2B%7B%7D%7C%5B%5D%3A%22%3B%3C%3E%3F%2C./%60/dwijqndjqwnjNJKNDKJANKDNJWNJIvmnbzxnmvbcxvbm%2Cuiqwerioeqwndjkla`
+				`https://ardrive.net/${stubTransactionID}/~!%40%23%24%25%5E%26*()_%2B%7B%7D%7C%5B%5D%3A%22%3B%3C%3E%3F%2C./%60/dwijqndjqwnjNJKNDKJANKDNJWNJIvmnbzxnmvbcxvbm%2Cuiqwerioeqwndjkla`
 			);
 		});
 	});

--- a/src/arfs/multi_chunk_tx_uploader.ts
+++ b/src/arfs/multi_chunk_tx_uploader.ts
@@ -33,7 +33,7 @@ export interface MultiChunkTxUploaderConstructorParams {
  *
  *		const transactionUploader = new MultiChunkTxUploader({
  *			transaction,
- *			gatewayApi: new GatewayAPI({ gatewayUrl: new URL('https://arweave.net:443') })
+ *			gatewayApi: new GatewayAPI({ gatewayUrl: new URL('https://ardrive.net') })
  *		});
  *
  *		await transactionUploader.batchUploadChunks();

--- a/src/community/ardrive_community_oracle.ts
+++ b/src/community/ardrive_community_oracle.ts
@@ -9,7 +9,7 @@ import { SmartweaveContractReader } from './smartweave_contract_oracle';
 
 /**
  * Minimum ArDrive community tip from the Community Improvement Proposal Doc:
- * https://arweave.net/Yop13NrLwqlm36P_FDCdMaTBwSlj0sdNGAC4FqfRUgo
+ * https://ardrive.net/Yop13NrLwqlm36P_FDCdMaTBwSlj0sdNGAC4FqfRUgo
  */
 export const minArDriveCommunityWinstonTip = W(10_000_000);
 

--- a/src/pricing/ar_data_price_chunk_estimator.ts
+++ b/src/pricing/ar_data_price_chunk_estimator.ts
@@ -94,7 +94,7 @@ export class ARDataPriceChunkEstimator extends AbstractARDataPriceAndCapacityEst
 
 		const numberOfChunksToUpload = Math.ceil(byteCount.valueOf() / byteCountPerChunk.valueOf());
 
-		// Every 5th chunk, arweave.net pricing adds 1 Winston, which they define as a
+		// Every 5th chunk, Arweave pricing adds 1 Winston, which they define as a
 		// mining reward as a proportion of the estimated transaction storage costs
 		const minerFeeShareResidual = W(Math.floor(numberOfChunksToUpload / 5));
 

--- a/src/utils/common_browser.ts
+++ b/src/utils/common_browser.ts
@@ -4,15 +4,12 @@
  */
 
 import { ByteCount, DriveSignatureType } from '../types';
-import { authTagLength } from './constants';
+import { authTagLength, defaultGatewayHost, defaultGatewayProtocol } from './constants';
 
 /** Derives gateway URL from provided Arweave instance */
 export function gatewayUrlForArweave(arweave: {
 	api: { config: { protocol?: string; host?: string; port?: string | number } };
 }): URL {
-	const defaultGatewayProtocol = 'https';
-	const defaultGatewayHost = 'arweave.net';
-
 	const protocol = arweave.api.config.protocol ?? defaultGatewayProtocol;
 	const host = arweave.api.config.host ?? defaultGatewayHost;
 	const portStr = arweave.api.config.port ? `:${arweave.api.config.port}` : '';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,7 +20,7 @@ export const turboProdUrl = new URL('https://upload.ardrive.io/');
 export const defaultTurboUploadUrl = new URL('https://upload.ardrive.io/');
 export const defaultTurboPaymentUrl = new URL('https://payment.ardrive.io/');
 
-export const defaultGatewayHost = 'arweave.net';
+export const defaultGatewayHost = 'ardrive.net';
 export const defaultGatewayProtocol = 'https';
 export const defaultGatewayPort = 443;
 export const defaultArweaveGatewayPath = `${defaultGatewayProtocol}://${defaultGatewayHost}/`;
@@ -33,7 +33,7 @@ export const fakeTxID = TxID('0000000000000000000000000000000000000000000');
 
 /**
  * Minimum ArDrive community tip from the Community Improvement Proposal Doc:
- * https://arweave.net/Yop13NrLwqlm36P_FDCdMaTBwSlj0sdNGAC4FqfRUgo
+ * https://ardrive.net/Yop13NrLwqlm36P_FDCdMaTBwSlj0sdNGAC4FqfRUgo
  *
  * Voted on by the ArDrive community (vote #82):
  * https://community.xyz/#-8A6RexFkpfWwuyVO98wzSFZh0d6VJuI-buTJvlwOJQ/votes/

--- a/src/web/ardrive_factory_web.ts
+++ b/src/web/ardrive_factory_web.ts
@@ -6,7 +6,7 @@ import { JWKWalletWeb } from './jwk_wallet_web';
 import type { JWKInterface, ArweaveSigner } from '@dha-team/arbundles';
 import { ArconnectSigner } from '@dha-team/arbundles';
 import type Arweave from 'arweave';
-import { DEFAULT_APP_NAME, DEFAULT_APP_VERSION } from '../utils/constants';
+import { DEFAULT_APP_NAME, DEFAULT_APP_VERSION, defaultArweaveGatewayPath } from '../utils/constants';
 import type { ArDriveSigner } from './ardrive_signer';
 import type { TurboSettings } from './turbo_web';
 
@@ -32,7 +32,7 @@ function createStubArweave(gatewayUrl: URL): Arweave {
 
 // Matches Node naming while targeting browser - now uses core classes!
 export function arDriveAnonymousFactory({
-	gatewayUrl = new URL('https://arweave.net/')
+	gatewayUrl = new URL(defaultArweaveGatewayPath)
 }: ArDriveSettingsAnonymousWeb = {}) {
 	// Create GatewayAPI for web
 	const gatewayApi = new GatewayAPI({ gatewayUrl });
@@ -74,7 +74,7 @@ export interface ArDriveSettingsWeb {
  * @param settings - Configuration object
  * @param settings.wallet - JWK wallet (provide either wallet or signer)
  * @param settings.signer - ArDriveSigner, ArweaveSigner, or ArconnectSigner instance (provide either wallet or signer)
- * @param settings.gatewayUrl - Gateway URL (default: https://arweave.net/)
+ * @param settings.gatewayUrl - Gateway URL (default: https://ardrive.net/)
  * @param settings.appName - Application name
  * @param settings.appVersion - Application version
  * @param settings.turboSettings - Turbo configuration for automatic uploads

--- a/src/web/ardrive_web.ts
+++ b/src/web/ardrive_web.ts
@@ -23,7 +23,7 @@ import type { CustomMetaDataJsonFields } from '../types/custom_metadata_types';
 import Arweave from 'arweave';
 import type { ArDriveSigner } from './ardrive_signer';
 import { TurboWeb, TurboSettings } from './turbo_web';
-import { DEFAULT_APP_NAME, DEFAULT_APP_VERSION } from '../utils/constants';
+import { DEFAULT_APP_NAME, DEFAULT_APP_VERSION, defaultArweaveGatewayPath } from '../utils/constants';
 import { ArFSTagSettings } from '../arfs/arfs_tag_settings';
 
 export interface ArDriveWebSettings {
@@ -107,7 +107,7 @@ export class ArDriveWeb extends ArDriveAnonymous {
 			throw new Error('Either wallet or signer must be provided to ArDriveWeb');
 		}
 
-		const gw = new GatewayAPI({ gatewayUrl: settings.gatewayUrl ?? new URL('https://arweave.net/') });
+		const gw = new GatewayAPI({ gatewayUrl: settings.gatewayUrl ?? new URL(defaultArweaveGatewayPath) });
 		// Use provided signer or create one from wallet
 		const signer: Signer | ArDriveSigner = settings.signer ?? new ArweaveSigner(settings.wallet!.getPrivateKey());
 		const appName = settings.appName ?? DEFAULT_APP_NAME;
@@ -858,7 +858,7 @@ export class ArDriveWeb extends ArDriveAnonymous {
 		});
 
 		const manifestTxId = uploadResult.dataTxId;
-		const links = arweaveManifest.getLinksOutput(TxID(manifestTxId), new URL('https://arweave.net'));
+		const links = arweaveManifest.getLinksOutput(TxID(manifestTxId), new URL(defaultArweaveGatewayPath));
 
 		return {
 			manifestTxId,

--- a/src/web/arfsdao_authenticated_web.ts
+++ b/src/web/arfsdao_authenticated_web.ts
@@ -174,7 +174,7 @@ export class ArFSDAOAuthenticatedWeb extends ArFSDAOAuthenticatedBase {
 				} else {
 					// Fetch the encrypted signature data using gateway URL directly
 					// Can't use getPublicDataStream because it requires arweave instance (null in browser)
-					const gatewayUrl = new URL(txId, this.gatewayApi['gatewayUrl'] || 'https://arweave.net/');
+					const gatewayUrl = new URL(txId, this.gatewayApi['gatewayUrl'] || defaultArweaveGatewayPath);
 					const dataUrl = gatewayUrl.href;
 					const response = await fetch(dataUrl);
 					if (!response.ok) {

--- a/src/web/arfsdao_authenticated_web.ts
+++ b/src/web/arfsdao_authenticated_web.ts
@@ -13,7 +13,7 @@ import { GatewayAPI } from '../utils/gateway_api';
 import { TxPreparer } from '../arfs/tx/tx_preparer';
 import { ArFSTagSettings } from '../arfs/arfs_tag_settings';
 import { ArFSTagAssembler } from '../arfs/tags/tag_assembler';
-import { DEFAULT_APP_NAME, DEFAULT_APP_VERSION, gqlTagNameRecord } from '../utils/constants';
+import { DEFAULT_APP_NAME, DEFAULT_APP_VERSION, defaultArweaveGatewayPath, gqlTagNameRecord } from '../utils/constants';
 import { TurboWeb, TurboSettings } from './turbo_web';
 import { TurboUploadDataItemResponse } from '@ardrive/turbo-sdk';
 import {

--- a/tests/playwright/browser-vs-node.spec.ts
+++ b/tests/playwright/browser-vs-node.spec.ts
@@ -239,7 +239,7 @@ test.describe('Browser vs Node.js Build Comparison', () => {
 				const ArDriveModule = await import('/dist/web/index.js');
 				const { GatewayAPI } = ArDriveModule;
 
-				const gateway = new GatewayAPI({ gatewayUrl: new URL('https://arweave.net/') });
+				const gateway = new GatewayAPI({ gatewayUrl: new URL('https://ardrive.net/') });
 
 				return {
 					success: true,
@@ -279,7 +279,7 @@ test.describe('Browser vs Node.js Build Comparison', () => {
 				const ArDriveModule = await import('/dist/web/index.js');
 				const { ArFSDAOAnonymous, GatewayAPI } = ArDriveModule;
 
-				const gatewayApi = new GatewayAPI({ gatewayUrl: new URL('https://arweave.net/') });
+				const gatewayApi = new GatewayAPI({ gatewayUrl: new URL('https://ardrive.net/') });
 				const dao = new ArFSDAOAnonymous(
 					null, // arweave - not used by web methods
 					'test-app',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Default gateway endpoint changed from arweave.net to ardrive.net across the application.
  * Gateway configuration centralized to streamline default URL handling.
  * Package version bumped to 4.0.0.

* **Tests**
  * Test cases and documentation examples updated to reflect the new default gateway.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->