### PR TITLE
fix(arfs): throw a clear error when a drive GQL query returns zero edges

### DIFF
--- a/src/arfs/arfsdao.test.ts
+++ b/src/arfs/arfsdao.test.ts
@@ -1030,6 +1030,73 @@ describe('The ArFSDAO class', () => {
 	});
 });
 
+// These GQL empty-edges guard tests live in their own describe with a minimal
+// fixture that does NOT derive a stub drive key, so they exercise the drive
+// lookup guards directly without depending on private-key crypto helpers.
+describe('The ArFSDAO class GQL empty-edges guards', () => {
+	const emptyEdgesWallet = readJWKFile('./test_wallet.json');
+	const emptyEdgesArweave = Arweave.init({
+		host: 'localhost',
+		port: 443,
+		protocol: 'https',
+		timeout: 600000
+	});
+	const emptyEdgesTagSettings = new ArFSTagSettings({ appName: 'ArFSDAO-Test', appVersion: '1.0' });
+
+	let emptyEdgesGatewayApi: GatewayAPI;
+	let emptyEdgesDao: ArFSDAO;
+
+	beforeEach(() => {
+		emptyEdgesGatewayApi = new GatewayAPI({ gatewayUrl: new URL('http://test.net:1337') });
+		const caches: ArFSCache = {
+			...defaultArFSAnonymousCache,
+			privateDriveCache: new PromiseCache<ArFSPrivateDriveCacheKey, ArFSPrivateDrive>(defaultCacheParams),
+			privateFolderCache: new PromiseCache<ArFSPrivateFolderCacheKey, ArFSPrivateFolder>(defaultCacheParams),
+			privateFileCache: new PromiseCache<ArFSPrivateFileCacheKey, ArFSPrivateFile>(defaultCacheParams),
+			privateConflictCache: new PromiseCache<ArFSPrivateFolderCacheKey, NameConflictInfo>(defaultCacheParams),
+			publicConflictCache: new PromiseCache<ArFSPublicFolderCacheKey, NameConflictInfo>(defaultCacheParams)
+		};
+		emptyEdgesDao = new ArFSDAO(
+			emptyEdgesWallet,
+			emptyEdgesArweave,
+			true,
+			'ArFSDAO-Test',
+			'1.0',
+			emptyEdgesTagSettings,
+			caches,
+			emptyEdgesGatewayApi
+		);
+	});
+
+	describe('getDriveSignatureInfo function', () => {
+		it('throws a clear "drive not found" error when the GQL query returns zero edges', async () => {
+			stub(emptyEdgesGatewayApi, 'gqlRequest').resolves({
+				edges: [],
+				pageInfo: { hasNextPage: false }
+			});
+
+			await expectAsyncErrorThrow({
+				promiseToError: emptyEdgesDao.getDriveSignatureInfo(stubEntityID, stubArweaveAddress()),
+				errorMessage: `Drive with Drive-Id "${stubEntityID}" not found (check the drive id and that the owner address is correct)`
+			});
+		});
+	});
+
+	describe('isPublicDrive function', () => {
+		it('throws a clear "drive not found" error when the GQL query returns zero edges', async () => {
+			stub(emptyEdgesGatewayApi, 'gqlRequest').resolves({
+				edges: [],
+				pageInfo: { hasNextPage: false }
+			});
+
+			await expectAsyncErrorThrow({
+				promiseToError: emptyEdgesDao.isPublicDrive(stubEntityID, stubArweaveAddress()),
+				errorMessage: `Drive with Drive-Id "${stubEntityID}" not found (check the drive id and that the owner address is correct)`
+			});
+		});
+	});
+});
+
 const entityIdRegex = /^[a-f\d]{8}-([a-f\d]{4}-){3}[a-f\d]{12}$/i;
 const txIdRegex = /^(\w|-){43}$/;
 

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -235,6 +235,18 @@ export interface ArFSCache extends ArFSAnonymousCache {
 	privateConflictCache: PromiseCache<ArFSPrivateFolderCacheKey, NameConflictInfo>;
 }
 
