### PR TITLE
chore(release): v4.0.1 — hide/unhide (#270) + zero-edge guard (#271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1] - 2026-07-05
+
+Additive, backward-compatible release off `master` (all changes land after the
+`v4.0.0` tag). No breaking changes; peer ranges (node/arweave/turbo) unchanged.
+
+### Added
+
+- **File & folder hide / unhide support** (#270, [CORE-4]): new `ArDrive` methods
+  `hidePublicFile` / `unhidePublicFile`, `hidePublicFolder` / `unhidePublicFolder`,
+  `hidePrivateFile` / `unhidePrivateFile`, `hidePrivateFolder` / `unhidePrivateFolder`,
+  and `hidePublicDrive`. Entities are hidden via an ArFS metadata revision (`Hidden`
+  state) rather than deletion, so the operation is reversible and preserves history.
+  Adds the corresponding `Hide*Params` types to the public API.
+- **`prepare` build hook** (#270): building `lib/` now runs automatically on install,
+  so consumers can depend on a git commit ref (e.g. GitHub install) and still receive
+  compiled output without a manual build step.
+
+### Fixed
+
+- **Clear error on empty drive GQL result** (#271): drive-metadata GraphQL queries that
+  return zero edges now throw a descriptive error (via the extracted
+  `assertDriveEdgesFound` helper) instead of failing later with an opaque
+  undefined-access error. Improves diagnosability of transient gateway/404 responses.
+
 ## [3.1.0] - 2025-10-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ardrive-core-js",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"description": "ArDrive Core contains the essential back end application features to support the ArDrive CLI and Desktop apps, such as file management, Permaweb upload/download, wallet management and other common functions.",
 	"main": "./lib/exports.js",
 	"types": "./lib/exports.d.ts",


### PR DESCRIPTION
Prepares the **4.0.1** release off `master` (additive/backward-compatible; all changes land after the `v4.0.0` tag).

## What's in it
- **#270** file/folder hide/unhide + install-time `prepare` build hook (CORE-4)
- **#271** clear error on zero-edge drive GQL result (owner-scoped robustness)
- `getDriveSignatureInfo` (already in the 4.x line) — the desktop's private-drive v1/v2 unlock (PRIV-SIG-1) depends on it

## Why this release
The desktop app currently pins `^3.0.3`, which **lacks hide/unhide AND getDriveSignatureInfo**. Published `4.0.0` also lacks hide/unhide (those commits are post-tag on master). This cuts a clean release the desktop can pin to.

## Verified (2026-07-05)
- core-js: `tsc` clean; **692 tests pass** (1 env-only failure = arlocal needs a local node).
- Desktop pinned to this build via tarball: typecheck + build clean, **556 tests, zero delta**; both `getDriveSignatureInfo` and all 8 hide/unhide methods confirmed present + callable.

## To publish (owner action)
```
git checkout master && git merge --ff-only release/4.0.1-prep
npm ci && npm publish --access public
git tag v4.0.1 && git push origin master v4.0.1
```

Snapshot consumption (CORE-3), CORE-5 (unixTime tolerance), and CORE-6 (private-listing) are verified on separate branches and will follow in **4.1.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reversible hide/unhide support for files, folders, and entire drives.
  * Introduced new API options for managing hide-related actions.
  * Build files are now prepared automatically during installation.

* **Bug Fixes**
  * Improved error handling when drive information is missing, with a clearer message instead of a generic failure.

* **Chores**
  * Bumped the package version to 4.0.1.
  * Updated the release notes with the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->