### PR TITLE
test(arfs): fix flaky MultiChunkTxUploader before-hook timeout

### DIFF
--- a/src/arfs/multi_chunk_tx_uploader.test.ts
+++ b/src/arfs/multi_chunk_tx_uploader.test.ts
@@ -22,7 +22,12 @@ describe('MultiChunkTxUploader class', () => {
 	let txWithOneChunkOfData: Transaction;
 	let txWithTwentyChunksOfData: Transaction;
 
-	before(async () => {
+	// Regular function (not an arrow) so mocha's `this.timeout` applies. This hook
+	// does genuinely expensive LOCAL crypto — RSA wallet generation + creating,
+	// signing, and chunk-hashing a 5 MB transaction, twice — with no network. Under
+	// CI load that intermittently exceeds mocha's 5s default, so give it real headroom.
+	before(async function () {
+		this.timeout(60_000);
 		const wallet = await arweave.wallets.generate();
 
 		const oneChunkOfData = new Uint8Array(5);


### PR DESCRIPTION
The `MultiChunkTxUploader` `before` hook does expensive **local** crypto — RSA wallet generation + creating, signing, and chunk-hashing a **5 MB** transaction, twice (no network; the gateway is stubbed). It routinely takes 20–40s and intermittently exceeds mocha's **5s default**, failing the `build` job under CI load (seen on PR #272 — the parallel `test` job passed the same suite, the tell-tale sign of a flake).

**Fix:** convert the arrow `before(async () => …)` to a regular `function` so mocha's `this.timeout` applies, and set `this.timeout(60_000)`.

**Verified:** isolated MultiChunkTxUploader run **12/12 passing** across repeated runs (one took 37s — far over the old 5s), zero timeouts. `tsc` clean.

Unblocks reliable CI for the incoming 4.1.0 batch (snapshots + robustness fixes) which all run through this same workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)