+/**
+ * Throws a clear "drive not found" error when a drive GQL query returns zero edges,
+ * so callers get an actionable message instead of a `TypeError` from `edges[0]`.
+ */
+function assertDriveEdgesFound(driveId: DriveID, edges: GQLEdgeInterface[]): void {
+	if (!edges.length) {
+		throw new Error(
+			`Drive with Drive-Id "${driveId}" not found (check the drive id and that the owner address is correct)`
+		);
+	}
+}
+
 export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 	private readonly signer?: ArweaveSigner;
 
@@ -1513,11 +1525,7 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 
 		const driveTransactions = await this.gatewayApi.gqlRequest(gqlDriveQuery);
 
-		if (!driveTransactions.edges.length) {
-			throw new Error(
-				`Drive with Drive-Id "${driveId}" not found (check the drive id and that the owner address is correct)`
-			);
-		}
+		assertDriveEdgesFound(driveId, driveTransactions.edges);
 
 		const drivePrivacyFromTag = driveTransactions.edges[0].node.tags.find(
 			(t) => t.name === gqlTagNameRecord.drivePrivacy
@@ -1932,11 +1940,7 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 
 		const transactions = await this.gatewayApi.gqlRequest(gqlQuery);
 
-		if (!transactions.edges.length) {
-			throw new Error(
-				`Drive with Drive-Id "${driveId}" not found (check the drive id and that the owner address is correct)`
-			);
-		}
+		assertDriveEdgesFound(driveId, transactions.edges);
 
 		const drivePrivacyFromTag = transactions.edges[0].node.tags.find(
 			(t) => t.name === gqlTagNameRecord.drivePrivacy

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -1513,6 +1513,12 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 
 		const driveTransactions = await this.gatewayApi.gqlRequest(gqlDriveQuery);
 
+		if (!driveTransactions.edges.length) {
+			throw new Error(
+				`Drive with Drive-Id "${driveId}" not found (check the drive id and that the owner address is correct)`
+			);
+		}
+
 		const drivePrivacyFromTag = driveTransactions.edges[0].node.tags.find(
 			(t) => t.name === gqlTagNameRecord.drivePrivacy
 		);
@@ -1925,6 +1931,12 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 		});
 
 		const transactions = await this.gatewayApi.gqlRequest(gqlQuery);
+
+		if (!transactions.edges.length) {
+			throw new Error(
+				`Drive with Drive-Id "${driveId}" not found (check the drive id and that the owner address is correct)`
+			);
+		}
 
 		const drivePrivacyFromTag = transactions.edges[0].node.tags.find(
 			(t) => t.name === gqlTagNameRecord.drivePrivacy


### PR DESCRIPTION
## Problem
`ArDrive.getPrivateDrive` (via `getDriveSignatureInfo`) and `isPublicDrive` read `edges[0].node` from the GraphQL response with **no empty-edges guard**. When a drive query returns zero edges — e.g. a wrong/missing owner, or a gateway whose index doesn't (yet) hold that drive — they throw an opaque `TypeError: Cannot read properties of undefined (reading 'node')` instead of a clear "drive not found".

Found via real on-chain testing (ArDrive Desktop): querying an incomplete-index gateway for a drive absent from that index crashed with the cryptic `TypeError` on every drive, rather than a usable error.

## Fix
Guard the empty-edges case in `getDriveSignatureInfo` and `isPublicDrive` — throw a clear, actionable error:
> `Drive with Drive-Id "<id>" not found (check the drive id and that the owner address is correct)`

The three drive builders (`ArFSPublicDriveBuilder` / `ArFSPrivateDriveBuilder` / `SafeArFSDriveBuilder`) already guard empty edges via the shared `parseFromArweaveNode`; these two standalone GQL calls were the remaining unguarded `edges[0]` sites (audited all 8 `edges[0]` usages — no others needed a guard).

## Tests
Adds 2 tests in `arfsdao.test.ts` asserting both functions throw the clear "not found" error (not `TypeError`) when the GQL query returns `edges: []`. Build + the new tests pass on top of current `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drive lookup handling when no matching results are returned from the network.
  * Added clearer error messages for missing drives instead of failing on empty results.
  * Strengthened checks for both public and signature-based drive lookups.
* **Tests**
  * Added coverage for empty search results to verify the new error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->