### PR TITLE
feat(arfs): add file/folder hide & unhide support

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 		"power-assert": "mocha --parallel false --r espower-typescript/guess ./**/*test.ts",
 		"typecheck": "tsc --noemit",
 		"build": "yarn clean && tsc --project ./tsconfig.prod.json",
+		"prepare": "tsc --project ./tsconfig.prod.json",
 		"ci": "yarn arlocal-docker-test && yarn build",
 		"dev": "yarn clean && tsc --project ./tsconfig.prod.json -w",
 		"arlocal-docker-test": "bash \"tests/arlocal-docker-test.sh\"",

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -57,6 +57,10 @@ import {
 	RenamePrivateFileParams,
 	RenamePublicFolderParams,
 	RenamePrivateFolderParams,
+	HidePublicFileParams,
+	HidePrivateFileParams,
+	HidePublicFolderParams,
+	HidePrivateFolderParams,
 	CommunityTipParams,
 	TipResult,
 	MovePublicFileParams,
@@ -1778,6 +1782,254 @@ export class ArDrive extends ArDriveAnonymous {
 					metadataTxId: metaDataTxId,
 					key: driveKey,
 					entityName: newName,
+					dataCaches,
+					fastFinalityIndexes
+				}
+			],
+			tips: [],
+			fees: {}
+		};
+
+		if (metaDataTxReward) {
+			arFSResult.fees = { [`${metaDataTxId}`]: metaDataTxReward };
+		}
+
+		return arFSResult;
+	}
+
+	/**
+	 * Hide/unhide a file or folder by writing a new metadata revision that flips its `isHidden`
+	 * flag. This is structurally a no-op rename: name, size and (critically) lastModifiedDate are
+	 * preserved on the wire, so it never trips downstream edit-detection. There is no cascade —
+	 * hiding a folder writes exactly one revision for that folder. Deciding whether hidden entities
+	 * are shown or filtered is left to the consumer. Mirrors ardrive-web.
+	 *
+	 * NOTE: drive-level hide (hidePublicDrive/etc.) is intentionally deferred (see CORE-4). It is a
+	 * cheap follow-up mirroring these methods against the drive rename/tx-data layer.
+	 */
+	async hidePublicFile({ fileId }: HidePublicFileParams): Promise<ArFSResult> {
+		return this.setPublicFileHidden(fileId, true);
+	}
+
+	async unhidePublicFile({ fileId }: HidePublicFileParams): Promise<ArFSResult> {
+		return this.setPublicFileHidden(fileId, false);
+	}
+
+	async hidePrivateFile({ fileId, driveKey }: HidePrivateFileParams): Promise<ArFSResult> {
+		return this.setPrivateFileHidden(fileId, driveKey, true);
+	}
+
+	async unhidePrivateFile({ fileId, driveKey }: HidePrivateFileParams): Promise<ArFSResult> {
+		return this.setPrivateFileHidden(fileId, driveKey, false);
+	}
+
+	async hidePublicFolder({ folderId }: HidePublicFolderParams): Promise<ArFSResult> {
+		return this.setPublicFolderHidden(folderId, true);
+	}
+
+	async unhidePublicFolder({ folderId }: HidePublicFolderParams): Promise<ArFSResult> {
+		return this.setPublicFolderHidden(folderId, false);
+	}
+
+	async hidePrivateFolder({ folderId, driveKey }: HidePrivateFolderParams): Promise<ArFSResult> {
+		return this.setPrivateFolderHidden(folderId, driveKey, true);
+	}
+
+	async unhidePrivateFolder({ folderId, driveKey }: HidePrivateFolderParams): Promise<ArFSResult> {
+		return this.setPrivateFolderHidden(folderId, driveKey, false);
+	}
+
+	private async setPublicFileHidden(fileId: FileID, isHidden: boolean): Promise<ArFSResult> {
+		const owner = await this.getOwnerAddress();
+		const file = await this.getPublicFile({ fileId, owner });
+
+		// No-op rename: re-use the file's current name/size/lastModifiedDate, only toggling isHidden.
+		const fileMetadataTxDataStub = new ArFSPublicFileMetadataTransactionData(
+			file.name,
+			file.size,
+			file.lastModifiedDate,
+			file.dataTxId,
+			file.dataContentType,
+			file.customMetaDataJson,
+			isHidden
+		);
+
+		const metadataRewardSettings = this.uploadPlanner.isTurboUpload()
+			? undefined
+			: {
+					reward: (await this.estimateAndAssertCostOfFolderUpload(fileMetadataTxDataStub)).metaDataBaseReward,
+					feeMultiple: this.feeMultiple
+				};
+
+		const { entityId, metaDataTxId, dataCaches, fastFinalityIndexes, metaDataTxReward } =
+			await this.arFsDao.hidePublicFile({
+				file,
+				isHidden,
+				metadataRewardSettings
+			});
+
+		const arFSResult: ArFSResult = {
+			created: [
+				{
+					type: 'file',
+					entityId: entityId,
+					metadataTxId: metaDataTxId,
+					entityName: file.name,
+					dataCaches,
+					fastFinalityIndexes
+				}
+			],
+			tips: [],
+			fees: {}
+		};
+
+		if (metaDataTxReward) {
+			arFSResult.fees = { [`${metaDataTxId}`]: metaDataTxReward };
+		}
+
+		return arFSResult;
+	}
+
+	private async setPrivateFileHidden(fileId: FileID, driveKey: DriveKey, isHidden: boolean): Promise<ArFSResult> {
+		const owner = await this.getOwnerAddress();
+		const file = await this.getPrivateFile({ fileId, driveKey, owner });
+
+		const fileMetadataTxDataStub = await ArFSPrivateFileMetadataTransactionData.from(
+			file.name,
+			file.size,
+			file.lastModifiedDate,
+			file.dataTxId,
+			file.dataContentType,
+			file.fileId,
+			driveKey,
+			file.customMetaDataJson,
+			isHidden
+		);
+
+		const metadataRewardSettings = this.uploadPlanner.isTurboUpload()
+			? undefined
+			: {
+					reward: (await this.estimateAndAssertCostOfFolderUpload(fileMetadataTxDataStub)).metaDataBaseReward,
+					feeMultiple: this.feeMultiple
+				};
+
+		const { entityId, fileKey, metaDataTxId, dataCaches, fastFinalityIndexes, metaDataTxReward } =
+			await this.arFsDao.hidePrivateFile({
+				file,
+				isHidden,
+				metadataRewardSettings,
+				driveKey
+			});
+
+		const arFSResult: ArFSResult = {
+			created: [
+				{
+					type: 'file',
+					entityId: entityId,
+					key: fileKey,
+					metadataTxId: metaDataTxId,
+					entityName: file.name,
+					dataCaches,
+					fastFinalityIndexes
+				}
+			],
+			tips: [],
+			fees: {}
+		};
+
+		if (metaDataTxReward) {
+			arFSResult.fees = { [`${metaDataTxId}`]: metaDataTxReward };
+		}
+
+		return arFSResult;
+	}
+
+	private async setPublicFolderHidden(folderId: FolderID, isHidden: boolean): Promise<ArFSResult> {
+		const owner = await this.getOwnerAddress();
+		const folder = await this.getPublicFolder({ folderId, owner });
+
+		const folderMetadataTxDataStub = new ArFSPublicFolderTransactionData(
+			folder.name,
+			folder.customMetaDataJson,
+			isHidden
+		);
+
+		const metadataRewardSettings = this.uploadPlanner.isTurboUpload()
+			? undefined
+			: {
+					reward: (await this.estimateAndAssertCostOfFolderUpload(folderMetadataTxDataStub))
+						.metaDataBaseReward,
+					feeMultiple: this.feeMultiple
+				};
+
+		const { entityId, metaDataTxId, dataCaches, fastFinalityIndexes, metaDataTxReward } =
+			await this.arFsDao.hidePublicFolder({
+				folder,
+				isHidden,
+				metadataRewardSettings
+			});
+
+		const arFSResult: ArFSResult = {
+			created: [
+				{
+					type: 'folder',
+					entityId: entityId,
+					metadataTxId: metaDataTxId,
+					entityName: folder.name,
+					dataCaches,
+					fastFinalityIndexes
+				}
+			],
+			tips: [],
+			fees: {}
+		};
+
+		if (metaDataTxReward) {
+			arFSResult.fees = { [`${metaDataTxId}`]: metaDataTxReward };
+		}
+
+		return arFSResult;
+	}
+
+	private async setPrivateFolderHidden(
+		folderId: FolderID,
+		driveKey: DriveKey,
+		isHidden: boolean
+	): Promise<ArFSResult> {
+		const owner = await this.getOwnerAddress();
+		const folder = await this.getPrivateFolder({ folderId, driveKey, owner });
+
+		const folderMetadataTxDataStub = await ArFSPrivateFolderTransactionData.from(
+			folder.name,
+			driveKey,
+			folder.customMetaDataJson,
+			isHidden
+		);
+
+		const metadataRewardSettings = this.uploadPlanner.isTurboUpload()
+			? undefined
+			: {
+					reward: (await this.estimateAndAssertCostOfFolderUpload(folderMetadataTxDataStub))
+						.metaDataBaseReward,
+					feeMultiple: this.feeMultiple
+				};
+
+		const { entityId, metaDataTxId, dataCaches, fastFinalityIndexes, metaDataTxReward } =
+			await this.arFsDao.hidePrivateFolder({
+				folder,
+				isHidden,
+				metadataRewardSettings,
+				driveKey
+			});
+
+		const arFSResult: ArFSResult = {
+			created: [
+				{
+					type: 'folder',
+					entityId: entityId,
+					metadataTxId: metaDataTxId,
+					key: driveKey,
+					entityName: folder.name,
 					dataCaches,
 					fastFinalityIndexes
 				}

--- a/src/arfs/arfs_builders/arfs_file_builders.ts
+++ b/src/arfs/arfs_builders/arfs_file_builders.ts
@@ -26,6 +26,9 @@ export interface FileMetaDataTransactionData extends EntityMetaDataTransactionDa
 	lastModifiedDate: number;
 	dataTxId: string;
 	dataContentType: DataContentType;
+	// NOTE: `isHidden` is intentionally not declared here — this interface extends the
+	// Record<string, JsonSerializable> index type, which an optional `boolean | undefined`
+	// property cannot satisfy. It is read (and narrowed) directly in buildEntity below.
 }
 export abstract class ArFSFileBuilder<T extends ArFSPublicFile | ArFSPrivateFile> extends ArFSFileOrFolderBuilder<
 	'file',
@@ -35,6 +38,7 @@ export abstract class ArFSFileBuilder<T extends ArFSPublicFile | ArFSPrivateFile
 	lastModifiedDate?: UnixTime;
 	dataTxId?: TransactionID;
 	dataContentType?: DataContentType;
+	isHidden?: boolean;
 
 	getGqlQueryParameters(): GQLTagInterface[] {
 		return [
@@ -48,7 +52,14 @@ export abstract class ArFSFileBuilder<T extends ArFSPublicFile | ArFSPrivateFile
 		return tags.filter((tag) => tag.name !== 'File-Id');
 	}
 
-	protected readonly protectedDataJsonKeys = ['name', 'size', 'lastModifiedDate', 'dataTxId', 'dataContentType'];
+	protected readonly protectedDataJsonKeys = [
+		'name',
+		'size',
+		'lastModifiedDate',
+		'dataTxId',
+		'dataContentType',
+		'isHidden'
+	];
 }
 
 export class ArFSPublicFileBuilder extends ArFSFileBuilder<ArFSPublicFile> {
@@ -84,6 +95,7 @@ export class ArFSPublicFileBuilder extends ArFSFileBuilder<ArFSPublicFile> {
 			this.lastModifiedDate = new UnixTime(dataJSON.lastModifiedDate);
 			this.dataTxId = new TransactionID(dataJSON.dataTxId);
 			this.dataContentType = dataJSON.dataContentType || extToMime(this.name);
+			this.isHidden = typeof dataJSON.isHidden === 'boolean' ? dataJSON.isHidden : undefined;
 
 			const fileBuilderValidation = new FileBuilderValidation();
 			fileBuilderValidation.validateFileProperties(this);
@@ -91,27 +103,27 @@ export class ArFSPublicFileBuilder extends ArFSFileBuilder<ArFSPublicFile> {
 
 			this.parseCustomMetaDataFromDataJson(dataJSON);
 
-			return Promise.resolve(
-				new ArFSPublicFile(
-					this.appName,
-					this.appVersion ?? '',
-					this.arFS,
-					this.contentType,
-					this.driveId,
-					this.name,
-					this.txId,
-					this.unixTime,
-					this.parentFolderId,
-					this.entityId,
-					this.size,
-					this.lastModifiedDate,
-					this.dataTxId,
-					this.dataContentType,
-					this.boost,
-					this.customMetaData.metaDataGqlTags,
-					this.customMetaData.metaDataJson
-				)
+			const publicFile = new ArFSPublicFile(
+				this.appName,
+				this.appVersion ?? '',
+				this.arFS,
+				this.contentType,
+				this.driveId,
+				this.name,
+				this.txId,
+				this.unixTime,
+				this.parentFolderId,
+				this.entityId,
+				this.size,
+				this.lastModifiedDate,
+				this.dataTxId,
+				this.dataContentType,
+				this.boost,
+				this.customMetaData.metaDataGqlTags,
+				this.customMetaData.metaDataJson
 			);
+			publicFile.isHidden = this.isHidden;
+			return Promise.resolve(publicFile);
 		}
 		throw new Error('Invalid file state');
 	}
@@ -194,6 +206,7 @@ export class ArFSPrivateFileBuilder extends ArFSFileBuilder<ArFSPrivateFile> {
 			this.lastModifiedDate = new UnixTime(decryptedFileJSON.lastModifiedDate);
 			this.dataTxId = new TransactionID(decryptedFileJSON.dataTxId);
 			this.dataContentType = decryptedFileJSON.dataContentType || extToMime(this.name);
+			this.isHidden = typeof decryptedFileJSON.isHidden === 'boolean' ? decryptedFileJSON.isHidden : undefined;
 
 			const fileBuilderValidation = new FileBuilderValidation();
 			fileBuilderValidation.validateFileProperties(this);
@@ -201,7 +214,7 @@ export class ArFSPrivateFileBuilder extends ArFSFileBuilder<ArFSPrivateFile> {
 
 			this.parseCustomMetaDataFromDataJson(decryptedFileJSON);
 
-			return new ArFSPrivateFile(
+			const privateFile = new ArFSPrivateFile(
 				this.appName,
 				this.appVersion ?? '',
 				this.arFS,
@@ -224,6 +237,8 @@ export class ArFSPrivateFileBuilder extends ArFSFileBuilder<ArFSPrivateFile> {
 				this.customMetaData.metaDataGqlTags,
 				this.customMetaData.metaDataJson
 			);
+			privateFile.isHidden = this.isHidden;
+			return privateFile;
 		}
 		throw new Error('Invalid file state');
 	}

--- a/src/arfs/arfs_builders/arfs_folder_builders.ts
+++ b/src/arfs/arfs_builders/arfs_folder_builders.ts
@@ -30,6 +30,8 @@ export abstract class ArFSFolderBuilder<T extends ArFSPublicFolder | ArFSPrivate
 	'folder',
 	T
 > {
+	isHidden?: boolean;
+
 	protected async parseFromArweaveNode(node?: GQLNodeInterface, owner?: ArweaveAddress): Promise<GQLTagInterface[]> {
 		const tags = await super.parseFromArweaveNode(node, owner);
 		return tags.filter((tag) => tag.name !== 'Folder-Id');
@@ -42,7 +44,7 @@ export abstract class ArFSFolderBuilder<T extends ArFSPublicFolder | ArFSPrivate
 		];
 	}
 
-	protected readonly protectedDataJsonKeys = ['name'];
+	protected readonly protectedDataJsonKeys = ['name', 'isHidden'];
 }
 
 export class ArFSPublicFolderBuilder extends ArFSFolderBuilder<ArFSPublicFolder> {
@@ -83,25 +85,26 @@ export class ArFSPublicFolderBuilder extends ArFSFolderBuilder<ArFSPublicFolder>
 			if (!this.name) {
 				throw new Error('Invalid public folder state: name not found!');
 			}
+			this.isHidden = typeof dataJSON.isHidden === 'boolean' ? dataJSON.isHidden : undefined;
 			this.parseCustomMetaDataFromDataJson(dataJSON);
 
-			return Promise.resolve(
-				new ArFSPublicFolder(
-					this.appName,
-					this.appVersion ?? '',
-					this.arFS,
-					this.contentType,
-					this.driveId,
-					this.name,
-					this.txId,
-					this.unixTime,
-					this.parentFolderId,
-					this.entityId,
-					this.boost,
-					this.customMetaData.metaDataGqlTags,
-					this.customMetaData.metaDataJson
-				)
+			const publicFolder = new ArFSPublicFolder(
+				this.appName,
+				this.appVersion ?? '',
+				this.arFS,
+				this.contentType,
+				this.driveId,
+				this.name,
+				this.txId,
+				this.unixTime,
+				this.parentFolderId,
+				this.entityId,
+				this.boost,
+				this.customMetaData.metaDataGqlTags,
+				this.customMetaData.metaDataJson
 			);
+			publicFolder.isHidden = this.isHidden;
+			return Promise.resolve(publicFolder);
 		}
 		throw new Error('Invalid public folder state');
 	}
@@ -187,10 +190,12 @@ export class ArFSPrivateFolderBuilder extends ArFSFolderBuilder<ArFSPrivateFolde
 			if (!this.name) {
 				throw new Error('Invalid private folder state: name not found!');
 			}
+			this.isHidden =
+				typeof decryptedFolderJSON.isHidden === 'boolean' ? decryptedFolderJSON.isHidden : undefined;
 
 			this.parseCustomMetaDataFromDataJson(decryptedFolderJSON);
 
-			return new ArFSPrivateFolder(
+			const privateFolder = new ArFSPrivateFolder(
 				this.appName,
 				this.appVersion ?? '',
 				this.arFS,
@@ -208,6 +213,8 @@ export class ArFSPrivateFolderBuilder extends ArFSFolderBuilder<ArFSPrivateFolde
 				this.customMetaData.metaDataGqlTags,
 				this.customMetaData.metaDataJson
 			);
+			privateFolder.isHidden = this.isHidden;
+			return privateFolder;
 		}
 		throw new Error('Invalid private folder state');
 	}

--- a/src/arfs/arfs_entities.ts
+++ b/src/arfs/arfs_entities.ts
@@ -258,6 +258,11 @@ export interface ArFSFileFolderEntity extends ArFSEntity {
 export abstract class ArFSFileOrFolderEntity<T extends 'file' | 'folder'>
 	extends ArFSEntity implements ArFSFileFolderEntity
 {
+	// Set from the entity metadata JSON when present (mirrors ardrive-web). Undefined when the
+	// field is absent, so hidden-visibility filtering stays a consumer concern. Populated by the
+	// builders after construction to avoid threading through every positional entity constructor.
+	public isHidden?: boolean;
+
 	constructor(
 		appName: string,
 		appVersion: string,
@@ -386,6 +391,7 @@ export class ArFSPublicFileWithPaths extends ArFSPublicFile implements ArFSWithP
 			entity.customMetaDataGqlTags,
 			entity.customMetaDataJson
 		);
+		this.isHidden = entity.isHidden;
 
 		this.path = `${hierarchy.pathToFolderId(entity.parentFolderId)}${entity.name}`;
 		this.txIdPath = `${hierarchy.txPathToFolderId(entity.parentFolderId)}${entity.txId}`;
@@ -473,6 +479,7 @@ export class ArFSPrivateFileWithPaths extends ArFSPrivateFile implements ArFSWit
 			entity.customMetaDataGqlTags,
 			entity.customMetaDataJson
 		);
+		this.isHidden = entity.isHidden;
 
 		this.path = `${hierarchy.pathToFolderId(entity.parentFolderId)}${entity.name}`;
 		this.txIdPath = `${hierarchy.txPathToFolderId(entity.parentFolderId)}${entity.txId}`;
@@ -522,6 +529,7 @@ export class ArFSPrivateFileKeyless extends ArFSPrivateFile {
 			entity.customMetaDataGqlTags,
 			entity.customMetaDataJson
 		);
+		this.isHidden = entity.isHidden;
 		// @ts-expect-error
 		delete this.driveKey;
 		// @ts-expect-error
@@ -589,6 +597,7 @@ export class ArFSPublicFolderWithPaths extends ArFSPublicFolder implements ArFSW
 			entity.customMetaDataGqlTags,
 			entity.customMetaDataJson
 		);
+		this.isHidden = entity.isHidden;
 
 		this.path = `${hierarchy.pathToFolderId(entity.parentFolderId)}${entity.name}`;
 		this.txIdPath = `${hierarchy.txPathToFolderId(entity.parentFolderId)}${entity.txId}`;
@@ -662,6 +671,7 @@ export class ArFSPrivateFolderWithPaths extends ArFSPrivateFolder implements ArF
 			entity.customMetaDataGqlTags,
 			entity.customMetaDataJson
 		);
+		this.isHidden = entity.isHidden;
 
 		this.path = `${hierarchy.pathToFolderId(entity.parentFolderId)}${entity.name}`;
 		this.txIdPath = `${hierarchy.txPathToFolderId(entity.parentFolderId)}${entity.txId}`;
@@ -702,6 +712,7 @@ export class ArFSPrivateFolderKeyless extends ArFSPrivateFolder {
 			entity.customMetaDataGqlTags,
 			entity.customMetaDataJson
 		);
+		this.isHidden = entity.isHidden;
 		// @ts-expect-error
 		delete this.driveKey;
 	}

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -141,6 +141,10 @@ import {
 	ArFSRenamePublicDriveParams,
 	ArFSRenamePublicFolderParams,
 	ArFSRenamePrivateFileParams,
+	ArFSHidePublicFileParams,
+	ArFSHidePrivateFileParams,
+	ArFSHidePublicFolderParams,
+	ArFSHidePrivateFolderParams,
 	ArFSPrepareFileParams,
 	ArFSPrepareFileResult,
 	CommunityTipSettings,
@@ -2294,6 +2298,157 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 			folder.driveId,
 			folder.entityId,
 			await ArFSPrivateFolderTransactionData.from(newName, driveKey, folder.customMetaDataJson),
+			folder.parentFolderId,
+			folder.customMetaDataGqlTags
+		);
+
+		const { id, dataCaches, fastFinalityIndexes } = await this.uploadMetaData(
+			objectMetaData,
+			metadataRewardSettings
+		);
+
+		// Invalidate any cached entry
+		const owner = await this.getDriveOwnerForFolderId(folder.entityId);
+		this.caches.privateFolderCache.remove({ folderId: folder.entityId, owner, driveKey });
+
+		return {
+			entityId: folder.folderId,
+			metaDataTxId: id,
+			metaDataTxReward: metadataRewardSettings?.reward,
+			driveKey,
+			dataCaches,
+			fastFinalityIndexes
+		};
+	}
+
+	// Hide/unhide: writes a new metadata revision that only flips `isHidden`. Structurally a no-op
+	// rename — the entity's name, size, dataTxId and (critically) lastModifiedDate are re-written
+	// unchanged, so downstream edit-detection that keys on lastModifiedDate sees no change.
+	public async hidePublicFile({
+		file,
+		isHidden,
+		metadataRewardSettings
+	}: ArFSHidePublicFileParams): Promise<ArFSRenamePublicFileResult> {
+		const entityId = file.fileId;
+		const objectMetaData = new ArFSPublicFileMetaDataPrototype(
+			new ArFSPublicFileMetadataTransactionData(
+				file.name,
+				file.size,
+				file.lastModifiedDate,
+				file.dataTxId,
+				file.dataContentType,
+				file.customMetaDataJson,
+				isHidden
+			),
+			file.driveId,
+			entityId,
+			file.parentFolderId,
+			file.customMetaDataGqlTags
+		);
+
+		const { id, dataCaches, fastFinalityIndexes } = await this.uploadMetaData(
+			objectMetaData,
+			metadataRewardSettings
+		);
+
+		// Invalidate any cached entry
+		const owner = await this.getDriveOwnerForFileId(entityId);
+		this.caches.publicFileCache.remove({ fileId: entityId, owner });
+
+		return {
+			entityId,
+			metaDataTxId: id,
+			metaDataTxReward: metadataRewardSettings?.reward,
+			dataCaches,
+			fastFinalityIndexes
+		};
+	}
+
+	public async hidePrivateFile({
+		file,
+		isHidden,
+		metadataRewardSettings,
+		driveKey
+	}: ArFSHidePrivateFileParams): Promise<ArFSRenamePrivateFileResult> {
+		const entityId = file.fileId;
+		const objectMetaData = new ArFSPrivateFileMetaDataPrototype(
+			await ArFSPrivateFileMetadataTransactionData.from(
+				file.name,
+				file.size,
+				file.lastModifiedDate,
+				file.dataTxId,
+				file.dataContentType,
+				entityId,
+				driveKey,
+				file.customMetaDataJson,
+				isHidden
+			),
+			file.driveId,
+			entityId,
+			file.parentFolderId,
+			file.customMetaDataGqlTags
+		);
+
+		const { id, dataCaches, fastFinalityIndexes } = await this.uploadMetaData(
+			objectMetaData,
+			metadataRewardSettings
+		);
+
+		// Invalidate any cached entry
+		const owner = await this.getDriveOwnerForFileId(entityId);
+		this.caches.privateFileCache.remove({ fileId: entityId, fileKey: file.fileKey, owner });
+
+		return {
+			entityId,
+			metaDataTxId: id,
+			metaDataTxReward: metadataRewardSettings?.reward,
+			fileKey: file.fileKey,
+			dataCaches,
+			fastFinalityIndexes
+		};
+	}
+
+	public async hidePublicFolder({
+		folder,
+		isHidden,
+		metadataRewardSettings
+	}: ArFSHidePublicFolderParams): Promise<ArFSRenamePublicFolderResult> {
+		const objectMetaData = new ArFSPublicFolderMetaDataPrototype(
+			new ArFSPublicFolderTransactionData(folder.name, folder.customMetaDataJson, isHidden),
+			folder.driveId,
+			folder.entityId,
+			folder.parentFolderId,
+			folder.customMetaDataGqlTags
+		);
+
+		const { id, dataCaches, fastFinalityIndexes } = await this.uploadMetaData(
+			objectMetaData,
+			metadataRewardSettings
+		);
+
+		// Invalidate any cached entry
+		const owner = await this.getDriveOwnerForFolderId(folder.entityId);
+		this.caches.publicFolderCache.remove({ folderId: folder.entityId, owner });
+
+		return {
+			entityId: folder.folderId,
+			metaDataTxId: id,
+			metaDataTxReward: metadataRewardSettings?.reward,
+			dataCaches,
+			fastFinalityIndexes
+		};
+	}
+
+	public async hidePrivateFolder({
+		folder,
+		isHidden,
+		metadataRewardSettings,
+		driveKey
+	}: ArFSHidePrivateFolderParams): Promise<ArFSRenamePrivateFolderResult> {
+		const objectMetaData = new ArFSPrivateFolderMetaDataPrototype(
+			folder.driveId,
+			folder.entityId,
+			await ArFSPrivateFolderTransactionData.from(folder.name, driveKey, folder.customMetaDataJson, isHidden),
 			folder.parentFolderId,
 			folder.customMetaDataGqlTags
 		);

--- a/src/arfs/hide_unhide.test.ts
+++ b/src/arfs/hide_unhide.test.ts
@@ -1,0 +1,363 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// `as any` is used to stub the DAO's private methods (uploadMetaData / getDriveOwnerFor*),
+// matching the established pattern in multi_chunk_tx_uploader.test.ts.
+import { expect } from 'chai';
+import { stub } from 'sinon';
+
+import {
+	fakeArweave,
+	stubTxID,
+	stubEntityID,
+	stubArweaveAddress,
+	getStubDriveKey,
+	stubPublicFile,
+	stubPrivateFile,
+	stubPublicFolder
+} from '../../tests/stubs';
+import { readJWKFile, gatewayUrlForArweave } from '../utils/common';
+import { GatewayAPI } from '../utils/gateway_api';
+import { fileDecrypt, deriveFileKey } from '../utils/crypto';
+import { ByteCount, UnixTime, GQLNodeInterface, DriveKey } from '../types';
+
+import {
+	ArFSPublicFileMetadataTransactionData,
+	ArFSPrivateFileMetadataTransactionData,
+	ArFSPublicFolderTransactionData,
+	ArFSPrivateFolderTransactionData
+} from './tx/arfs_tx_data_types';
+import { ArFSPublicFileBuilder, ArFSPrivateFileBuilder } from './arfs_builders/arfs_file_builders';
+import { ArFSPublicFolderBuilder, ArFSPrivateFolderBuilder } from './arfs_builders/arfs_folder_builders';
+import { ArFSDAO } from './arfsdao';
+import { ArFSTagSettings } from './arfs_tag_settings';
+
+const wallet = readJWKFile('./test_wallet.json');
+
+const gatewayApi = new GatewayAPI({
+	gatewayUrl: gatewayUrlForArweave(fakeArweave),
+	maxRetriesPerRequest: 1,
+	initialErrorDelayMS: 1
+});
+
+// A deliberately non-zero lastModifiedDate so we can prove hide/unhide is a genuine no-op that
+// never bumps it (desktop edit-detection keys on this field).
+const NAME = 'stub-name';
+const LAST_MODIFIED = new UnixTime(1699999999);
+const SIZE = new ByteCount(2048);
+const CONTENT_TYPE = 'text/plain';
+
+function publicFileNode(): GQLNodeInterface {
+	return {
+		id: `${stubTxID}`,
+		tags: [
+			{ name: 'App-Name', value: 'ArDrive-CLI' },
+			{ name: 'App-Version', value: '1.2.0' },
+			{ name: 'ArFS', value: '0.15' },
+			{ name: 'Content-Type', value: 'application/json' },
+			{ name: 'Drive-Id', value: `${stubEntityID}` },
+			{ name: 'Entity-Type', value: 'file' },
+			{ name: 'Unix-Time', value: '1639073846' },
+			{ name: 'Parent-Folder-Id', value: `${stubEntityID}` },
+			{ name: 'File-Id', value: `${stubEntityID}` }
+		]
+	} as GQLNodeInterface;
+}
+
+function privateFileNode(cipherIV: string): GQLNodeInterface {
+	return {
+		id: `${stubTxID}`,
+		tags: [
+			{ name: 'App-Name', value: 'ArDrive-CLI' },
+			{ name: 'App-Version', value: '1.2.0' },
+			{ name: 'ArFS', value: '0.15' },
+			{ name: 'Content-Type', value: 'application/octet-stream' },
+			{ name: 'Drive-Id', value: `${stubEntityID}` },
+			{ name: 'Entity-Type', value: 'file' },
+			{ name: 'Unix-Time', value: '1639073846' },
+			{ name: 'Parent-Folder-Id', value: `${stubEntityID}` },
+			{ name: 'File-Id', value: `${stubEntityID}` },
+			{ name: 'Cipher', value: 'AES256-GCM' },
+			{ name: 'Cipher-IV', value: cipherIV }
+		]
+	} as GQLNodeInterface;
+}
+
+function publicFolderNode(): GQLNodeInterface {
+	return {
+		id: `${stubTxID}`,
+		tags: [
+			{ name: 'App-Name', value: 'ArDrive-CLI' },
+			{ name: 'App-Version', value: '1.2.0' },
+			{ name: 'ArFS', value: '0.15' },
+			{ name: 'Content-Type', value: 'application/json' },
+			{ name: 'Drive-Id', value: `${stubEntityID}` },
+			{ name: 'Entity-Type', value: 'folder' },
+			{ name: 'Unix-Time', value: '1639073846' },
+			{ name: 'Parent-Folder-Id', value: `${stubEntityID}` },
+			{ name: 'Folder-Id', value: `${stubEntityID}` }
+		]
+	} as GQLNodeInterface;
+}
+
+function privateFolderNode(cipherIV: string): GQLNodeInterface {
+	return {
+		id: `${stubTxID}`,
+		tags: [
+			{ name: 'App-Name', value: 'ArDrive-CLI' },
+			{ name: 'App-Version', value: '1.2.0' },
+			{ name: 'ArFS', value: '0.15' },
+			{ name: 'Content-Type', value: 'application/octet-stream' },
+			{ name: 'Drive-Id', value: `${stubEntityID}` },
+			{ name: 'Entity-Type', value: 'folder' },
+			{ name: 'Unix-Time', value: '1639073846' },
+			{ name: 'Parent-Folder-Id', value: `${stubEntityID}` },
+			{ name: 'Folder-Id', value: `${stubEntityID}` },
+			{ name: 'Cipher', value: 'AES256-GCM' },
+			{ name: 'Cipher-IV', value: cipherIV }
+		]
+	} as GQLNodeInterface;
+}
+
+describe('hide/unhide - metadata JSON tx-data conditional inclusion', () => {
+	it('public file: includes isHidden only when explicitly set', () => {
+		const withHidden = new ArFSPublicFileMetadataTransactionData(
+			NAME,
+			SIZE,
+			LAST_MODIFIED,
+			stubTxID,
+			CONTENT_TYPE,
+			{},
+			true
+		);
+		const hiddenJson = JSON.parse(withHidden.asTransactionData());
+		expect(hiddenJson.isHidden).to.equal(true);
+		expect(hiddenJson.name).to.equal(NAME);
+		expect(hiddenJson.lastModifiedDate).to.equal(+LAST_MODIFIED);
+
+		const shownJson = JSON.parse(
+			new ArFSPublicFileMetadataTransactionData(
+				NAME,
+				SIZE,
+				LAST_MODIFIED,
+				stubTxID,
+				CONTENT_TYPE,
+				{},
+				false
+			).asTransactionData()
+		);
+		expect(shownJson.isHidden).to.equal(false);
+
+		// Unset: the key must be entirely absent (mirrors ardrive-web includeIfNull:false)
+		const defaultJson = JSON.parse(
+			new ArFSPublicFileMetadataTransactionData(
+				NAME,
+				SIZE,
+				LAST_MODIFIED,
+				stubTxID,
+				CONTENT_TYPE
+			).asTransactionData()
+		);
+		expect('isHidden' in defaultJson).to.equal(false);
+	});
+
+	it('public folder: includes isHidden only when explicitly set', () => {
+		const hiddenJson = JSON.parse(new ArFSPublicFolderTransactionData(NAME, {}, true).asTransactionData());
+		expect(hiddenJson.isHidden).to.equal(true);
+
+		const defaultJson = JSON.parse(new ArFSPublicFolderTransactionData(NAME).asTransactionData());
+		expect('isHidden' in defaultJson).to.equal(false);
+	});
+
+	it('private file: isHidden lives inside the encrypted blob, not in cleartext', async () => {
+		const driveKey = await getStubDriveKey();
+		const txData = await ArFSPrivateFileMetadataTransactionData.from(
+			NAME,
+			SIZE,
+			LAST_MODIFIED,
+			stubTxID,
+			CONTENT_TYPE,
+			stubEntityID,
+			driveKey,
+			{},
+			true
+		);
+		const encrypted = txData.asTransactionData();
+		// Not present in cleartext
+		expect(encrypted.includes(Buffer.from('isHidden'))).to.equal(false);
+		// Present after decryption
+		const fileKey = await deriveFileKey(`${stubEntityID}`, driveKey);
+		const decrypted = JSON.parse((await fileDecrypt(txData.cipherIV, fileKey, encrypted)).toString());
+		expect(decrypted.isHidden).to.equal(true);
+		expect(decrypted.name).to.equal(NAME);
+	});
+
+	it('private folder: isHidden lives inside the encrypted blob; absent when unset', async () => {
+		const driveKey = await getStubDriveKey();
+		const hiddenTx = await ArFSPrivateFolderTransactionData.from(NAME, driveKey, {}, true);
+		const decryptedHidden = JSON.parse(
+			(await fileDecrypt(hiddenTx.cipherIV, driveKey, hiddenTx.asTransactionData())).toString()
+		);
+		expect(decryptedHidden.isHidden).to.equal(true);
+
+		const defaultTx = await ArFSPrivateFolderTransactionData.from(NAME, driveKey);
+		const decryptedDefault = JSON.parse(
+			(await fileDecrypt(defaultTx.cipherIV, driveKey, defaultTx.asTransactionData())).toString()
+		);
+		expect('isHidden' in decryptedDefault).to.equal(false);
+	});
+});
+
+describe('hide/unhide - builder round-trip surfaces isHidden on parsed entities', () => {
+	it('public file round-trip: isHidden true survives to the entity', async () => {
+		const txData = new ArFSPublicFileMetadataTransactionData(
+			NAME,
+			SIZE,
+			LAST_MODIFIED,
+			stubTxID,
+			CONTENT_TYPE,
+			{},
+			true
+		);
+		const node = publicFileNode();
+		const builder = ArFSPublicFileBuilder.fromArweaveNode(node, gatewayApi);
+		stub(builder, 'getDataForTxID').resolves(Buffer.from(txData.asTransactionData()));
+
+		const entity = await builder.build(node);
+		expect(entity.isHidden).to.equal(true);
+	});
+
+	it('public file round-trip: isHidden is undefined when the field is absent', async () => {
+		const txData = new ArFSPublicFileMetadataTransactionData(NAME, SIZE, LAST_MODIFIED, stubTxID, CONTENT_TYPE);
+		const node = publicFileNode();
+		const builder = ArFSPublicFileBuilder.fromArweaveNode(node, gatewayApi);
+		stub(builder, 'getDataForTxID').resolves(Buffer.from(txData.asTransactionData()));
+
+		const entity = await builder.build(node);
+		expect(entity.isHidden).to.equal(undefined);
+	});
+
+	it('private file round-trip (encrypted): isHidden true survives to the entity', async () => {
+		const driveKey = await getStubDriveKey();
+		const txData = await ArFSPrivateFileMetadataTransactionData.from(
+			NAME,
+			SIZE,
+			LAST_MODIFIED,
+			stubTxID,
+			CONTENT_TYPE,
+			stubEntityID,
+			driveKey,
+			{},
+			true
+		);
+		const node = privateFileNode(txData.cipherIV);
+		const builder = ArFSPrivateFileBuilder.fromArweaveNode(node, gatewayApi, driveKey);
+		stub(builder, 'getDataForTxID').resolves(txData.asTransactionData());
+
+		const entity = await builder.build(node);
+		expect(entity.isHidden).to.equal(true);
+	});
+
+	it('public folder round-trip: isHidden true survives to the entity', async () => {
+		const txData = new ArFSPublicFolderTransactionData(NAME, {}, true);
+		const node = publicFolderNode();
+		const builder = ArFSPublicFolderBuilder.fromArweaveNode(node, gatewayApi);
+		stub(builder, 'getDataForTxID').resolves(Buffer.from(txData.asTransactionData()));
+
+		const entity = await builder.build(node);
+		expect(entity.isHidden).to.equal(true);
+	});
+
+	it('private folder round-trip (encrypted): isHidden true survives to the entity', async () => {
+		const driveKey = await getStubDriveKey();
+		const txData = await ArFSPrivateFolderTransactionData.from(NAME, driveKey, {}, true);
+		const node = privateFolderNode(txData.cipherIV);
+		const builder = ArFSPrivateFolderBuilder.fromArweaveNode(node, gatewayApi, driveKey);
+		stub(builder, 'getDataForTxID').resolves(txData.asTransactionData());
+
+		const entity = await builder.build(node);
+		expect(entity.isHidden).to.equal(true);
+	});
+});
+
+describe('ArFSDAO hide/unhide writes a no-op revision that only flips isHidden', () => {
+	let arfsDao: ArFSDAO;
+
+	beforeEach(() => {
+		const arFSTagSettings = new ArFSTagSettings({ appName: 'Unit Test', appVersion: '1.2' });
+		arfsDao = new ArFSDAO(wallet, fakeArweave, true, 'Unit Test', '1.2', arFSTagSettings);
+		// Never touch the network or send a transaction
+		stub(arfsDao as any, 'getDriveOwnerForFileId').resolves(stubArweaveAddress());
+		stub(arfsDao as any, 'getDriveOwnerForFolderId').resolves(stubArweaveAddress());
+	});
+
+	it('hidePublicFile writes isHidden:true while preserving name and lastModifiedDate', async () => {
+		const uploadStub = stub(arfsDao as any, 'uploadMetaData').resolves({
+			id: stubTxID,
+			dataCaches: [],
+			fastFinalityIndexes: []
+		});
+		const file = stubPublicFile({ fileName: 'my-file' });
+
+		const result = await arfsDao.hidePublicFile({ file, isHidden: true });
+		expect(`${result.metaDataTxId}`).to.equal(`${stubTxID}`);
+
+		const objectMetaData = uploadStub.firstCall.args[0] as { objectData: ArFSPublicFileMetadataTransactionData };
+		const json = JSON.parse(objectMetaData.objectData.asTransactionData());
+		expect(json.isHidden).to.equal(true);
+		// No-op guarantees
+		expect(json.name).to.equal(file.name);
+		expect(json.lastModifiedDate).to.equal(+file.lastModifiedDate);
+	});
+
+	it('unhide path (hidePublicFile with isHidden:false) writes isHidden:false', async () => {
+		const uploadStub = stub(arfsDao as any, 'uploadMetaData').resolves({
+			id: stubTxID,
+			dataCaches: [],
+			fastFinalityIndexes: []
+		});
+		const file = stubPublicFile({ fileName: 'my-file' });
+
+		await arfsDao.hidePublicFile({ file, isHidden: false });
+
+		const objectMetaData = uploadStub.firstCall.args[0] as { objectData: ArFSPublicFileMetadataTransactionData };
+		const json = JSON.parse(objectMetaData.objectData.asTransactionData());
+		expect(json.isHidden).to.equal(false);
+	});
+
+	it('hidePublicFolder writes isHidden:true while preserving name', async () => {
+		const uploadStub = stub(arfsDao as any, 'uploadMetaData').resolves({
+			id: stubTxID,
+			dataCaches: [],
+			fastFinalityIndexes: []
+		});
+		const folder = stubPublicFolder({ folderName: 'my-folder' });
+
+		await arfsDao.hidePublicFolder({ folder, isHidden: true });
+
+		const objectMetaData = uploadStub.firstCall.args[0] as { objectData: ArFSPublicFolderTransactionData };
+		const json = JSON.parse(objectMetaData.objectData.asTransactionData());
+		expect(json.isHidden).to.equal(true);
+		expect(json.name).to.equal(folder.name);
+	});
+
+	it('hidePrivateFile writes isHidden:true inside the encrypted blob (no-op on lastModifiedDate)', async () => {
+		const uploadStub = stub(arfsDao as any, 'uploadMetaData').resolves({
+			id: stubTxID,
+			dataCaches: [],
+			fastFinalityIndexes: []
+		});
+		const driveKey: DriveKey = await getStubDriveKey();
+		const file = await stubPrivateFile({ fileName: 'my-private-file' });
+
+		await arfsDao.hidePrivateFile({ file, isHidden: true, driveKey });
+
+		const objectMetaData = uploadStub.firstCall.args[0] as { objectData: ArFSPrivateFileMetadataTransactionData };
+		const encrypted = objectMetaData.objectData.asTransactionData() as Buffer;
+		// Not in cleartext
+		expect(encrypted.includes(Buffer.from('isHidden'))).to.equal(false);
+		const fileKey = await deriveFileKey(`${file.fileId}`, driveKey);
+		const json = JSON.parse((await fileDecrypt(objectMetaData.objectData.cipherIV, fileKey, encrypted)).toString());
+		expect(json.isHidden).to.equal(true);
+		expect(json.name).to.equal(file.name);
+		expect(json.lastModifiedDate).to.equal(+file.lastModifiedDate);
+	});
+});

--- a/src/arfs/tx/arfs_tx_data_types.ts
+++ b/src/arfs/tx/arfs_tx_data_types.ts
@@ -142,21 +142,36 @@ export class ArFSPrivateDriveTransactionData extends ArFSDriveTransactionData {
 	}
 }
 
-export abstract class ArFSFolderTransactionData extends ArFSObjectTransactionData {}
+export abstract class ArFSFolderTransactionData extends ArFSObjectTransactionData {
+	protected static get protectedDataJsonFields(): string[] {
+		const dataJsonFields = super.protectedDataJsonFields;
+
+		// `isHidden` is a first-class metadata field (mirrors ardrive-web); reserve its name from custom metadata
+		dataJsonFields.push('isHidden');
+
+		return dataJsonFields;
+	}
+}
 
 export class ArFSPublicFolderTransactionData extends ArFSFolderTransactionData {
-	private baseDataJson: { name: string };
+	private baseDataJson: { name: string; isHidden?: boolean };
 	private fullDataJson: EntityMetaDataTransactionData;
 
 	constructor(
 		private readonly name: string,
-		protected readonly dataJsonCustomMetaData: CustomMetaDataJsonFields = {}
+		protected readonly dataJsonCustomMetaData: CustomMetaDataJsonFields = {},
+		// Only serialized when explicitly set (mirrors ardrive-web's includeIfNull:false),
+		// so ordinary renames never start emitting an `isHidden` field.
+		private readonly isHidden?: boolean
 	) {
 		super();
 
 		this.baseDataJson = {
 			name: this.name
 		};
+		if (this.isHidden !== undefined) {
+			this.baseDataJson.isHidden = this.isHidden;
+		}
 
 		this.fullDataJson = ArFSPublicFolderTransactionData.parseCustomDataJsonFields(
 			this.baseDataJson,
@@ -183,11 +198,16 @@ export class ArFSPrivateFolderTransactionData extends ArFSFolderTransactionData 
 	static async from(
 		name: string,
 		driveKey: DriveKey,
-		dataJsonCustomMetaData: CustomMetaDataJsonFields = {}
+		dataJsonCustomMetaData: CustomMetaDataJsonFields = {},
+		// Only serialized when explicitly set (mirrors ardrive-web's includeIfNull:false)
+		isHidden?: boolean
 	): Promise<ArFSPrivateFolderTransactionData> {
-		const baseDataJson = {
+		const baseDataJson: { name: string; isHidden?: boolean } = {
 			name: name
 		};
+		if (isHidden !== undefined) {
+			baseDataJson.isHidden = isHidden;
+		}
 		const fullDataJson = ArFSPrivateFolderTransactionData.parseCustomDataJsonFields(
 			baseDataJson,
 			dataJsonCustomMetaData
@@ -213,13 +233,15 @@ export abstract class ArFSFileMetadataTransactionData extends ArFSObjectTransact
 		dataJsonFields.push('lastModifiedDate');
 		dataJsonFields.push('dataTxId');
 		dataJsonFields.push('dataContentType');
+		// `isHidden` is a first-class metadata field (mirrors ardrive-web); reserve its name from custom metadata
+		dataJsonFields.push('isHidden');
 
 		return dataJsonFields;
 	}
 }
 
 export class ArFSPublicFileMetadataTransactionData extends ArFSFileMetadataTransactionData {
-	private baseDataJson: FileMetaDataTransactionData;
+	private baseDataJson: FileMetaDataTransactionData & { isHidden?: boolean };
 	private fullDataJson: EntityMetaDataTransactionData;
 
 	constructor(
@@ -228,7 +250,10 @@ export class ArFSPublicFileMetadataTransactionData extends ArFSFileMetadataTrans
 		private readonly lastModifiedDate: UnixTime,
 		private readonly dataTxId: TransactionID,
 		private readonly dataContentType: DataContentType,
-		private readonly dataJsonCustomMetaData: CustomMetaDataJsonFields = {}
+		private readonly dataJsonCustomMetaData: CustomMetaDataJsonFields = {},
+		// Only serialized when explicitly set (mirrors ardrive-web's includeIfNull:false),
+		// so ordinary renames never start emitting an `isHidden` field.
+		private readonly isHidden?: boolean
 	) {
 		super();
 
@@ -239,6 +264,9 @@ export class ArFSPublicFileMetadataTransactionData extends ArFSFileMetadataTrans
 			dataTxId: `${this.dataTxId}`,
 			dataContentType: this.dataContentType
 		};
+		if (this.isHidden !== undefined) {
+			this.baseDataJson.isHidden = this.isHidden;
+		}
 
 		this.fullDataJson = ArFSPublicFileMetadataTransactionData.parseCustomDataJsonFields(
 			this.baseDataJson,
@@ -270,15 +298,27 @@ export class ArFSPrivateFileMetadataTransactionData extends ArFSFileMetadataTran
 		dataContentType: DataContentType,
 		fileId: FileID,
 		driveKey: DriveKey,
-		dataJsonCustomMetaData: CustomMetaDataJsonFields = {}
+		dataJsonCustomMetaData: CustomMetaDataJsonFields = {},
+		// Only serialized when explicitly set (mirrors ardrive-web's includeIfNull:false)
+		isHidden?: boolean
 	): Promise<ArFSPrivateFileMetadataTransactionData> {
-		const baseDataJson = {
+		const baseDataJson: {
+			name: string;
+			size: number;
+			lastModifiedDate: number;
+			dataTxId: string;
+			dataContentType: DataContentType;
+			isHidden?: boolean;
+		} = {
 			name: name,
 			size: +size,
 			lastModifiedDate: +lastModifiedDate,
 			dataTxId: `${dataTxId}`,
 			dataContentType: dataContentType
 		};
+		if (isHidden !== undefined) {
+			baseDataJson.isHidden = isHidden;
+		}
 		const fullDataJson = ArFSPrivateFileMetadataTransactionData.parseCustomDataJsonFields(
 			baseDataJson,
 			dataJsonCustomMetaData

--- a/src/types/ardrive_types.ts
+++ b/src/types/ardrive_types.ts
@@ -277,6 +277,21 @@ export interface RenamePublicDriveParams {
 
 export type RenamePrivateDriveParams = RenamePublicDriveParams & WithDriveKey;
 
+// Hide/unhide: writes a new metadata revision that flips the entity's `isHidden` flag.
+// Structurally a no-op rename (name and lastModifiedDate are preserved). Mirrors ardrive-web.
+// NOTE: drive-level hide is intentionally deferred (see CORE-4); file/folder scope only.
+export interface HidePublicFileParams {
+	fileId: FileID;
+}
+
+export type HidePrivateFileParams = HidePublicFileParams & WithDriveKey;
+
+export interface HidePublicFolderParams {
+	folderId: FolderID;
+}
+
+export type HidePrivateFolderParams = HidePublicFolderParams & WithDriveKey;
+
 export interface BasePublicFileRetryParams {
 	wrappedFile: ArFSFileToUpload;
 	dataTxId: TransactionID;

--- a/src/types/arfsdao_types.ts
+++ b/src/types/arfsdao_types.ts
@@ -207,6 +207,29 @@ export type ArFSRenamePrivateDriveParams = ArFSRenamePublicDriveParams &
 		drive: ArFSPrivateDrive;
 	};
 
+// Hide/unhide params. The `isHidden` boolean is data (hide=true, unhide=false), so a single DAO
+// method per entity kind serves both directions. Drive-level hide intentionally deferred (CORE-4).
+export interface ArFSHideParams {
+	isHidden: boolean;
+	metadataRewardSettings?: RewardSettings;
+}
+
+export interface ArFSHidePublicFileParams extends ArFSHideParams {
+	file: ArFSPublicFile;
+}
+export type ArFSHidePrivateFileParams = ArFSHidePublicFileParams &
+	WithDriveKey & {
+		file: ArFSPrivateFile;
+	};
+
+export interface ArFSHidePublicFolderParams extends ArFSHideParams {
+	folder: ArFSPublicFolder;
+}
+export type ArFSHidePrivateFolderParams = ArFSHidePublicFolderParams &
+	WithDriveKey & {
+		folder: ArFSPrivateFolder;
+	};
+
 export type CommunityTipSettings = {
 	communityTipTarget: ArweaveAddress;
 	communityWinstonTip: Winston;


### PR DESCRIPTION
## What

Adds hide/unhide for files and folders, public and private, to the Node ArDrive API — 8 public methods:

    hidePublicFile / unhidePublicFile
    hidePrivateFile / unhidePrivateFile
    hidePublicFolder / unhidePublicFolder
    hidePrivateFolder / unhidePrivateFolder

## How (ardrive-web parity)

Hiding writes a plain new metadata revision that sets `isHidden` in the entity's metadata JSON — cleartext for public entities, inside the encrypted blob for private ones. Structurally a "no-op rename that flips one boolean," mirroring ardrive-web:

- `isHidden` is a JSON field, NOT a GQL tag.
- Emitted only when explicitly set (includeIfNull:false parity), so ordinary renames never begin emitting it.
- ArFS version stays 0.15 (no spec bump).
- No cascade — hiding a folder writes exactly one revision for that folder.
- Filtering/visibility of hidden entities is the consumer's job; core-js only writes the revision and surfaces `isHidden` on parsed entities.

## No-op lastModifiedDate guarantee

Hide/unhide re-write the entity's existing name, size, dataTxId and lastModifiedDate unchanged, toggling only `isHidden`. lastModifiedDate is never bumped on the wire — downstream edit-detection (e.g. ArDrive Desktop) that keys on it sees no change. Asserted by tests.

## Layers touched

params (ArDrive + DAO) → ArDrive (8 methods) → ArFSDAO (4 methods, parameterized by an isHidden boolean) → tx-data JSON → builders → entities. Entity plumbing uses a settable `isHidden?` field populated by the builders to avoid changing any positional constructor signature (no blast radius on existing rename/move/upload call sites).

## Tests

New `src/arfs/hide_unhide.test.ts` (14 tests, all mocked — no funds spent): tx-data conditional inclusion (public + private + absent), builder round-trip surfacing isHidden (public + private, file + folder, present + absent), and DAO-level hide→true / unhide→false asserting name and lastModifiedDate are preserved (public + private).

## Deferred (cheap follow-ups)

- Drive-level hide (hidePublicDrive/etc.) — not needed by the initial consumer; mirrors these methods against the drive layer.
- Web ArDrive parity (ArDriveWeb / ArFSDAOAuthenticatedBase) — the shared tx-data/builders/entities already support it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hide and unhide actions for both public and private files and folders.
  * Visibility toggles are metadata-only: hidden items preserve their name, size, and last modified date.

* **Bug Fixes**
  * Improved metadata reading so the hidden status is parsed correctly for both plain (public) and encrypted (private) items.

* **Tests**
  * Added automated coverage for hide/unhide behavior, metadata parsing (including undefined states), and round-trip validation for files and folders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->