### PR TITLE
perf(gql): page size 100→1000 + bounded fetch concurrency (~10× fewer GraphQL requests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Bounded per-batch entity-fetch concurrency (CORE-9)**: turning a page of GraphQL
+  edges into built entities does a per-entity metadata GET, and every fan-out site did
+  so for the whole page at once (`Promise.all`/`Promise.allSettled(edges.map(...))`).
+  After CORE-7 raised the page size 100 → 1000 that meant up to ~1000 concurrent
+  metadata fetches per host per batch — a ~10x jump in peak parallelism that spikes
+  memory and open connections and risks gateway rate-limits. Concurrency is now
+  DECOUPLED from page size: a new bounded-concurrency helper (`src/utils/concurrency.ts`,
+  `mapWithConcurrency` / `mapSettledWithConcurrency`) processes each batch in
+  concurrency-limited waves capped at `MAX_CONCURRENT_ENTITY_FETCHES = 30`
+  (`src/utils/constants.ts`). So a 1000-entity page still costs ~10x fewer GraphQL
+  round-trips (CORE-7) while at most 30 entity fetches are ever in flight at once
+  (~3x below the pre-CORE-7 worst case of 100). Applied at every per-entity-fetch
+  fan-out: both incremental-sync DAOs' `processFolder/FileBatch`, the full-listing
+  walks (`getAllDrivesForAddress`, `getPublic/PrivateFilesWithParentFolderIds`,
+  `getAllFoldersOfPublic/PrivateDrive`, `getEntitiesInFolder`), the snapshot-tail
+  builders (`buildPublic/PrivateFolders/FilesFromNodes` — snapshot nodes build from
+  the seeded metadata cache with no fetch, only the live tail fetches), and the web
+  authenticated DAO's private folder/file listings. The change is internal and
+  additive: the helpers preserve input order, run each item exactly once, and keep the
+  exact `Promise.all` (reject-on-any) vs `Promise.allSettled` + `failedEntities`
+  semantics of the site they replace, so the entity SET returned is identical — only
+  parallelism is bounded. Pagination, the CORE-7 `hasNextPage` safety and the #43
+  per-type early-stop are unchanged. The inline CORE-8 "keep the file/folder incremental
+  queries separate" note was also softened to clarify that only a NAIVE shared-counter
+  merge would drop entities (a per-type-counter merge could be safe); the queries stay
+  split because merging is a ~zero-latency win now that the two walks already run in
+  parallel via `Promise.all`.
+  - _Follow-up (CORE-10, not in this change):_ a failed per-entity metadata fetch in the
+    incremental DAOs is still counted (`failedEntities`) and logged but not retried — a
+    transient fetch failure can silently drop that entity from the batch. That is a
+    pre-existing data-integrity concern, tracked separately as CORE-10; this change only
+    bounds concurrency and does not add retry logic.
+
 - **GraphQL page size 100 → 1000 (CORE-7)**: every paged `transactions(first: …)`
   GraphQL walk now requests the gateway maximum of 1000 entities per page instead
   of 100, via a single shared `GQL_PAGE_SIZE` constant (`src/utils/constants.ts`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **GraphQL page size 100 → 1000 (CORE-7)**: every paged `transactions(first: …)`
+  GraphQL walk now requests the gateway maximum of 1000 entities per page instead
+  of 100, via a single shared `GQL_PAGE_SIZE` constant (`src/utils/constants.ts`).
+  This covers `buildQuery`'s default `pageLimit` (used by all listing/drive/folder
+  walks), the `batchSize` default in both incremental-sync DAOs
+  (`arfsdao_incremental_sync`, `arfsdao_anonymous_incremental_sync`), and the
+  snapshot-listing query (`buildSnapshotQuery`). Fetching a drive of N entities now
+  costs `ceil(N/1000)` page requests rather than `ceil(N/100)` — roughly a 10x
+  reduction in GraphQL round-trips — with no change to the set of entities returned.
+  Pagination remains strictly cursor + `pageInfo.hasNextPage` driven, so it stays
+  correct even against a gateway that silently returns fewer than `first` entities
+  for a page (gateways cap `first` at 1000): it keeps following the cursor until
+  `hasNextPage` is false and never drops an entity. `batchSize` remains an additive
+  per-call override (public API unchanged; a smaller value only changes round-trip
+  count). The separate file/folder incremental queries were intentionally left
+  un-consolidated to preserve their per-type early-stop correctness (see CORE-8
+  note in the DAOs).
+
 ## [4.1.0] - 2026-07-05
 
 Additive minor over 4.0.1 (hide/unhide). Converges four independently-verified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,23 +42,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     pre-existing data-integrity concern, tracked separately as CORE-10; this change only
     bounds concurrency and does not add retry logic.
 
-- **GraphQL page size 100 → 1000 (CORE-7)**: every paged `transactions(first: …)`
-  GraphQL walk now requests the gateway maximum of 1000 entities per page instead
-  of 100, via a single shared `GQL_PAGE_SIZE` constant (`src/utils/constants.ts`).
-  This covers `buildQuery`'s default `pageLimit` (used by all listing/drive/folder
+- **GraphQL page size 100 → 1000, now tunable (CORE-7)**: every paged
+  `transactions(first: …)` GraphQL walk now requests the gateway maximum of 1000
+  entities per page instead of 100. `GQL_PAGE_SIZE = 1000` (the documented ar.io
+  default/max) stays in `src/utils/constants.ts`, but the per-page default is now a
+  **process-global, tunable value** read through a new `getGqlPageSize()` /
+  `setGqlPageSize(pageSize)` accessor pair (both exported from the package). This lets a
+  consumer (e.g. the ArDrive desktop app) lower the default for a GraphQL gateway that
+  caps `first:` **below** the 1000 ar.io max — Goldsky, for instance — with a single
+  `setGqlPageSize(100)` call; `setGqlPageSize` validates its argument is an integer in
+  `[1, 1000]` and throws `RangeError` otherwise. The default is read at CALL time by the
+  query builders, so a `setGqlPageSize()` made after import takes effect on subsequent
+  queries. It drives `buildQuery`'s default `first:` (used by all listing/drive/folder
   walks), the `batchSize` default in both incremental-sync DAOs
   (`arfsdao_incremental_sync`, `arfsdao_anonymous_incremental_sync`), and the
   snapshot-listing query (`buildSnapshotQuery`). Fetching a drive of N entities now
-  costs `ceil(N/1000)` page requests rather than `ceil(N/100)` — roughly a 10x
-  reduction in GraphQL round-trips — with no change to the set of entities returned.
-  Pagination remains strictly cursor + `pageInfo.hasNextPage` driven, so it stays
-  correct even against a gateway that silently returns fewer than `first` entities
-  for a page (gateways cap `first` at 1000): it keeps following the cursor until
-  `hasNextPage` is false and never drops an entity. `batchSize` remains an additive
-  per-call override (public API unchanged; a smaller value only changes round-trip
-  count). The separate file/folder incremental queries were intentionally left
-  un-consolidated to preserve their per-type early-stop correctness (see CORE-8
-  note in the DAOs).
+  costs `ceil(N/pageSize)` page requests (`ceil(N/1000)` at the default) rather than
+  `ceil(N/100)` — roughly a 10x reduction in GraphQL round-trips at the default — with
+  no change to the set of entities returned. Pagination remains strictly cursor +
+  `pageInfo.hasNextPage` driven, so it stays correct even against a gateway that silently
+  returns fewer than `first` entities for a page (or one capped below 1000): it keeps
+  following the cursor until `hasNextPage` is false and never drops an entity. Explicit
+  per-call overrides (`first`, `batchSize`) still win over the configured default (public
+  API unchanged; a smaller value only changes round-trip count). The separate file/folder
+  incremental queries were intentionally left un-consolidated to preserve their per-type
+  early-stop correctness (see CORE-8 note in the DAOs).
 
 ## [4.1.0] - 2026-07-05
 

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -92,8 +92,10 @@ import {
 	ENCRYPTED_DATA_PLACEHOLDER,
 	defaultTurboPaymentUrl,
 	defaultTurboUploadUrl,
-	gqlTagNameRecord
+	gqlTagNameRecord,
+	MAX_CONCURRENT_ENTITY_FETCHES
 } from '../utils/constants';
+import { mapWithConcurrency } from '../utils/concurrency';
 import { PrivateKeyData } from './private_key_data';
 import {
 	EID,
@@ -1662,27 +1664,32 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 			const { edges } = transactions;
 			hasNextPage = transactions.pageInfo.hasNextPage;
 
-			const folderPromises: Promise<ArFSPrivateFolder | null>[] = edges.map(async (edge: GQLEdgeInterface) => {
-				try {
-					cursor = edge.cursor;
-					const { node } = edge;
-					const folderBuilder = ArFSPrivateFolderBuilder.fromArweaveNode(node, this.gatewayApi, driveKey);
-					// Build the folder so that we don't add something invalid to the cache
-					const folder = await folderBuilder.build(node);
-					const cacheKey = { folderId: folder.entityId, owner, driveKey };
-					return this.caches.privateFolderCache.put(cacheKey, Promise.resolve(folder));
-				} catch (e) {
-					// If the folder is broken, skip it
-					if (e instanceof SyntaxError) {
-						console.error(`Error building folder. Skipping... Error: ${e}`);
-						return null;
+			// Bounded fan-out: build at most MAX_CONCURRENT_ENTITY_FETCHES folders at a time so a
+			// full (1000-edge) page does not put ~1000 metadata GETs on the gateway at once
+			// [CORE-9]. Order-preserving and skip-on-broken semantics unchanged.
+			const folders = await mapWithConcurrency(
+				edges,
+				MAX_CONCURRENT_ENTITY_FETCHES,
+				async (edge: GQLEdgeInterface) => {
+					try {
+						cursor = edge.cursor;
+						const { node } = edge;
+						const folderBuilder = ArFSPrivateFolderBuilder.fromArweaveNode(node, this.gatewayApi, driveKey);
+						// Build the folder so that we don't add something invalid to the cache
+						const folder = await folderBuilder.build(node);
+						const cacheKey = { folderId: folder.entityId, owner, driveKey };
+						return this.caches.privateFolderCache.put(cacheKey, Promise.resolve(folder));
+					} catch (e) {
+						// If the folder is broken, skip it
+						if (e instanceof SyntaxError) {
+							console.error(`Error building folder. Skipping... Error: ${e}`);
+							return null;
+						}
+
+						throw e;
 					}
-
-					throw e;
 				}
-			});
-
-			const folders = await Promise.all(folderPromises);
+			);
 
 			// Filter out null values
 			const validFolders = folders.filter((f) => f !== null) as ArFSPrivateFolder[];
@@ -1717,46 +1724,53 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 			const transactions = await this.gatewayApi.gqlRequest(gqlQuery);
 			const { edges } = transactions;
 			hasNextPage = transactions.pageInfo.hasNextPage;
-			const files: Promise<ArFSPrivateFile | null>[] = edges.map(async (edge: GQLEdgeInterface) => {
-				try {
-					const { node } = edge;
-					cursor = edge.cursor;
-					const fileBuilder = ArFSPrivateFileBuilder.fromArweaveNode(node, this.gatewayApi, driveKey);
-					// Build the file so that we don't add something invalid to the cache
-					const file = await fileBuilder.build(node);
-					const fileKey: FileKey = await deriveFileKey(`${file.fileId}`, driveKey);
-					const cacheKey = {
-						fileId: file.fileId,
-						owner,
-						fileKey
-					};
-					return this.caches.privateFileCache.put(cacheKey, Promise.resolve(file));
-				} catch (e) {
-					// CORE-6: Tolerate individual broken private files instead of aborting the
-					// whole drive listing. When a private file's data cannot be decrypted,
-					// fileDecrypt() swallows the error and returns the "Error" sentinel buffer,
-					// so JSON.parse() of the "decrypted" metadata throws a SyntaxError. The public
-					// file-listing path (getPublicFilesWithParentFolderIds) and the private
-					// folder-listing path (getAllFoldersOfPrivateDrive) already skip such entities;
-					// the private file path did not, so one undecryptable/incomplete file killed
-					// the entire private-drive reconstruction. Mirror the public path exactly:
-					// skip SyntaxError (unparseable/undecryptable metadata) and
-					// InvalidFileStateException (metadata missing required properties), but keep
-					// re-throwing any other error so genuine/unexpected failures are not masked.
-					if (e instanceof SyntaxError) {
-						console.error(`Error building file. Skipping... Error: ${e}`);
-						return null;
-					}
+			// Bounded fan-out: build at most MAX_CONCURRENT_ENTITY_FETCHES files at a time so a
+			// full (1000-edge) page does not put ~1000 metadata GETs on the gateway at once
+			// [CORE-9]. Order-preserving and skip-on-broken semantics unchanged.
+			const files = await mapWithConcurrency(
+				edges,
+				MAX_CONCURRENT_ENTITY_FETCHES,
+				async (edge: GQLEdgeInterface) => {
+					try {
+						const { node } = edge;
+						cursor = edge.cursor;
+						const fileBuilder = ArFSPrivateFileBuilder.fromArweaveNode(node, this.gatewayApi, driveKey);
+						// Build the file so that we don't add something invalid to the cache
+						const file = await fileBuilder.build(node);
+						const fileKey: FileKey = await deriveFileKey(`${file.fileId}`, driveKey);
+						const cacheKey = {
+							fileId: file.fileId,
+							owner,
+							fileKey
+						};
+						return this.caches.privateFileCache.put(cacheKey, Promise.resolve(file));
+					} catch (e) {
+						// CORE-6: Tolerate individual broken private files instead of aborting the
+						// whole drive listing. When a private file's data cannot be decrypted,
+						// fileDecrypt() swallows the error and returns the "Error" sentinel buffer,
+						// so JSON.parse() of the "decrypted" metadata throws a SyntaxError. The public
+						// file-listing path (getPublicFilesWithParentFolderIds) and the private
+						// folder-listing path (getAllFoldersOfPrivateDrive) already skip such entities;
+						// the private file path did not, so one undecryptable/incomplete file killed
+						// the entire private-drive reconstruction. Mirror the public path exactly:
+						// skip SyntaxError (unparseable/undecryptable metadata) and
+						// InvalidFileStateException (metadata missing required properties), but keep
+						// re-throwing any other error so genuine/unexpected failures are not masked.
+						if (e instanceof SyntaxError) {
+							console.error(`Error building file. Skipping... Error: ${e}`);
+							return null;
+						}
 
-					if (e instanceof InvalidFileStateException) {
-						console.error(`Error building file. Skipping... Error: ${e}`);
-						return null;
-					}
+						if (e instanceof InvalidFileStateException) {
+							console.error(`Error building file. Skipping... Error: ${e}`);
+							return null;
+						}
 
-					throw e;
+						throw e;
+					}
 				}
-			});
-			const validFiles = (await Promise.all(files)).filter((f) => f !== null) as ArFSPrivateFile[];
+			);
+			const validFiles = files.filter((f) => f !== null) as ArFSPrivateFile[];
 			allFiles.push(...validFiles);
 		}
 		return latestRevisionsOnly ? allFiles.filter(latestRevisionFilter) : allFiles;
@@ -1794,22 +1808,28 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 			const { edges } = transactions;
 			hasNextPage = transactions.pageInfo.hasNextPage;
 
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const folders: Promise<T>[] = (edges as any).map(async (edge: GQLEdgeInterface) => {
-				const { node } = edge;
-				cursor = edge.cursor;
-				const { tags } = node;
+			// Bounded fan-out: build at most MAX_CONCURRENT_ENTITY_FETCHES entities at a time so a
+			// full (1000-edge) page does not put ~1000 metadata GETs on the gateway at once
+			// [CORE-9]. Order-preserving and reject-on-any-failure semantics unchanged.
+			const folders = (await mapWithConcurrency(
+				edges,
+				MAX_CONCURRENT_ENTITY_FETCHES,
+				async (edge: GQLEdgeInterface) => {
+					const { node } = edge;
+					cursor = edge.cursor;
+					const { tags } = node;
 
-				// Check entityType to determine which builder to use
-				const entityType = tags.find((t) => t.name === 'Entity-Type')?.value;
-				if (!entityType || (entityType !== 'file' && entityType !== 'folder')) {
-					throw new Error('Entity-Type tag is missing or invalid!');
+					// Check entityType to determine which builder to use
+					const entityType = tags.find((t) => t.name === 'Entity-Type')?.value;
+					if (!entityType || (entityType !== 'file' && entityType !== 'folder')) {
+						throw new Error('Entity-Type tag is missing or invalid!');
+					}
+
+					return builder(node, entityType).build(node);
 				}
+			)) as T[];
 
-				return builder(node, entityType).build(node);
-			});
-
-			allEntities.push(...(await Promise.all(folders)));
+			allEntities.push(...folders);
 		}
 		return latestRevisionsOnly ? allEntities.filter(latestRevisionFilter) : allEntities;
 	}
@@ -2654,7 +2674,11 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 		driveKey: DriveKey,
 		owner: ArweaveAddress
 	): Promise<ArFSPrivateFolder[]> {
-		const folderPromises = nodes.map(async (node) => {
+		// Bounded fan-out: snapshot nodes build from the seeded metadata cache (no fetch) but
+		// the live-tail nodes each do a per-entity metadata GET; cap in-flight builds at
+		// MAX_CONCURRENT_ENTITY_FETCHES so a large tail does not swamp the gateway [CORE-9].
+		// Order-preserving and skip-on-broken semantics unchanged.
+		const folders = await mapWithConcurrency(nodes, MAX_CONCURRENT_ENTITY_FETCHES, async (node) => {
 			try {
 				const folderBuilder = ArFSPrivateFolderBuilder.fromArweaveNode(node, this.gatewayApi, driveKey);
 				const folder = await folderBuilder.build(node);
@@ -2669,7 +2693,6 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 				throw e;
 			}
 		});
-		const folders = await Promise.all(folderPromises);
 		return folders.filter((folder) => folder !== null) as ArFSPrivateFolder[];
 	}
 
@@ -2678,7 +2701,11 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 		driveKey: DriveKey,
 		owner: ArweaveAddress
 	): Promise<ArFSPrivateFile[]> {
-		const filePromises = nodes.map(async (node) => {
+		// Bounded fan-out: snapshot nodes build from the seeded metadata cache (no fetch) but
+		// the live-tail nodes each do a per-entity metadata GET; cap in-flight builds at
+		// MAX_CONCURRENT_ENTITY_FETCHES so a large tail does not swamp the gateway [CORE-9].
+		// Order-preserving and skip-on-broken semantics unchanged.
+		const files = await mapWithConcurrency(nodes, MAX_CONCURRENT_ENTITY_FETCHES, async (node) => {
 			try {
 				const fileBuilder = ArFSPrivateFileBuilder.fromArweaveNode(node, this.gatewayApi, driveKey);
 				const file = await fileBuilder.build(node);
@@ -2694,7 +2721,6 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 				throw e;
 			}
 		});
-		const files = await Promise.all(filePromises);
 		return files.filter((file) => file !== null) as ArFSPrivateFile[];
 	}
 

--- a/src/arfs/arfsdao_anonymous.ts
+++ b/src/arfs/arfsdao_anonymous.ts
@@ -29,7 +29,8 @@ import { ArFSPublicFolderBuilder } from './arfs_builders/arfs_folder_builders';
 import { ArFSPublicFileBuilder } from './arfs_builders/arfs_file_builders';
 import { ArFSDriveEntity, ArFSPublicDrive, ArFSPublicFile, ArFSPublicFolder } from './arfs_entities';
 import { PrivateKeyData } from './private_key_data';
-import { DEFAULT_APP_NAME, DEFAULT_APP_VERSION } from '../utils/constants';
+import { DEFAULT_APP_NAME, DEFAULT_APP_VERSION, MAX_CONCURRENT_ENTITY_FETCHES } from '../utils/constants';
+import { mapWithConcurrency } from '../utils/concurrency';
 import axios, { AxiosRequestConfig } from 'axios';
 import { Readable } from 'stream';
 import { join as joinPath } from 'path';
@@ -240,22 +241,29 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 			const { edges } = transactions;
 			hasNextPage = transactions.pageInfo.hasNextPage;
 
-			const drives: Promise<ArFSDriveEntity>[] = edges.map(async (edge: GQLEdgeInterface) => {
-				const { node } = edge;
-				cursor = edge.cursor;
+			// Bounded fan-out: build at most MAX_CONCURRENT_ENTITY_FETCHES drives at a time so a
+			// full (1000-edge) page does not put ~1000 metadata GETs on the gateway at once
+			// [CORE-9]. Order-preserving; the built set is identical to the prior Promise.all.
+			const drives = await mapWithConcurrency(
+				edges,
+				MAX_CONCURRENT_ENTITY_FETCHES,
+				async (edge: GQLEdgeInterface) => {
+					const { node } = edge;
+					cursor = edge.cursor;
 
-				const driveBuilder = SafeArFSDriveBuilder.fromArweaveNode(node, this.gatewayApi, privateKeyData);
-				const drive = await driveBuilder.build(node);
-				if (drive.drivePrivacy === 'public') {
-					const cacheKey = { driveId: drive.driveId, owner: address };
-					return this.caches.publicDriveCache.put(cacheKey, Promise.resolve(drive as ArFSPublicDrive));
-				} else {
-					// TODO: No access to private drive cache from here
-					return Promise.resolve(drive);
+					const driveBuilder = SafeArFSDriveBuilder.fromArweaveNode(node, this.gatewayApi, privateKeyData);
+					const drive = await driveBuilder.build(node);
+					if (drive.drivePrivacy === 'public') {
+						const cacheKey = { driveId: drive.driveId, owner: address };
+						return this.caches.publicDriveCache.put(cacheKey, Promise.resolve(drive as ArFSPublicDrive));
+					} else {
+						// TODO: No access to private drive cache from here
+						return Promise.resolve(drive);
+					}
 				}
-			});
+			);
 
-			allDrives.push(...(await Promise.all(drives)));
+			allDrives.push(...drives);
 		}
 
 		return latestRevisionsOnly ? allDrives.filter(latestRevisionFilterForDrives) : allDrives;
@@ -285,31 +293,38 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 			const transactions = await this.gatewayApi.gqlRequest(gqlQuery);
 			const { edges } = transactions;
 			hasNextPage = transactions.pageInfo.hasNextPage;
-			const files: Promise<ArFSPublicFile | null>[] = edges.map(async (edge: GQLEdgeInterface) => {
-				try {
-					const { node } = edge;
-					cursor = edge.cursor;
-					const fileBuilder = ArFSPublicFileBuilder.fromArweaveNode(node, this.gatewayApi);
-					const file = await fileBuilder.build(node);
-					const cacheKey = { fileId: file.fileId, owner };
-					return this.caches.publicFileCache.put(cacheKey, Promise.resolve(file));
-				} catch (e) {
-					// If the file is broken, skip it
-					if (e instanceof SyntaxError) {
-						console.error(`Error building file. Skipping... Error: ${e}`);
-						return null;
-					}
+			// Bounded fan-out: build at most MAX_CONCURRENT_ENTITY_FETCHES files at a time so a
+			// full (1000-edge) page does not put ~1000 metadata GETs on the gateway at once
+			// [CORE-9]. Order-preserving and skip-on-broken semantics unchanged.
+			const files = await mapWithConcurrency(
+				edges,
+				MAX_CONCURRENT_ENTITY_FETCHES,
+				async (edge: GQLEdgeInterface) => {
+					try {
+						const { node } = edge;
+						cursor = edge.cursor;
+						const fileBuilder = ArFSPublicFileBuilder.fromArweaveNode(node, this.gatewayApi);
+						const file = await fileBuilder.build(node);
+						const cacheKey = { fileId: file.fileId, owner };
+						return this.caches.publicFileCache.put(cacheKey, Promise.resolve(file));
+					} catch (e) {
+						// If the file is broken, skip it
+						if (e instanceof SyntaxError) {
+							console.error(`Error building file. Skipping... Error: ${e}`);
+							return null;
+						}
 
-					if (e instanceof InvalidFileStateException) {
-						console.error(`Error building file. Skipping... Error: ${e}`);
-						return null;
-					}
+						if (e instanceof InvalidFileStateException) {
+							console.error(`Error building file. Skipping... Error: ${e}`);
+							return null;
+						}
 
-					throw e;
+						throw e;
+					}
 				}
-			});
+			);
 
-			const validFiles = (await Promise.all(files)).filter((f) => f !== null) as ArFSPublicFile[];
+			const validFiles = files.filter((f) => f !== null) as ArFSPublicFile[];
 
 			allFiles.push(...validFiles);
 		}
@@ -339,27 +354,32 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 			const { edges } = transactions;
 
 			hasNextPage = transactions.pageInfo.hasNextPage;
-			const folderPromises = edges.map(async (edge: GQLEdgeInterface) => {
-				const { node } = edge;
-				cursor = edge.cursor;
-				try {
-					const folderBuilder = ArFSPublicFolderBuilder.fromArweaveNode(node, this.gatewayApi);
-					const folder = await folderBuilder.build(node);
-					const cacheKey = { folderId: folder.entityId, owner };
-					await this.caches.publicFolderCache.put(cacheKey, Promise.resolve(folder));
-					return folder;
-				} catch (e) {
-					// If the folder is broken, skip it
-					if (e instanceof SyntaxError) {
-						console.error(`Error building folder. Skipping... Error: ${e}`);
-						return null;
+			// Bounded fan-out: build at most MAX_CONCURRENT_ENTITY_FETCHES folders at a time so a
+			// full (1000-edge) page does not put ~1000 metadata GETs on the gateway at once
+			// [CORE-9]. Order-preserving and skip-on-broken semantics unchanged.
+			const folders = await mapWithConcurrency(
+				edges,
+				MAX_CONCURRENT_ENTITY_FETCHES,
+				async (edge: GQLEdgeInterface) => {
+					const { node } = edge;
+					cursor = edge.cursor;
+					try {
+						const folderBuilder = ArFSPublicFolderBuilder.fromArweaveNode(node, this.gatewayApi);
+						const folder = await folderBuilder.build(node);
+						const cacheKey = { folderId: folder.entityId, owner };
+						await this.caches.publicFolderCache.put(cacheKey, Promise.resolve(folder));
+						return folder;
+					} catch (e) {
+						// If the folder is broken, skip it
+						if (e instanceof SyntaxError) {
+							console.error(`Error building folder. Skipping... Error: ${e}`);
+							return null;
+						}
+
+						throw e;
 					}
-
-					throw e;
 				}
-			});
-
-			const folders = await Promise.all(folderPromises);
+			);
 
 			// Filter out null values
 			const validFolders = folders.filter((folder) => folder !== null) as ArFSPublicFolder[];
@@ -498,7 +518,11 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 		nodes: GQLNodeInterface[],
 		owner: ArweaveAddress
 	): Promise<ArFSPublicFolder[]> {
-		const folderPromises = nodes.map(async (node) => {
+		// Bounded fan-out: snapshot nodes build from the seeded metadata cache (no fetch) but
+		// the live-tail nodes each do a per-entity metadata GET; cap in-flight builds at
+		// MAX_CONCURRENT_ENTITY_FETCHES so a large tail does not swamp the gateway [CORE-9].
+		// Order-preserving and skip-on-broken semantics unchanged.
+		const folders = await mapWithConcurrency(nodes, MAX_CONCURRENT_ENTITY_FETCHES, async (node) => {
 			try {
 				const folderBuilder = ArFSPublicFolderBuilder.fromArweaveNode(node, this.gatewayApi);
 				const folder = await folderBuilder.build(node);
@@ -514,7 +538,6 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 				throw e;
 			}
 		});
-		const folders = await Promise.all(folderPromises);
 		return folders.filter((folder) => folder !== null) as ArFSPublicFolder[];
 	}
 
@@ -522,7 +545,11 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 		nodes: GQLNodeInterface[],
 		owner: ArweaveAddress
 	): Promise<ArFSPublicFile[]> {
-		const filePromises = nodes.map(async (node) => {
+		// Bounded fan-out: snapshot nodes build from the seeded metadata cache (no fetch) but
+		// the live-tail nodes each do a per-entity metadata GET; cap in-flight builds at
+		// MAX_CONCURRENT_ENTITY_FETCHES so a large tail does not swamp the gateway [CORE-9].
+		// Order-preserving and skip-on-broken semantics unchanged.
+		const files = await mapWithConcurrency(nodes, MAX_CONCURRENT_ENTITY_FETCHES, async (node) => {
 			try {
 				const fileBuilder = ArFSPublicFileBuilder.fromArweaveNode(node, this.gatewayApi);
 				const file = await fileBuilder.build(node);
@@ -537,7 +564,6 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 				throw e;
 			}
 		});
-		const files = await Promise.all(filePromises);
 		return files.filter((file) => file !== null) as ArFSPublicFile[];
 	}
 

--- a/src/arfs/arfsdao_anonymous_incremental_sync.ts
+++ b/src/arfs/arfsdao_anonymous_incremental_sync.ts
@@ -23,6 +23,7 @@ import { ArFSPublicFolderBuilder } from './arfs_builders/arfs_folder_builders';
 import { ArFSPublicFileBuilder } from './arfs_builders/arfs_file_builders';
 import { buildQuery } from '../utils/query';
 import { DESCENDING_ORDER } from '../utils/query';
+import { GQL_PAGE_SIZE } from '../utils/constants';
 import { incrementalMinBlock, selectLatestRevisions } from '../utils/sync_state';
 import { PromiseCache } from '@ardrive/ardrive-promise-cache';
 import { SyncStateStore } from '../utils/sync_state_store';
@@ -77,7 +78,13 @@ export class ArFSDAOAnonymousIncrementalSync extends ArFSDAOAnonymous {
 		owner: ArweaveAddress,
 		options: IncrementalSyncOptions = {}
 	): Promise<IncrementalSyncResult> {
-		const { syncState, includeRevisions = false, onProgress, batchSize = 100, stopAfterKnownCount = 10 } = options;
+		const {
+			syncState,
+			includeRevisions = false,
+			onProgress,
+			batchSize = GQL_PAGE_SIZE,
+			stopAfterKnownCount = 10
+		} = options;
 
 		const stats: SyncStats = {
 			totalProcessed: 0,
@@ -106,7 +113,21 @@ export class ArFSDAOAnonymousIncrementalSync extends ArFSDAOAnonymous {
 			// reconciled rather than silently missed.
 			const minBlock = incrementalMinBlock(syncState?.lastSyncedBlockHeight);
 
-			// Fetch all entities with optional block height filter
+			// Fetch folders and files as two SEPARATE paged queries, run concurrently.
+			//
+			// These are deliberately NOT merged into one `Entity-Type: [file, folder]`
+			// query [CORE-8]: each stream carries an independent `stopAfterKnownCount`
+			// early-stop that counts CONSECUTIVE already-known entities OF ITS OWN TYPE in
+			// descending block order. A single combined query would force one shared cursor,
+			// one pagination loop and therefore one shared early-stop counting known
+			// entities of EITHER type — which trips sooner and could stop paginating before
+			// a changed entity of one type that sits (in block order) just below a run of
+			// >= stopAfterKnownCount known entities of the other type, silently dropping it.
+			// The per-type early-stop is what preserves the no-dropped-entities invariant,
+			// so the query stays split. (Downstream selectLatestRevisions/detectChanges are
+			// order-independent, so combining would not help correctness — only request
+			// count, which the 1000-entity page size already reduces ~10x.) Running both in
+			// parallel means wall-clock latency is already ~max(folders, files), not the sum.
 			const [folders, files] = await Promise.all([
 				this.getIncrementalFolders(
 					driveId,

--- a/src/arfs/arfsdao_anonymous_incremental_sync.ts
+++ b/src/arfs/arfsdao_anonymous_incremental_sync.ts
@@ -23,7 +23,8 @@ import { ArFSPublicFolderBuilder } from './arfs_builders/arfs_folder_builders';
 import { ArFSPublicFileBuilder } from './arfs_builders/arfs_file_builders';
 import { buildQuery } from '../utils/query';
 import { DESCENDING_ORDER } from '../utils/query';
-import { GQL_PAGE_SIZE } from '../utils/constants';
+import { GQL_PAGE_SIZE, MAX_CONCURRENT_ENTITY_FETCHES } from '../utils/constants';
+import { mapSettledWithConcurrency } from '../utils/concurrency';
 import { incrementalMinBlock, selectLatestRevisions } from '../utils/sync_state';
 import { PromiseCache } from '@ardrive/ardrive-promise-cache';
 import { SyncStateStore } from '../utils/sync_state_store';
@@ -118,16 +119,19 @@ export class ArFSDAOAnonymousIncrementalSync extends ArFSDAOAnonymous {
 			// These are deliberately NOT merged into one `Entity-Type: [file, folder]`
 			// query [CORE-8]: each stream carries an independent `stopAfterKnownCount`
 			// early-stop that counts CONSECUTIVE already-known entities OF ITS OWN TYPE in
-			// descending block order. A single combined query would force one shared cursor,
-			// one pagination loop and therefore one shared early-stop counting known
-			// entities of EITHER type — which trips sooner and could stop paginating before
-			// a changed entity of one type that sits (in block order) just below a run of
+			// descending block order. Merging is not fundamentally unsafe — only a NAIVE
+			// merge is: a single combined query with ONE shared early-stop counter (counting
+			// known entities of EITHER type) trips sooner and could stop paginating before a
+			// changed entity of one type that sits (in block order) just below a run of
 			// >= stopAfterKnownCount known entities of the other type, silently dropping it.
-			// The per-type early-stop is what preserves the no-dropped-entities invariant,
-			// so the query stays split. (Downstream selectLatestRevisions/detectChanges are
-			// order-independent, so combining would not help correctness — only request
-			// count, which the 1000-entity page size already reduces ~10x.) Running both in
-			// parallel means wall-clock latency is already ~max(folders, files), not the sum.
+			// A combined query that kept a SEPARATE per-type counter (only stopping once both
+			// types have independently hit the threshold) would preserve the no-dropped-
+			// entities invariant just as well. The queries stay split simply because merging
+			// buys almost nothing: after CORE-7 the two walks already run in parallel via
+			// `Promise.all`, so wall-clock latency is ~max(folders, files) not the sum, and
+			// the ~10x round-trip reduction is already delivered by the 1000-entity page size.
+			// Downstream selectLatestRevisions/detectChanges are order-independent, so a merge
+			// would add per-type-counter/shared-cursor bookkeeping for a ~zero latency win.
 			const [folders, files] = await Promise.all([
 				this.getIncrementalFolders(
 					driveId,
@@ -350,7 +354,11 @@ export class ArFSDAOAnonymousIncrementalSync extends ArFSDAOAnonymous {
 		owner: ArweaveAddress,
 		stats: SyncStats
 	): Promise<ArFSPublicFolder[]> {
-		const folders: Promise<ArFSPublicFolder & { blockHeight: number }>[] = edges.map(async (edge) => {
+		// Bounded fan-out: build at most MAX_CONCURRENT_ENTITY_FETCHES entities at a time
+		// so a 1000-edge page (CORE-7) does not put ~1000 metadata GETs on the gateway at
+		// once [CORE-9]. Results stay index-aligned with `edges`, so order and the
+		// failedEntities accounting below are identical to the previous Promise.allSettled.
+		const results = await mapSettledWithConcurrency(edges, MAX_CONCURRENT_ENTITY_FETCHES, async (edge) => {
 			const { node } = edge;
 
 			// Update block height stats
@@ -388,7 +396,6 @@ export class ArFSDAOAnonymousIncrementalSync extends ArFSDAOAnonymous {
 			return Object.assign(folder, { blockHeight });
 		});
 
-		const results = await Promise.allSettled(folders);
 		const successfulFolders: (ArFSPublicFolder & { blockHeight: number })[] = [];
 
 		for (const result of results) {
@@ -412,7 +419,11 @@ export class ArFSDAOAnonymousIncrementalSync extends ArFSDAOAnonymous {
 		owner: ArweaveAddress,
 		stats: SyncStats
 	): Promise<ArFSPublicFile[]> {
-		const files: Promise<ArFSPublicFile & { blockHeight: number }>[] = edges.map(async (edge) => {
+		// Bounded fan-out: build at most MAX_CONCURRENT_ENTITY_FETCHES entities at a time
+		// so a 1000-edge page (CORE-7) does not put ~1000 metadata GETs on the gateway at
+		// once [CORE-9]. Results stay index-aligned with `edges`, so order and the
+		// failedEntities accounting below are identical to the previous Promise.allSettled.
+		const results = await mapSettledWithConcurrency(edges, MAX_CONCURRENT_ENTITY_FETCHES, async (edge) => {
 			const { node } = edge;
 
 			// Update block height stats
@@ -450,7 +461,6 @@ export class ArFSDAOAnonymousIncrementalSync extends ArFSDAOAnonymous {
 			return Object.assign(file, { blockHeight });
 		});
 
-		const results = await Promise.allSettled(files);
 		const successfulFiles: (ArFSPublicFile & { blockHeight: number })[] = [];
 
 		for (const result of results) {

--- a/src/arfs/arfsdao_anonymous_incremental_sync.ts
+++ b/src/arfs/arfsdao_anonymous_incremental_sync.ts
@@ -23,7 +23,7 @@ import { ArFSPublicFolderBuilder } from './arfs_builders/arfs_folder_builders';
 import { ArFSPublicFileBuilder } from './arfs_builders/arfs_file_builders';
 import { buildQuery } from '../utils/query';
 import { DESCENDING_ORDER } from '../utils/query';
-import { GQL_PAGE_SIZE, MAX_CONCURRENT_ENTITY_FETCHES } from '../utils/constants';
+import { getGqlPageSize, MAX_CONCURRENT_ENTITY_FETCHES } from '../utils/constants';
 import { mapSettledWithConcurrency } from '../utils/concurrency';
 import { incrementalMinBlock, selectLatestRevisions } from '../utils/sync_state';
 import { PromiseCache } from '@ardrive/ardrive-promise-cache';
@@ -83,7 +83,7 @@ export class ArFSDAOAnonymousIncrementalSync extends ArFSDAOAnonymous {
 			syncState,
 			includeRevisions = false,
 			onProgress,
-			batchSize = GQL_PAGE_SIZE,
+			batchSize = getGqlPageSize(),
 			stopAfterKnownCount = 10
 		} = options;
 

--- a/src/arfs/arfsdao_incremental_sync.ts
+++ b/src/arfs/arfsdao_incremental_sync.ts
@@ -35,6 +35,7 @@ import { ArFSPublicFolderCacheKey } from './arfsdao_anonymous';
 import { ArFSPrivateFolderCacheKey } from './arfsdao';
 import { buildQuery } from '../utils/query';
 import { DESCENDING_ORDER } from '../utils/query';
+import { GQL_PAGE_SIZE } from '../utils/constants';
 import { incrementalMinBlock, selectLatestRevisions } from '../utils/sync_state';
 import { PromiseCache } from '@ardrive/ardrive-promise-cache';
 import { ArFSDAOAnonymousIncrementalSync, ArFSIncrementalSyncCache } from './arfsdao_anonymous_incremental_sync';
@@ -121,7 +122,13 @@ export class ArFSDAOIncrementalSync extends ArFSDAO {
 		owner: ArweaveAddress,
 		options: IncrementalSyncOptions = {}
 	): Promise<IncrementalSyncResult> {
-		const { syncState, includeRevisions = false, onProgress, batchSize = 100, stopAfterKnownCount = 10 } = options;
+		const {
+			syncState,
+			includeRevisions = false,
+			onProgress,
+			batchSize = GQL_PAGE_SIZE,
+			stopAfterKnownCount = 10
+		} = options;
 
 		const stats: SyncStats = {
 			totalProcessed: 0,
@@ -150,7 +157,21 @@ export class ArFSDAOIncrementalSync extends ArFSDAO {
 			// reconciled rather than silently missed.
 			const minBlock = incrementalMinBlock(syncState?.lastSyncedBlockHeight);
 
-			// Fetch all entities with optional block height filter
+			// Fetch folders and files as two SEPARATE paged queries, run concurrently.
+			//
+			// These are deliberately NOT merged into one `Entity-Type: [file, folder]`
+			// query [CORE-8]: each stream carries an independent `stopAfterKnownCount`
+			// early-stop that counts CONSECUTIVE already-known entities OF ITS OWN TYPE in
+			// descending block order. A single combined query would force one shared cursor,
+			// one pagination loop and therefore one shared early-stop counting known
+			// entities of EITHER type — which trips sooner and could stop paginating before
+			// a changed entity of one type that sits (in block order) just below a run of
+			// >= stopAfterKnownCount known entities of the other type, silently dropping it.
+			// The per-type early-stop is what preserves the no-dropped-entities invariant,
+			// so the query stays split. (Downstream selectLatestRevisions/detectChanges are
+			// order-independent, so combining would not help correctness — only request
+			// count, which the 1000-entity page size already reduces ~10x.) Running both in
+			// parallel means wall-clock latency is already ~max(folders, files), not the sum.
 			const [folders, files] = await Promise.all([
 				this.getIncrementalPrivateFolders(
 					driveId,

--- a/src/arfs/arfsdao_incremental_sync.ts
+++ b/src/arfs/arfsdao_incremental_sync.ts
@@ -35,7 +35,7 @@ import { ArFSPublicFolderCacheKey } from './arfsdao_anonymous';
 import { ArFSPrivateFolderCacheKey } from './arfsdao';
 import { buildQuery } from '../utils/query';
 import { DESCENDING_ORDER } from '../utils/query';
-import { GQL_PAGE_SIZE, MAX_CONCURRENT_ENTITY_FETCHES } from '../utils/constants';
+import { getGqlPageSize, MAX_CONCURRENT_ENTITY_FETCHES } from '../utils/constants';
 import { mapWithConcurrency } from '../utils/concurrency';
 import { incrementalMinBlock, selectLatestRevisions } from '../utils/sync_state';
 import { PromiseCache } from '@ardrive/ardrive-promise-cache';
@@ -127,7 +127,7 @@ export class ArFSDAOIncrementalSync extends ArFSDAO {
 			syncState,
 			includeRevisions = false,
 			onProgress,
-			batchSize = GQL_PAGE_SIZE,
+			batchSize = getGqlPageSize(),
 			stopAfterKnownCount = 10
 		} = options;
 

--- a/src/arfs/arfsdao_incremental_sync.ts
+++ b/src/arfs/arfsdao_incremental_sync.ts
@@ -35,7 +35,8 @@ import { ArFSPublicFolderCacheKey } from './arfsdao_anonymous';
 import { ArFSPrivateFolderCacheKey } from './arfsdao';
 import { buildQuery } from '../utils/query';
 import { DESCENDING_ORDER } from '../utils/query';
-import { GQL_PAGE_SIZE } from '../utils/constants';
+import { GQL_PAGE_SIZE, MAX_CONCURRENT_ENTITY_FETCHES } from '../utils/constants';
+import { mapWithConcurrency } from '../utils/concurrency';
 import { incrementalMinBlock, selectLatestRevisions } from '../utils/sync_state';
 import { PromiseCache } from '@ardrive/ardrive-promise-cache';
 import { ArFSDAOAnonymousIncrementalSync, ArFSIncrementalSyncCache } from './arfsdao_anonymous_incremental_sync';
@@ -162,16 +163,19 @@ export class ArFSDAOIncrementalSync extends ArFSDAO {
 			// These are deliberately NOT merged into one `Entity-Type: [file, folder]`
 			// query [CORE-8]: each stream carries an independent `stopAfterKnownCount`
 			// early-stop that counts CONSECUTIVE already-known entities OF ITS OWN TYPE in
-			// descending block order. A single combined query would force one shared cursor,
-			// one pagination loop and therefore one shared early-stop counting known
-			// entities of EITHER type — which trips sooner and could stop paginating before
-			// a changed entity of one type that sits (in block order) just below a run of
+			// descending block order. Merging is not fundamentally unsafe — only a NAIVE
+			// merge is: a single combined query with ONE shared early-stop counter (counting
+			// known entities of EITHER type) trips sooner and could stop paginating before a
+			// changed entity of one type that sits (in block order) just below a run of
 			// >= stopAfterKnownCount known entities of the other type, silently dropping it.
-			// The per-type early-stop is what preserves the no-dropped-entities invariant,
-			// so the query stays split. (Downstream selectLatestRevisions/detectChanges are
-			// order-independent, so combining would not help correctness — only request
-			// count, which the 1000-entity page size already reduces ~10x.) Running both in
-			// parallel means wall-clock latency is already ~max(folders, files), not the sum.
+			// A combined query that kept a SEPARATE per-type counter (only stopping once both
+			// types have independently hit the threshold) would preserve the no-dropped-
+			// entities invariant just as well. The queries stay split simply because merging
+			// buys almost nothing: after CORE-7 the two walks already run in parallel via
+			// `Promise.all`, so wall-clock latency is ~max(folders, files) not the sum, and
+			// the ~10x round-trip reduction is already delivered by the 1000-entity page size.
+			// Downstream selectLatestRevisions/detectChanges are order-independent, so a merge
+			// would add per-type-counter/shared-cursor bookkeeping for a ~zero latency win.
 			const [folders, files] = await Promise.all([
 				this.getIncrementalPrivateFolders(
 					driveId,
@@ -399,45 +403,45 @@ export class ArFSDAOIncrementalSync extends ArFSDAO {
 		owner: ArweaveAddress,
 		stats: SyncStats
 	): Promise<((ArFSPrivateFolder | ArFSPrivateFolderKeyless) & { blockHeight: number })[]> {
-		const folders: Promise<(ArFSPrivateFolder | ArFSPrivateFolderKeyless) & { blockHeight: number }>[] = edges.map(
-			async (edge) => {
-				const { node } = edge;
+		// Bounded fan-out: build at most MAX_CONCURRENT_ENTITY_FETCHES entities at a time so
+		// a 1000-edge page (CORE-7) does not put ~1000 metadata GETs on the gateway at once
+		// [CORE-9]. mapWithConcurrency preserves input order and Promise.all's reject-on-any-
+		// failure semantics, so the returned batch is identical — only parallelism is capped.
+		return mapWithConcurrency(edges, MAX_CONCURRENT_ENTITY_FETCHES, async (edge) => {
+			const { node } = edge;
 
-				// Update block height stats
-				const blockHeight = node.block?.height || 0;
-				stats.lowestBlockHeight = Math.min(stats.lowestBlockHeight, blockHeight);
-				stats.highestBlockHeight = Math.max(stats.highestBlockHeight, blockHeight);
+			// Update block height stats
+			const blockHeight = node.block?.height || 0;
+			stats.lowestBlockHeight = Math.min(stats.lowestBlockHeight, blockHeight);
+			stats.highestBlockHeight = Math.max(stats.highestBlockHeight, blockHeight);
 
-				// Check cache first. Only reuse the cached entity when it is the SAME
-				// revision as this node (matching txId); reusing it for a different
-				// revision would return stale metadata and mislabel latest-revision
-				// selection. Block height is deterministic per txId.
-				const folderId = this.extractEntityId(node, 'Folder-Id');
-				const folderCacheKey = { folderId, owner, driveKey };
-				const cached = this.caches.privateFolderCache.get(folderCacheKey);
+			// Check cache first. Only reuse the cached entity when it is the SAME
+			// revision as this node (matching txId); reusing it for a different
+			// revision would return stale metadata and mislabel latest-revision
+			// selection. Block height is deterministic per txId.
+			const folderId = this.extractEntityId(node, 'Folder-Id');
+			const folderCacheKey = { folderId, owner, driveKey };
+			const cached = this.caches.privateFolderCache.get(folderCacheKey);
 
-				if (cached) {
-					const cachedFolder = await cached;
-					if (`${cachedFolder.txId}` === node.id) {
-						stats.fromCache++;
-						return Object.assign(cachedFolder, { blockHeight });
-					}
+			if (cached) {
+				const cachedFolder = await cached;
+				if (`${cachedFolder.txId}` === node.id) {
+					stats.fromCache++;
+					return Object.assign(cachedFolder, { blockHeight });
 				}
-
-				// Build from network
-				stats.fromNetwork++;
-				const folderBuilder = ArFSPrivateFolderBuilder.fromArweaveNode(node, this.gatewayApi, driveKey);
-				const folder = await folderBuilder.build(node);
-
-				// Cache this revision (overwrites any older cached revision for the entity)
-				this.caches.privateFolderCache.put(folderCacheKey, Promise.resolve(folder));
-
-				// Add blockHeight to the entity
-				return Object.assign(folder, { blockHeight });
 			}
-		);
 
-		return Promise.all(folders);
+			// Build from network
+			stats.fromNetwork++;
+			const folderBuilder = ArFSPrivateFolderBuilder.fromArweaveNode(node, this.gatewayApi, driveKey);
+			const folder = await folderBuilder.build(node);
+
+			// Cache this revision (overwrites any older cached revision for the entity)
+			this.caches.privateFolderCache.put(folderCacheKey, Promise.resolve(folder));
+
+			// Add blockHeight to the entity
+			return Object.assign(folder, { blockHeight });
+		});
 	}
 
 	/**
@@ -449,45 +453,45 @@ export class ArFSDAOIncrementalSync extends ArFSDAO {
 		owner: ArweaveAddress,
 		stats: SyncStats
 	): Promise<((ArFSPrivateFile | ArFSPrivateFileKeyless) & { blockHeight: number })[]> {
-		const files: Promise<(ArFSPrivateFile | ArFSPrivateFileKeyless) & { blockHeight: number }>[] = edges.map(
-			async (edge) => {
-				const { node } = edge;
+		// Bounded fan-out: build at most MAX_CONCURRENT_ENTITY_FETCHES entities at a time so
+		// a 1000-edge page (CORE-7) does not put ~1000 metadata GETs on the gateway at once
+		// [CORE-9]. mapWithConcurrency preserves input order and Promise.all's reject-on-any-
+		// failure semantics, so the returned batch is identical — only parallelism is capped.
+		return mapWithConcurrency(edges, MAX_CONCURRENT_ENTITY_FETCHES, async (edge) => {
+			const { node } = edge;
 
-				// Update block height stats
-				const blockHeight = node.block?.height || 0;
-				stats.lowestBlockHeight = Math.min(stats.lowestBlockHeight, blockHeight);
-				stats.highestBlockHeight = Math.max(stats.highestBlockHeight, blockHeight);
+			// Update block height stats
+			const blockHeight = node.block?.height || 0;
+			stats.lowestBlockHeight = Math.min(stats.lowestBlockHeight, blockHeight);
+			stats.highestBlockHeight = Math.max(stats.highestBlockHeight, blockHeight);
 
-				// Check cache first
-				const fileId = this.extractEntityId(node, 'File-Id');
-				// For private files, we need the file key which we don't have yet
-				// So we can't use the cache effectively here
-				const cached = undefined;
+			// Check cache first
+			const fileId = this.extractEntityId(node, 'File-Id');
+			// For private files, we need the file key which we don't have yet
+			// So we can't use the cache effectively here
+			const cached = undefined;
 
-				if (cached) {
-					stats.fromCache++;
-					return cached;
-				}
-
-				// Build from network
-				stats.fromNetwork++;
-				const fileBuilder = ArFSPrivateFileBuilder.fromArweaveNode(node, this.gatewayApi, driveKey);
-				const file = await fileBuilder.build(node);
-
-				// Cache the result if we have a file key
-				if ('fileKey' in file && file.fileKey) {
-					const cacheKey = { fileId, owner, fileKey: file.fileKey };
-					this.caches.privateFileCache.put(cacheKey, Promise.resolve(file as ArFSPrivateFile));
-				}
-
-				// Add blockHeight to the entity
-				const fileWithBlockHeight = Object.assign(file, { blockHeight });
-
-				return fileWithBlockHeight;
+			if (cached) {
+				stats.fromCache++;
+				return cached;
 			}
-		);
 
-		return Promise.all(files);
+			// Build from network
+			stats.fromNetwork++;
+			const fileBuilder = ArFSPrivateFileBuilder.fromArweaveNode(node, this.gatewayApi, driveKey);
+			const file = await fileBuilder.build(node);
+
+			// Cache the result if we have a file key
+			if ('fileKey' in file && file.fileKey) {
+				const cacheKey = { fileId, owner, fileKey: file.fileKey };
+				this.caches.privateFileCache.put(cacheKey, Promise.resolve(file as ArFSPrivateFile));
+			}
+
+			// Add blockHeight to the entity
+			const fileWithBlockHeight = Object.assign(file, { blockHeight });
+
+			return fileWithBlockHeight;
+		});
 	}
 
 	/**

--- a/src/arfs/gql_fetch_concurrency.test.ts
+++ b/src/arfs/gql_fetch_concurrency.test.ts
@@ -1,0 +1,141 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import Arweave from 'arweave';
+import { expect } from 'chai';
+import { stub, SinonStub } from 'sinon';
+import { stubArweaveAddress, stubEntityID, stubTxID, stubPublicDrive } from '../../tests/stubs';
+import { DriveID, DriveSyncState, GQLEdgeInterface, GQLNodeInterface } from '../types';
+import { ArFSDAOAnonymousIncrementalSync, ArFSIncrementalSyncCache } from './arfsdao_anonymous_incremental_sync';
+import { GatewayAPI } from '../utils/gateway_api';
+import { MAX_CONCURRENT_ENTITY_FETCHES } from '../utils/constants';
+
+const fakeArweave = Arweave.init({
+	host: 'localhost',
+	port: 443,
+	protocol: 'https',
+	timeout: 600000
+});
+
+/**
+ * CORE-9: with CORE-7 raising the page size 100 -> 1000, a single batch of edges can carry
+ * up to 1000 entities, each of which is built with a per-entity metadata GET. This test
+ * drives the REAL incremental-sync fan-out (processFolderBatch) against a page far larger
+ * than the concurrency cap and asserts, via a counter over the actual metadata fetches,
+ * that:
+ *   - every entity in the page is still processed — NONE dropped (result set unchanged),
+ *   - the peak number of simultaneously in-flight metadata fetches never exceeds
+ *     MAX_CONCURRENT_ENTITY_FETCHES (parallelism is decoupled from page size).
+ */
+describe('per-batch entity-fetch concurrency cap (CORE-9)', () => {
+	let arfsDaoIncSync: ArFSDAOAnonymousIncrementalSync;
+	let gatewayApiStub: SinonStub;
+	let getTxDataStub: SinonStub;
+	let caches: ArFSIncrementalSyncCache;
+
+	const mockDriveId = stubEntityID;
+	const mockOwner = stubArweaveAddress();
+
+	// A distinct 8-4-4-4-12 hex entity id per index so every folder is a distinct entity.
+	const folderIdForIndex = (i: number): string => `${i.toString(16).padStart(8, '0')}-1111-1111-1111-111111111111`;
+
+	const makeFolderEdge = (i: number): GQLEdgeInterface => ({
+		cursor: `cursor-${i}`,
+		node: {
+			id: stubTxID.toString(),
+			anchor: 'test-anchor',
+			signature: 'test-signature',
+			recipient: 'test-recipient',
+			owner: { address: mockOwner.toString(), key: 'test-owner-key' },
+			fee: { winston: '0', ar: '0' },
+			quantity: { winston: '0', ar: '0' },
+			data: { size: 0, type: 'application/json' },
+			block: { id: 'test-block-id', height: 1_000_000 + i, timestamp: 1_640_000_000, previous: 'prev' },
+			parent: { id: 'test-parent' },
+			tags: [
+				{ name: 'App-Name', value: 'ArDrive-Core' },
+				{ name: 'App-Version', value: '0.0.1' },
+				{ name: 'Content-Type', value: 'application/json' },
+				{ name: 'Drive-Id', value: mockDriveId.toString() },
+				{ name: 'Entity-Type', value: 'folder' },
+				{ name: 'Folder-Id', value: folderIdForIndex(i) },
+				{ name: 'Parent-Folder-Id', value: mockDriveId.toString() },
+				{ name: 'ArFS', value: '0.13' },
+				{ name: 'Unix-Time', value: '1640000000' }
+			]
+		} as GQLNodeInterface
+	});
+
+	/** Serves the whole folder set in a SINGLE page (files query resolves empty). */
+	const serveFolderPage = (total: number): void => {
+		const edges = Array.from({ length: total }, (_, i) => makeFolderEdge(i));
+		gatewayApiStub.callsFake(async (gqlQuery: { query: string }) => {
+			if (gqlQuery.query.includes('values: "folder"')) {
+				return { edges, pageInfo: { hasNextPage: false } };
+			}
+			// Files query: empty in a single page.
+			return { edges: [], pageInfo: { hasNextPage: false } };
+		});
+	};
+
+	beforeEach(async () => {
+		const { PromiseCache } = await import('@ardrive/ardrive-promise-cache');
+		const { defaultCacheParams } = await import('./arfsdao_anonymous');
+
+		caches = {
+			ownerCache: new PromiseCache(defaultCacheParams),
+			driveIdCache: new PromiseCache(defaultCacheParams),
+			publicDriveCache: new PromiseCache(defaultCacheParams),
+			publicFolderCache: new PromiseCache(defaultCacheParams),
+			publicFileCache: new PromiseCache(defaultCacheParams),
+			syncStateCache: new PromiseCache<DriveID, DriveSyncState>({
+				cacheCapacity: 100,
+				cacheTTL: 1000 * 60 * 5
+			})
+		};
+
+		const gatewayApi = new GatewayAPI({ gatewayUrl: new URL('https://arweave.net') });
+		gatewayApiStub = stub(gatewayApi, 'gqlRequest');
+		getTxDataStub = stub(gatewayApi, 'getTxData');
+
+		arfsDaoIncSync = new ArFSDAOAnonymousIncrementalSync(fakeArweave, 'test_app', '0.0', caches, gatewayApi);
+		stub(arfsDaoIncSync, 'getPublicDrive').resolves(await stubPublicDrive());
+	});
+
+	afterEach(() => {
+		gatewayApiStub.restore();
+		getTxDataStub.restore();
+	});
+
+	it('processes a page far larger than the cap with peak in-flight fetches <= the cap (none dropped)', async () => {
+		// A page ~8x the cap: enough to reveal any unbounded fan-out.
+		const total = MAX_CONCURRENT_ENTITY_FETCHES * 8 + 7; // 247
+		serveFolderPage(total);
+
+		// Instrument the per-entity metadata fetch to record peak concurrent in-flight count.
+		let inFlight = 0;
+		let peakInFlight = 0;
+		const folderMetadata = Buffer.from(JSON.stringify({ name: 'Test Folder' }));
+		getTxDataStub.callsFake(async () => {
+			inFlight++;
+			peakInFlight = Math.max(peakInFlight, inFlight);
+			// Hold the fetch open briefly so overlapping fetches actually overlap in time.
+			await new Promise((resolve) => setTimeout(resolve, 3));
+			inFlight--;
+			return folderMetadata;
+		});
+
+		const result = await arfsDaoIncSync.getPublicDriveIncrementalSync(mockDriveId, mockOwner);
+
+		// Every distinct folder was processed — nothing dropped by the concurrency bounding.
+		expect(result.stats.totalProcessed).to.equal(total);
+		expect(result.entities).to.have.lengthOf(total);
+		expect(new Set(result.entities.map((e) => `${e.entityId}`)).size).to.equal(total);
+		expect(result.stats.failedEntities ?? 0).to.equal(0);
+
+		// One metadata fetch per entity, all of them made...
+		expect(getTxDataStub.callCount).to.equal(total);
+		// ...but never more than the cap were ever in flight at once...
+		expect(peakInFlight).to.be.at.most(MAX_CONCURRENT_ENTITY_FETCHES);
+		// ...and the cap was actually reached (the fan-out is genuinely parallel, just bounded).
+		expect(peakInFlight).to.equal(MAX_CONCURRENT_ENTITY_FETCHES);
+	});
+});

--- a/src/arfs/gql_page_size.test.ts
+++ b/src/arfs/gql_page_size.test.ts
@@ -1,0 +1,173 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import Arweave from 'arweave';
+import { expect } from 'chai';
+import { stub, SinonStub } from 'sinon';
+import { stubArweaveAddress, stubEntityID, stubTxID, stubPublicDrive } from '../../tests/stubs';
+import { DriveID, DriveSyncState, GQLEdgeInterface, GQLNodeInterface } from '../types';
+import { ArFSDAOAnonymousIncrementalSync, ArFSIncrementalSyncCache } from './arfsdao_anonymous_incremental_sync';
+import { GatewayAPI } from '../utils/gateway_api';
+import { buildQuery } from '../utils/query';
+import { GQL_PAGE_SIZE } from '../utils/constants';
+
+const fakeArweave = Arweave.init({
+	host: 'localhost',
+	port: 443,
+	protocol: 'https',
+	timeout: 600000
+});
+
+/**
+ * CORE-7 (page size 100 -> 1000) safety + request-count tests.
+ *
+ * The load-bearing invariant these lock down: pagination is cursor +
+ * `pageInfo.hasNextPage` driven, so a larger `first:` NEVER drops entities — even
+ * against a gateway that silently returns FEWER than `first` for a page (all Arweave
+ * gateways cap `first` at 1000). The request count drops ~10x, the entity SET does not
+ * change.
+ */
+describe('GraphQL page size (CORE-7)', () => {
+	describe('buildQuery default page size', () => {
+		it('GQL_PAGE_SIZE is the 1000 gateway maximum', () => {
+			expect(GQL_PAGE_SIZE).to.equal(1000);
+		});
+
+		it('defaults transactions(first: …) to GQL_PAGE_SIZE for paged (cursor) queries', () => {
+			const { query } = buildQuery({ tags: [{ name: 'Drive-Id', value: 'x' }], cursor: 'CURSOR' });
+			expect(query).to.contain('first: 1000');
+		});
+
+		it('still honors an explicit first override', () => {
+			const { query } = buildQuery({ tags: [{ name: 'Drive-Id', value: 'x' }], cursor: 'CURSOR', first: 250 });
+			expect(query).to.contain('first: 250');
+			expect(query).to.not.contain('first: 1000');
+		});
+	});
+
+	describe('incremental sync pagination', () => {
+		let arfsDaoIncSync: ArFSDAOAnonymousIncrementalSync;
+		let gatewayApiStub: SinonStub;
+		let getTxDataStub: SinonStub;
+		let caches: ArFSIncrementalSyncCache;
+
+		const mockDriveId = stubEntityID;
+		const mockOwner = stubArweaveAddress();
+
+		// A distinct 8-4-4-4-12 hex entity id per index so every folder is a distinct entity.
+		const folderIdForIndex = (i: number): string =>
+			`${i.toString(16).padStart(8, '0')}-1111-1111-1111-111111111111`;
+
+		const makeFolderEdge = (i: number): GQLEdgeInterface => ({
+			cursor: `cursor-${i}`,
+			node: {
+				id: stubTxID.toString(),
+				anchor: 'test-anchor',
+				signature: 'test-signature',
+				recipient: 'test-recipient',
+				owner: { address: mockOwner.toString(), key: 'test-owner-key' },
+				fee: { winston: '0', ar: '0' },
+				quantity: { winston: '0', ar: '0' },
+				data: { size: 0, type: 'application/json' },
+				block: { id: 'test-block-id', height: 1_000_000 + i, timestamp: 1_640_000_000, previous: 'prev' },
+				parent: { id: 'test-parent' },
+				tags: [
+					{ name: 'App-Name', value: 'ArDrive-Core' },
+					{ name: 'App-Version', value: '0.0.1' },
+					{ name: 'Content-Type', value: 'application/json' },
+					{ name: 'Drive-Id', value: mockDriveId.toString() },
+					{ name: 'Entity-Type', value: 'folder' },
+					{ name: 'Folder-Id', value: folderIdForIndex(i) },
+					{ name: 'Parent-Folder-Id', value: mockDriveId.toString() },
+					{ name: 'ArFS', value: '0.13' },
+					{ name: 'Unix-Time', value: '1640000000' }
+				]
+			} as GQLNodeInterface
+		});
+
+		/** Wires the folder query to serve `total` edges in pages of at most `pageCap`. */
+		const serveFolderPagesCappedAt = (total: number, pageCap: number): { folderRequests: () => number } => {
+			const edges = Array.from({ length: total }, (_, i) => makeFolderEdge(i));
+			let folderRequests = 0;
+			gatewayApiStub.callsFake(async (gqlQuery: { query: string }) => {
+				const q = gqlQuery.query;
+				if (q.includes('values: "folder"')) {
+					const start = folderRequests * pageCap;
+					folderRequests++;
+					const pageEdges = edges.slice(start, start + pageCap);
+					return { edges: pageEdges, pageInfo: { hasNextPage: start + pageCap < total } };
+				}
+				// Files query: empty in a single page.
+				return { edges: [], pageInfo: { hasNextPage: false } };
+			});
+			return { folderRequests: () => folderRequests };
+		};
+
+		beforeEach(async () => {
+			const { PromiseCache } = await import('@ardrive/ardrive-promise-cache');
+			const { defaultCacheParams } = await import('./arfsdao_anonymous');
+
+			caches = {
+				ownerCache: new PromiseCache(defaultCacheParams),
+				driveIdCache: new PromiseCache(defaultCacheParams),
+				publicDriveCache: new PromiseCache(defaultCacheParams),
+				publicFolderCache: new PromiseCache(defaultCacheParams),
+				publicFileCache: new PromiseCache(defaultCacheParams),
+				syncStateCache: new PromiseCache<DriveID, DriveSyncState>({
+					cacheCapacity: 100,
+					cacheTTL: 1000 * 60 * 5
+				})
+			};
+
+			const gatewayApi = new GatewayAPI({ gatewayUrl: new URL('https://arweave.net') });
+			gatewayApiStub = stub(gatewayApi, 'gqlRequest');
+			getTxDataStub = stub(gatewayApi, 'getTxData');
+			getTxDataStub.resolves(Buffer.from(JSON.stringify({ name: 'Test Folder' })));
+
+			arfsDaoIncSync = new ArFSDAOAnonymousIncrementalSync(fakeArweave, 'test_app', '0.0', caches, gatewayApi);
+			stub(arfsDaoIncSync, 'getPublicDrive').resolves(await stubPublicDrive());
+		});
+
+		afterEach(() => {
+			gatewayApiStub.restore();
+			getTxDataStub.restore();
+		});
+
+		// (a) Capped-gateway safety: gateway caps pages at 100 even though we ask for 1000.
+		// hasNextPage-driven pagination must still fetch EVERY entity — none dropped.
+		it('fetches ALL entities when the gateway caps a 1000-page request at 100 (no drops)', async () => {
+			const total = 250;
+			const gatewayCap = 100; // gateway silently returns <= 100 despite first: 1000
+			const counter = serveFolderPagesCappedAt(total, gatewayCap);
+
+			const result = await arfsDaoIncSync.getPublicDriveIncrementalSync(mockDriveId, mockOwner);
+
+			// Every one of the 250 distinct folders survives to the result — nothing dropped.
+			expect(result.stats.totalProcessed).to.equal(total);
+			expect(result.entities).to.have.lengthOf(total);
+			expect(result.changes.added).to.have.lengthOf(total);
+			const distinctIds = new Set(result.entities.map((e) => `${e.entityId}`));
+			expect(distinctIds.size).to.equal(total);
+
+			// Pagination followed hasNextPage (ceil(250/100) = 3), NOT edges.length === first.
+			expect(counter.folderRequests()).to.equal(3);
+
+			// ...and every folder request still asked for the full 1000-entity page.
+			const folderCalls = gatewayApiStub.getCalls().filter((c) => c.args[0].query.includes('values: "folder"'));
+			folderCalls.forEach((c) => expect(c.args[0].query).to.contain('first: 1000'));
+		});
+
+		// (c) Request-count: N entities need ceil(N/1000) page requests, not ceil(N/100).
+		it('needs ceil(N/1000) page requests for a gateway honoring the full page (~10x fewer than size 100)', async () => {
+			const total = 1500;
+			const counter = serveFolderPagesCappedAt(total, GQL_PAGE_SIZE); // 1000, 500
+
+			const result = await arfsDaoIncSync.getPublicDriveIncrementalSync(mockDriveId, mockOwner);
+
+			expect(result.stats.totalProcessed).to.equal(total);
+			expect(result.entities).to.have.lengthOf(total);
+
+			// ceil(1500/1000) = 2 requests, versus ceil(1500/100) = 15 under the old page size.
+			expect(counter.folderRequests()).to.equal(2);
+			expect(Math.ceil(total / 100)).to.equal(15); // documents the request count the old size 100 would have needed
+		});
+	});
+});

--- a/src/arfs/gql_page_size.test.ts
+++ b/src/arfs/gql_page_size.test.ts
@@ -7,7 +7,8 @@ import { DriveID, DriveSyncState, GQLEdgeInterface, GQLNodeInterface } from '../
 import { ArFSDAOAnonymousIncrementalSync, ArFSIncrementalSyncCache } from './arfsdao_anonymous_incremental_sync';
 import { GatewayAPI } from '../utils/gateway_api';
 import { buildQuery } from '../utils/query';
-import { GQL_PAGE_SIZE } from '../utils/constants';
+import { buildSnapshotQuery } from '../snapshots/snapshot_query';
+import { GQL_PAGE_SIZE, getGqlPageSize, setGqlPageSize } from '../utils/constants';
 
 const fakeArweave = Arweave.init({
 	host: 'localhost',
@@ -26,9 +27,20 @@ const fakeArweave = Arweave.init({
  * change.
  */
 describe('GraphQL page size (CORE-7)', () => {
+	// The configured page size is process-global module state, so reset it after every
+	// test (including the tunable + Goldsky cases below) so nothing leaks between tests.
+	afterEach(() => {
+		setGqlPageSize(GQL_PAGE_SIZE);
+	});
+
 	describe('buildQuery default page size', () => {
 		it('GQL_PAGE_SIZE is the 1000 gateway maximum', () => {
 			expect(GQL_PAGE_SIZE).to.equal(1000);
+		});
+
+		it('getGqlPageSize() defaults to the 1000 gateway maximum', () => {
+			expect(getGqlPageSize()).to.equal(GQL_PAGE_SIZE);
+			expect(getGqlPageSize()).to.equal(1000);
 		});
 
 		it('defaults transactions(first: …) to GQL_PAGE_SIZE for paged (cursor) queries', () => {
@@ -40,6 +52,56 @@ describe('GraphQL page size (CORE-7)', () => {
 			const { query } = buildQuery({ tags: [{ name: 'Drive-Id', value: 'x' }], cursor: 'CURSOR', first: 250 });
 			expect(query).to.contain('first: 250');
 			expect(query).to.not.contain('first: 1000');
+		});
+	});
+
+	// A consumer whose gateway caps `first:` below the 1000 ar.io max (e.g. Goldsky) can
+	// lower the process-global default via setGqlPageSize; getters/query builders read it
+	// at CALL time so the change takes effect for later queries. Explicit overrides win.
+	describe('tunable default page size (setGqlPageSize / getGqlPageSize)', () => {
+		it('lowers the buildQuery default when set (sub-1000 gateway)', () => {
+			setGqlPageSize(100);
+			expect(getGqlPageSize()).to.equal(100);
+
+			const { query } = buildQuery({ tags: [{ name: 'Drive-Id', value: 'x' }], cursor: 'CURSOR' });
+			expect(query).to.contain('first: 100');
+			expect(query).to.not.contain('first: 1000');
+		});
+
+		it('lets an explicit first override win over a lowered default', () => {
+			setGqlPageSize(100);
+			const { query } = buildQuery({ tags: [{ name: 'Drive-Id', value: 'x' }], cursor: 'CURSOR', first: 250 });
+			expect(query).to.contain('first: 250');
+			expect(query).to.not.contain('first: 100');
+		});
+
+		it('is read at call time — a change after import takes effect on the next query', () => {
+			expect(buildQuery({ tags: [], cursor: 'CURSOR' }).query).to.contain('first: 1000');
+			setGqlPageSize(50);
+			expect(buildQuery({ tags: [], cursor: 'CURSOR' }).query).to.contain('first: 50');
+		});
+
+		it('drives the snapshot query page size', () => {
+			const asDefault = buildSnapshotQuery({ driveId: stubEntityID, owner: stubArweaveAddress() });
+			expect(asDefault.query).to.contain('first: 1000');
+
+			setGqlPageSize(100);
+			const lowered = buildSnapshotQuery({ driveId: stubEntityID, owner: stubArweaveAddress() });
+			expect(lowered.query).to.contain('first: 100');
+			expect(lowered.query).to.not.contain('first: 1000');
+		});
+
+		it('rejects non-integer, non-positive, and above-max page sizes; reset restores 1000', () => {
+			for (const bad of [0, -1, 1.5, 1001]) {
+				expect(() => setGqlPageSize(bad)).to.throw(RangeError);
+			}
+			// A rejected value never mutates the configured default.
+			expect(getGqlPageSize()).to.equal(1000);
+
+			// Boundaries are accepted.
+			expect(() => setGqlPageSize(1)).to.not.throw();
+			expect(() => setGqlPageSize(GQL_PAGE_SIZE)).to.not.throw();
+			expect(getGqlPageSize()).to.equal(1000);
 		});
 	});
 
@@ -153,6 +215,36 @@ describe('GraphQL page size (CORE-7)', () => {
 			// ...and every folder request still asked for the full 1000-entity page.
 			const folderCalls = gatewayApiStub.getCalls().filter((c) => c.args[0].query.includes('values: "folder"'));
 			folderCalls.forEach((c) => expect(c.args[0].query).to.contain('first: 1000'));
+		});
+
+		// (b) Goldsky scenario: consumer lowered the default to 100 for a gateway that caps
+		// there. batchSize picks up the configured value, so requests ask for first: 100
+		// (within the cap) AND hasNextPage pagination still lists EVERY entity — none dropped.
+		it('sends first: <configured> and lists ALL entities when the default is lowered to 100 (Goldsky)', async () => {
+			setGqlPageSize(100);
+
+			const total = 250;
+			const gatewayCap = 100;
+			const counter = serveFolderPagesCappedAt(total, gatewayCap);
+
+			const result = await arfsDaoIncSync.getPublicDriveIncrementalSync(mockDriveId, mockOwner);
+
+			// Every one of the 250 distinct folders survives — lowering the page size drops nothing.
+			expect(result.stats.totalProcessed).to.equal(total);
+			expect(result.entities).to.have.lengthOf(total);
+			const distinctIds = new Set(result.entities.map((e) => `${e.entityId}`));
+			expect(distinctIds.size).to.equal(total);
+
+			// Pagination followed hasNextPage (ceil(250/100) = 3 pages).
+			expect(counter.folderRequests()).to.equal(3);
+
+			// Every folder request asked for first: 100 (the configured default via batchSize) — NOT 1000.
+			const folderCalls = gatewayApiStub.getCalls().filter((c) => c.args[0].query.includes('values: "folder"'));
+			expect(folderCalls.length).to.be.greaterThan(0);
+			folderCalls.forEach((c) => {
+				expect(c.args[0].query).to.contain('first: 100');
+				expect(c.args[0].query).to.not.contain('first: 1000');
+			});
 		});
 
 		// (c) Request-count: N entities need ceil(N/1000) page requests, not ceil(N/100).

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -49,6 +49,10 @@ export * from './pricing/data_price_regression';
 export * from './pricing/gateway_oracle';
 
 // Utils
+// GraphQL page-size tuning (CORE-7): GQL_PAGE_SIZE is the 1000 ar.io default/max;
+// setGqlPageSize lets a consumer lower the process-global default for a gateway
+// that caps below 1000 (e.g. Goldsky), getGqlPageSize reads the current value.
+export { GQL_PAGE_SIZE, getGqlPageSize, setGqlPageSize } from './utils/constants';
 export * from './utils/common';
 export * from './utils/crypto';
 export * from './utils/error_message';

--- a/src/snapshots/snapshot_query.test.ts
+++ b/src/snapshots/snapshot_query.test.ts
@@ -20,7 +20,7 @@ describe('buildSnapshotQuery', () => {
 
 	it('requests a full page and selects block height + timestamp', () => {
 		const { query } = buildSnapshotQuery({ driveId, owner });
-		expect(query).to.contain('first: 100');
+		expect(query).to.contain('first: 1000');
 		expect(query).to.contain('height');
 		expect(query).to.contain('timestamp');
 		expect(query).to.contain('hasNextPage');

--- a/src/snapshots/snapshot_query.ts
+++ b/src/snapshots/snapshot_query.ts
@@ -1,9 +1,14 @@
 import { ArweaveAddress, EntityID } from '../types';
 import { GQLQuery, DESCENDING_ORDER } from '../utils/query';
+import { GQL_PAGE_SIZE } from '../utils/constants';
 import { SNAPSHOT_ENTITY_TYPE, SnapshotTagName } from './snapshot_tags';
 
-/** How many snapshot transactions to request per page. */
-const SNAPSHOT_PAGE_LIMIT = 100;
+/**
+ * How many snapshot transactions to request per page. Uses the shared
+ * {@link GQL_PAGE_SIZE} (the 1000 gateway max); pagination is cursor + hasNextPage
+ * driven, so this only affects request count, never the snapshot set returned.
+ */
+const SNAPSHOT_PAGE_LIMIT = GQL_PAGE_SIZE;
 
 export interface BuildSnapshotQueryParams {
 	/** The drive whose snapshots we're listing. */

--- a/src/snapshots/snapshot_query.ts
+++ b/src/snapshots/snapshot_query.ts
@@ -1,14 +1,7 @@
 import { ArweaveAddress, EntityID } from '../types';
 import { GQLQuery, DESCENDING_ORDER } from '../utils/query';
-import { GQL_PAGE_SIZE } from '../utils/constants';
+import { getGqlPageSize } from '../utils/constants';
 import { SNAPSHOT_ENTITY_TYPE, SnapshotTagName } from './snapshot_tags';
-
-/**
- * How many snapshot transactions to request per page. Uses the shared
- * {@link GQL_PAGE_SIZE} (the 1000 gateway max); pagination is cursor + hasNextPage
- * driven, so this only affects request count, never the snapshot set returned.
- */
-const SNAPSHOT_PAGE_LIMIT = GQL_PAGE_SIZE;
 
 export interface BuildSnapshotQueryParams {
 	/** The drive whose snapshots we're listing. */
@@ -57,7 +50,7 @@ export function buildSnapshotQuery({
 	return {
 		query: `query {
 			transactions(
-				first: ${SNAPSHOT_PAGE_LIMIT}
+				first: ${getGqlPageSize()}
 				sort: ${DESCENDING_ORDER}
 				owners: ["${owner}"]
 				${cursor === undefined ? '' : `after: "${cursor}"`}

--- a/src/types/sync_types.ts
+++ b/src/types/sync_types.ts
@@ -59,7 +59,12 @@ export interface IncrementalSyncOptions {
 	includeRevisions?: boolean;
 	/** Progress callback for long-running syncs */
 	onProgress?: (processed: number, total: number) => void;
-	/** Number of entities to fetch per GraphQL query (default: 100, max: 100) */
+	/**
+	 * Number of entities to fetch per GraphQL query (default: 1000, the gateway max).
+	 * Arweave gateways silently cap this at 1000; pagination is cursor + hasNextPage
+	 * driven, so a smaller value only changes the number of round-trips, never the set
+	 * of entities returned.
+	 */
 	batchSize?: number;
 	/** Stop sync after finding this many known entities (optimization for catching up) */
 	stopAfterKnownCount?: number;

--- a/src/types/sync_types.ts
+++ b/src/types/sync_types.ts
@@ -60,10 +60,12 @@ export interface IncrementalSyncOptions {
 	/** Progress callback for long-running syncs */
 	onProgress?: (processed: number, total: number) => void;
 	/**
-	 * Number of entities to fetch per GraphQL query (default: 1000, the gateway max).
-	 * Arweave gateways silently cap this at 1000; pagination is cursor + hasNextPage
-	 * driven, so a smaller value only changes the number of round-trips, never the set
-	 * of entities returned.
+	 * Number of entities to fetch per GraphQL query. Defaults to the configured page
+	 * size (`getGqlPageSize()`, initially 1000 — the ar.io gateway max — unless lowered
+	 * via `setGqlPageSize()` for a gateway that caps below 1000, e.g. Goldsky). An
+	 * explicit value here always wins over that default. Arweave gateways silently cap
+	 * this at 1000; pagination is cursor + hasNextPage driven, so a smaller value only
+	 * changes the number of round-trips, never the set of entities returned.
 	 */
 	batchSize?: number;
 	/** Stop sync after finding this many known entities (optimization for catching up) */

--- a/src/utils/concurrency.test.ts
+++ b/src/utils/concurrency.test.ts
@@ -1,0 +1,152 @@
+import { expect } from 'chai';
+import { mapSettledWithConcurrency, mapWithConcurrency } from './concurrency';
+
+/**
+ * CORE-9: the bounded-concurrency primitives that keep a 1000-edge page (CORE-7) from
+ * firing ~1000 per-entity metadata fetches at once. The load-bearing guarantees:
+ *   - every item is processed EXACTLY once (nothing dropped),
+ *   - results are index-aligned with the input (order preserved, completion order NOT),
+ *   - at most `limit` invocations are ever in flight at the same moment.
+ */
+describe('bounded-concurrency helpers (CORE-9)', () => {
+	/** An async task proxy that records the peak number of overlapping in-flight calls. */
+	const makeInFlightTracker = () => {
+		let inFlight = 0;
+		let peak = 0;
+		return {
+			run: async <R>(value: R, delayMs = 5): Promise<R> => {
+				inFlight++;
+				peak = Math.max(peak, inFlight);
+				await new Promise((resolve) => setTimeout(resolve, delayMs));
+				inFlight--;
+				return value;
+			},
+			get peak(): number {
+				return peak;
+			}
+		};
+	};
+
+	describe('mapWithConcurrency (Promise.all analogue)', () => {
+		it('processes ALL items when there are far more than the limit — none dropped', async () => {
+			const items = Array.from({ length: 250 }, (_, i) => i);
+
+			const results = await mapWithConcurrency(items, 30, async (n) => n * 2);
+
+			expect(results).to.have.lengthOf(250);
+			expect(results).to.deep.equal(items.map((n) => n * 2));
+		});
+
+		it('caps in-flight invocations at the limit and actually reaches it (real, bounded parallelism)', async () => {
+			const items = Array.from({ length: 250 }, (_, i) => i);
+			const tracker = makeInFlightTracker();
+			const limit = 30;
+
+			const results = await mapWithConcurrency(items, limit, (n) => tracker.run(n));
+
+			// Every one of the 250 items was processed...
+			expect(results).to.have.lengthOf(250);
+			expect(new Set(results).size).to.equal(250);
+			// ...but the peak simultaneous in-flight count never exceeded the cap...
+			expect(tracker.peak).to.be.at.most(limit);
+			// ...and did saturate it (proves concurrency is real, not accidentally serialized).
+			expect(tracker.peak).to.equal(limit);
+		});
+
+		it('preserves INPUT order even when later items finish first', async () => {
+			const items = [0, 1, 2, 3, 4, 5];
+
+			const results = await mapWithConcurrency(items, 3, async (n) => {
+				// Higher indices resolve sooner; result order must still be input order.
+				await new Promise((resolve) => setTimeout(resolve, (items.length - n) * 5));
+				return n;
+			});
+
+			expect(results).to.deep.equal([0, 1, 2, 3, 4, 5]);
+		});
+
+		it('invokes the worker EXACTLY once per item', async () => {
+			const items = Array.from({ length: 100 }, (_, i) => i);
+			const invocations = new Map<number, number>();
+
+			await mapWithConcurrency(items, 10, async (n) => {
+				invocations.set(n, (invocations.get(n) ?? 0) + 1);
+				return n;
+			});
+
+			expect(invocations.size).to.equal(100);
+			for (const count of invocations.values()) {
+				expect(count).to.equal(1);
+			}
+		});
+
+		it('rejects (like Promise.all) when any invocation rejects', async () => {
+			let caught: Error | undefined;
+			try {
+				await mapWithConcurrency([1, 2, 3, 4, 5], 2, async (n) => {
+					if (n === 3) {
+						throw new Error('boom-3');
+					}
+					return n;
+				});
+			} catch (e) {
+				caught = e as Error;
+			}
+			expect(caught).to.be.instanceOf(Error);
+			expect(caught?.message).to.equal('boom-3');
+		});
+
+		it('resolves to an empty array for empty input without invoking the worker', async () => {
+			let called = false;
+			const results = await mapWithConcurrency<number, number>([], 30, async (n) => {
+				called = true;
+				return n;
+			});
+			expect(results).to.deep.equal([]);
+			expect(called).to.equal(false);
+		});
+
+		it('never spins up more workers than there are items', async () => {
+			const tracker = makeInFlightTracker();
+			await mapWithConcurrency([1, 2, 3], 30, (n) => tracker.run(n));
+			expect(tracker.peak).to.be.at.most(3);
+		});
+	});
+
+	describe('mapSettledWithConcurrency (Promise.allSettled analogue)', () => {
+		it('never rejects; records per-item outcomes index-aligned, with bounded concurrency', async () => {
+			const items = Array.from({ length: 120 }, (_, i) => i);
+			const tracker = makeInFlightTracker();
+			const limit = 20;
+
+			const results = await mapSettledWithConcurrency(items, limit, async (n) => {
+				await tracker.run(n, 3);
+				if (n % 10 === 0) {
+					throw new Error(`fail-${n}`);
+				}
+				return n;
+			});
+
+			expect(results).to.have.lengthOf(120);
+			expect(tracker.peak).to.be.at.most(limit);
+
+			// 0,10,...,110 => 12 rejections; the remaining 108 fulfilled. Nothing dropped.
+			const rejected = results.filter((r) => r.status === 'rejected');
+			const fulfilled = results.filter((r) => r.status === 'fulfilled');
+			expect(rejected).to.have.lengthOf(12);
+			expect(fulfilled).to.have.lengthOf(108);
+
+			// Index alignment: slot 10 is the rejection for item 10, slot 11 the value 11.
+			const slot10 = results[10];
+			expect(slot10.status).to.equal('rejected');
+			if (slot10.status === 'rejected') {
+				expect((slot10.reason as Error).message).to.equal('fail-10');
+			}
+			const slot11 = results[11];
+			expect(slot11.status).to.equal('fulfilled');
+			if (slot11.status === 'fulfilled') {
+				expect(slot11.value).to.equal(11);
+			}
+		});
+	});
+});

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,83 @@
+/**
+ * Bounded-concurrency helpers for turning a page of GraphQL edges into built entities
+ * without firing every per-entity metadata fetch at once.
+ *
+ * A page can now carry up to {@link MAX_CONCURRENT_ENTITY_FETCHES}'s worth — actually up
+ * to GQL_PAGE_SIZE (1000) — edges (CORE-7), and each edge is turned into an entity by a
+ * per-entity network GET of its metadata tx. Mapping the whole page with
+ * `Promise.all(edges.map(...))` would put ~1000 requests on one gateway host at once.
+ * These helpers instead run at most `limit` invocations concurrently, in successive
+ * waves, so the request COUNT still drops ~10x (fewer, bigger pages) while the peak
+ * PARALLELISM stays bounded [CORE-9].
+ *
+ * Both helpers preserve INPUT ORDER (results are index-aligned with `items`) and run each
+ * item's worker function EXACTLY ONCE, so the set/order of results and any accumulated
+ * side effects are identical to the unbounded `Promise.all` / `Promise.allSettled` they
+ * replace — only the number of simultaneously in-flight invocations is capped.
+ */
+
+/**
+ * Bounded-concurrency analogue of `Promise.allSettled(items.map(fn))`.
+ *
+ * Runs `fn` over `items` with at most `limit` invocations in flight at any moment and
+ * NEVER rejects: each result slot is a settled outcome, index-aligned with `items` and in
+ * input order (regardless of the order invocations happen to finish).
+ */
+export async function mapSettledWithConcurrency<T, R>(
+	items: readonly T[],
+	limit: number,
+	fn: (item: T, index: number) => Promise<R>
+): Promise<PromiseSettledResult<R>[]> {
+	const results: PromiseSettledResult<R>[] = new Array(items.length);
+	if (items.length === 0) {
+		return results;
+	}
+
+	// Never spin up more workers than there is work, and always at least one.
+	const workerCount = Math.max(1, Math.min(Math.floor(limit) || 1, items.length));
+
+	// Shared cursor. `nextIndex++` reads-then-increments synchronously (no `await` in
+	// between), so on JS's single-threaded event loop no two workers can ever be handed
+	// the same index, and indices are handed out in strictly increasing order.
+	let nextIndex = 0;
+	const runWorker = async (): Promise<void> => {
+		while (nextIndex < items.length) {
+			const index = nextIndex++;
+			try {
+				results[index] = { status: 'fulfilled', value: await fn(items[index], index) };
+			} catch (reason) {
+				results[index] = { status: 'rejected', reason };
+			}
+		}
+	};
+
+	await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+	return results;
+}
+
+/**
+ * Bounded-concurrency analogue of `Promise.all(items.map(fn))`.
+ *
+ * Like {@link mapSettledWithConcurrency}, but REJECTS if any invocation rejects (with the
+ * first rejection reason in input-index order) and otherwise resolves to the results in
+ * input order. At most `limit` invocations run at once. As with `Promise.all`, every item
+ * is still processed; a rejection surfaces after the in-flight wave settles rather than
+ * cancelling work already started (promises cannot be cancelled) — the resolved value in
+ * the success path, and the fact that it rejects in the failure path, are unchanged.
+ */
+export async function mapWithConcurrency<T, R>(
+	items: readonly T[],
+	limit: number,
+	fn: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+	const settled = await mapSettledWithConcurrency(items, limit, fn);
+	const values: R[] = new Array(settled.length);
+	for (let i = 0; i < settled.length; i++) {
+		const outcome = settled[i];
+		if (outcome.status === 'rejected') {
+			throw outcome.reason;
+		}
+		values[i] = outcome.value;
+	}
+	return values;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -26,6 +26,19 @@ export const defaultGatewayPort = 443;
 export const defaultArweaveGatewayPath = `${defaultGatewayProtocol}://${defaultGatewayHost}/`;
 export const gatewayGqlEndpoint = 'graphql';
 
+/**
+ * Default number of transactions requested per GraphQL `transactions(first: …)` page.
+ *
+ * Arweave gateways cap `first` at 1000 and silently clamp anything larger (a request
+ * for 1001 returns 1000, with no error), so 1000 is the largest useful page size. All
+ * paged GraphQL walks in this library are cursor + `pageInfo.hasNextPage` driven, so
+ * this is purely a request-count optimization: a larger page fetches the same entities
+ * in ~10x fewer round-trips versus the previous default of 100, and pagination stays
+ * correct even if a gateway returns fewer than `first` entities for a page (it keeps
+ * following the cursor until `hasNextPage` is false — no entity is ever dropped).
+ */
+export const GQL_PAGE_SIZE = 1000;
+
 export const defaultCipher: CipherType = 'AES256-GCM';
 
 export const fakeEntityId = EID('00000000-0000-0000-0000-000000000000');

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -39,6 +39,25 @@ export const gatewayGqlEndpoint = 'graphql';
  */
 export const GQL_PAGE_SIZE = 1000;
 
+/**
+ * Maximum number of per-entity metadata/data fetches allowed in flight at once when
+ * turning a page of GraphQL edges into built entities (folders/files/drives).
+ *
+ * This is deliberately DECOUPLED from {@link GQL_PAGE_SIZE}: a page can now carry up to
+ * 1000 edges (CORE-7), but building an entity from an edge does a per-entity network GET
+ * of its metadata tx. Firing all 1000 at once would put ~1000 concurrent requests on a
+ * single gateway host — spiking memory and open connections and inviting rate-limits.
+ * Instead every batch is processed in concurrency-limited waves so the request COUNT
+ * still drops ~10x (fewer pages) while the peak PARALLELISM stays bounded here.
+ *
+ * 30 sits in the middle of the recommended 20–50 band: high enough that latency stays
+ * dominated by network round-trip time rather than serialization, yet ~3x BELOW the old
+ * page size of 100 (the pre-CORE-7 worst-case per-batch parallelism), so the larger page
+ * size cannot increase peak concurrent fetches. It is an internal tuning constant; the
+ * entity SET returned is identical regardless of its value — only parallelism changes.
+ */
+export const MAX_CONCURRENT_ENTITY_FETCHES = 30;
+
 export const defaultCipher: CipherType = 'AES256-GCM';
 
 export const fakeEntityId = EID('00000000-0000-0000-0000-000000000000');

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -40,6 +40,49 @@ export const gatewayGqlEndpoint = 'graphql';
 export const GQL_PAGE_SIZE = 1000;
 
 /**
+ * Process-global override for the default GraphQL page size, initialised to
+ * {@link GQL_PAGE_SIZE}. Kept module-private; read via {@link getGqlPageSize} and
+ * only mutated through {@link setGqlPageSize} so the [1, 1000] validation is always
+ * enforced.
+ */
+let configuredGqlPageSize: number = GQL_PAGE_SIZE;
+
+/**
+ * The currently-configured default GraphQL page size used by every paged GraphQL
+ * walk in this library (`transactions(first: …)`, incremental-sync `batchSize`,
+ * snapshot listing). Returns {@link GQL_PAGE_SIZE} (1000, the ar.io gateway max)
+ * unless a consumer has lowered it via {@link setGqlPageSize}.
+ *
+ * Read at CALL time by the query builders, so a later {@link setGqlPageSize} takes
+ * effect for subsequent queries.
+ */
+export function getGqlPageSize(): number {
+	return configuredGqlPageSize;
+}
+
+/**
+ * Override the process-global default GraphQL page size.
+ *
+ * Intended for consumers (e.g. the ArDrive desktop app) whose configured GraphQL
+ * gateway caps `first:` BELOW the 1000 ar.io maximum — Goldsky, for instance,
+ * accepts fewer entities per page. Lowering the default keeps a single request
+ * within such a gateway's per-page limit; pagination stays cursor + `hasNextPage`
+ * driven, so no entity is ever dropped regardless of the value. Explicit per-call
+ * overrides (`first`, `batchSize`) still win over this default.
+ *
+ * @param pageSize integer in `[1, {@link GQL_PAGE_SIZE}]` (1..1000). A gateway
+ *   cannot page more than the 1000 ar.io max meaningfully, so larger values —
+ *   and non-positive or non-integer values — are rejected.
+ * @throws {RangeError} if `pageSize` is not an integer within `[1, 1000]`.
+ */
+export function setGqlPageSize(pageSize: number): void {
+	if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > GQL_PAGE_SIZE) {
+		throw new RangeError(`GraphQL page size must be an integer in [1, ${GQL_PAGE_SIZE}], got: ${pageSize}`);
+	}
+	configuredGqlPageSize = pageSize;
+}
+
+/**
  * Maximum number of per-entity metadata/data fetches allowed in flight at once when
  * turning a page of GraphQL edges into built entities (folders/files/drives).
  *

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -1,5 +1,5 @@
 import { ArweaveAddress, TransactionID, GQLQueryTagInterface } from '../types';
-import { GQL_PAGE_SIZE } from './constants';
+import { getGqlPageSize } from './constants';
 
 const ownerFragment = `
 	owner {
@@ -40,7 +40,6 @@ export type GQLQuery = { query: string };
 export const ASCENDING_ORDER = 'HEIGHT_ASC';
 export const DESCENDING_ORDER = 'HEIGHT_DESC';
 const latestResult = 1;
-const pageLimit = GQL_PAGE_SIZE;
 
 type Sort = typeof ASCENDING_ORDER | typeof DESCENDING_ORDER;
 
@@ -63,8 +62,10 @@ export interface BuildGQLQueryParams {
 	/** Incremental-sync upper block-height bound (alias of maxBlockHeight) [CORE-2]. */
 	maxBlock?: number;
 	/**
-	 * Page size override for `transactions(first: …)`; defaults to {@link GQL_PAGE_SIZE}
-	 * (1000) when unset [CORE-2]. Gateways silently cap this at 1000.
+	 * Page size override for `transactions(first: …)`; defaults to the configured
+	 * page size (`getGqlPageSize()`, initially the 1000 ar.io max) when unset
+	 * [CORE-2]. An explicit value here always wins over the configured default.
+	 * Gateways silently cap this at 1000.
 	 */
 	first?: number;
 }
@@ -119,7 +120,7 @@ export function buildQuery({
 		query: `query {
 			transactions(
 				${ids?.length ? `ids: [${ids.map((id) => `"${id}"`)}]` : ''}
-				first: ${singleResult ? latestResult : first !== undefined ? first : pageLimit}
+				first: ${singleResult ? latestResult : first !== undefined ? first : getGqlPageSize()}
 				sort: ${sort}
 				${singleResult ? '' : `after: "${cursor}"`}
 				${owner === undefined ? '' : `owners: ["${owner}"]`}

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -1,4 +1,5 @@
 import { ArweaveAddress, TransactionID, GQLQueryTagInterface } from '../types';
+import { GQL_PAGE_SIZE } from './constants';
 
 const ownerFragment = `
 	owner {
@@ -39,7 +40,7 @@ export type GQLQuery = { query: string };
 export const ASCENDING_ORDER = 'HEIGHT_ASC';
 export const DESCENDING_ORDER = 'HEIGHT_DESC';
 const latestResult = 1;
-const pageLimit = 100;
+const pageLimit = GQL_PAGE_SIZE;
 
 type Sort = typeof ASCENDING_ORDER | typeof DESCENDING_ORDER;
 
@@ -61,7 +62,10 @@ export interface BuildGQLQueryParams {
 	minBlock?: number;
 	/** Incremental-sync upper block-height bound (alias of maxBlockHeight) [CORE-2]. */
 	maxBlock?: number;
-	/** Incremental-sync page size override; defaults to pageLimit when unset [CORE-2]. */
+	/**
+	 * Page size override for `transactions(first: …)`; defaults to {@link GQL_PAGE_SIZE}
+	 * (1000) when unset [CORE-2]. Gateways silently cap this at 1000.
+	 */
 	first?: number;
 }
 

--- a/src/web/arfsdao_authenticated_web.ts
+++ b/src/web/arfsdao_authenticated_web.ts
@@ -13,7 +13,14 @@ import { GatewayAPI } from '../utils/gateway_api';
 import { TxPreparer } from '../arfs/tx/tx_preparer';
 import { ArFSTagSettings } from '../arfs/arfs_tag_settings';
 import { ArFSTagAssembler } from '../arfs/tags/tag_assembler';
-import { DEFAULT_APP_NAME, DEFAULT_APP_VERSION, defaultArweaveGatewayPath, gqlTagNameRecord } from '../utils/constants';
+import {
+	DEFAULT_APP_NAME,
+	DEFAULT_APP_VERSION,
+	defaultArweaveGatewayPath,
+	gqlTagNameRecord,
+	MAX_CONCURRENT_ENTITY_FETCHES
+} from '../utils/constants';
+import { mapWithConcurrency } from '../utils/concurrency';
 import { TurboWeb, TurboSettings } from './turbo_web';
 import { TurboUploadDataItemResponse } from '@ardrive/turbo-sdk';
 import {
@@ -263,24 +270,30 @@ export class ArFSDAOAuthenticatedWeb extends ArFSDAOAuthenticatedBase {
 			const { edges } = transactions;
 			hasNextPage = transactions.pageInfo.hasNextPage;
 
-			const folderPromises: Promise<ArFSPrivateFolder | null>[] = edges.map(async (edge: GQLEdgeInterface) => {
-				try {
-					cursor = edge.cursor;
-					const { node } = edge;
-					const folderBuilder = ArFSPrivateFolderBuilder.fromArweaveNode(node, this.gatewayApi, driveKey);
-					const folder = await folderBuilder.build(node);
-					return folder;
-				} catch (e) {
-					// If the folder is broken, skip it
-					if (e instanceof SyntaxError) {
-						console.error(`Error building folder. Skipping... Error: ${e}`);
-						return null;
+			// Bounded fan-out: build at most MAX_CONCURRENT_ENTITY_FETCHES folders at a time so a
+			// full (1000-edge) page does not put ~1000 metadata GETs on the gateway at once
+			// [CORE-9]. Order-preserving and skip-on-broken semantics unchanged.
+			const folders = await mapWithConcurrency(
+				edges,
+				MAX_CONCURRENT_ENTITY_FETCHES,
+				async (edge: GQLEdgeInterface) => {
+					try {
+						cursor = edge.cursor;
+						const { node } = edge;
+						const folderBuilder = ArFSPrivateFolderBuilder.fromArweaveNode(node, this.gatewayApi, driveKey);
+						const folder = await folderBuilder.build(node);
+						return folder;
+					} catch (e) {
+						// If the folder is broken, skip it
+						if (e instanceof SyntaxError) {
+							console.error(`Error building folder. Skipping... Error: ${e}`);
+							return null;
+						}
+						throw e;
 					}
-					throw e;
 				}
-			});
+			);
 
-			const folders = await Promise.all(folderPromises);
 			const validFolders = folders.filter((f) => f !== null) as ArFSPrivateFolder[];
 			allFolders.push(...validFolders);
 		}
@@ -317,23 +330,30 @@ export class ArFSDAOAuthenticatedWeb extends ArFSDAOAuthenticatedBase {
 			const { edges } = transactions;
 			hasNextPage = transactions.pageInfo.hasNextPage;
 
-			const files: Promise<ArFSPrivateFile | null>[] = edges.map(async (edge: GQLEdgeInterface) => {
-				try {
-					cursor = edge.cursor;
-					const { node } = edge;
-					const fileBuilder = ArFSPrivateFileBuilder.fromArweaveNode(node, this.gatewayApi, driveKey);
-					const file = await fileBuilder.build(node);
-					return file;
-				} catch (e) {
-					if (e instanceof InvalidFileStateException) {
-						console.error(`Error building file. Skipping... Error: ${e}`);
-						return null;
+			// Bounded fan-out: build at most MAX_CONCURRENT_ENTITY_FETCHES files at a time so a
+			// full (1000-edge) page does not put ~1000 metadata GETs on the gateway at once
+			// [CORE-9]. Order-preserving and skip-on-broken semantics unchanged.
+			const files = await mapWithConcurrency(
+				edges,
+				MAX_CONCURRENT_ENTITY_FETCHES,
+				async (edge: GQLEdgeInterface) => {
+					try {
+						cursor = edge.cursor;
+						const { node } = edge;
+						const fileBuilder = ArFSPrivateFileBuilder.fromArweaveNode(node, this.gatewayApi, driveKey);
+						const file = await fileBuilder.build(node);
+						return file;
+					} catch (e) {
+						if (e instanceof InvalidFileStateException) {
+							console.error(`Error building file. Skipping... Error: ${e}`);
+							return null;
+						}
+						throw e;
 					}
-					throw e;
 				}
-			});
+			);
 
-			const validFiles = (await Promise.all(files)).filter((f) => f !== null) as ArFSPrivateFile[];
+			const validFiles = files.filter((f) => f !== null) as ArFSPrivateFile[];
 			allFiles.push(...validFiles);
 		}
 


### PR DESCRIPTION
## What

Raise the GraphQL page size **100 → 1000** across all listing/snapshot/incremental paths, and bound per-batch entity-fetch concurrency so the larger pages don't multiply parallel fetches.

## Why (measured)

turbo-gateway / ar.io gateways serve up to **1000 items/page** (they silently cap at 1000; `first:1001` → 1000, no error), but core-js requests 100. Live measurement on a real owner-scoped query (982 file+folder entities across 15 drives):

| page size | requests | time | entities |
|---|---|---|---|
| 100 | 10 | 3,628 ms | 982 |
| **1000** | **1** | **550 ms** | 982 |

**~10× fewer GraphQL requests, ~6.6× faster, identical result set** — which also means ~10× less rate-limit exposure.

## Changes

- **Page size (CORE-7):** new `GQL_PAGE_SIZE = 1000` constant routed through `pageLimit` (buildQuery default), both incremental-DAO `batchSize` defaults, and `SNAPSHOT_PAGE_LIMIT`. **Correctness-safe:** all pagination is `hasNextPage`-driven (never `edges.length === pageSize`), so against a gateway that returns fewer than requested it keeps following the cursor — **no entity is ever dropped** (covered by a new capped-gateway test). `batchSize` remains an additive per-call override; public API unchanged.
- **Bounded concurrency (CORE-9):** raising the page 10× would 10× the peak concurrent per-entity metadata fetches per batch. New `src/utils/concurrency.ts` (shared-cursor worker pool, input-order-preserving) caps per-batch fetches at `MAX_CONCURRENT_ENTITY_FETCHES = 30` (~3× below the old page-100 worst case) at all 16 fan-out sites. **Result set is identical** — only parallelism is bounded (index-aligned, same `Promise.all`/`allSettled` semantics, cursor/early-stop/stats untouched); a peak-in-flight test proves ≤ 30 with all entities processed.
- **Query consolidation (CORE-8):** the full-listing paths already fetch files+folders in one multi-value query. The *incremental* file/folder queries are intentionally kept separate — each carries an independent per-type `stopAfterKnownCount` early-stop, and they already run in parallel (`Promise.all`), so a merge would be a ~zero-latency win while risking that invariant.

## Follow-up (not in this PR)

**CORE-10:** the per-entity metadata fetch silently drops a transiently-failed entity (`console.warn` + `failedEntities++`, no retry) — pre-existing; the concurrency cap here restores the prior peak but a bounded retry is worth adding separately.

## Testing

- `yarn typecheck` ✅ · `yarn build` ✅ · eslint (changed files) ✅ · `npx mocha` unit suite **876 passing** (incl. new no-drop + peak-in-flight tests).
- ⚠️ Authored in a linux/arm64 sandbox — the **ArLocal integration suite** (docker) and the **drive-id-gated incremental integration suite** could not run locally. **Please let CI (`yarn ci` on amd64/docker) run them before merge.**

Adversarially reviewed for the no-dropped-entities invariant (capped-gateway proven), worker-pool correctness (run-once + input-order), and no regression to the snapshot/incremental paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved pagination performance for listing and sync operations, with larger page requests that reduce round trips.
  * Added bounded parallel processing to help large folders and drives load more smoothly.

* **Bug Fixes**
  * Fixed cases where pagination could stop early and miss items.
  * Preserved existing behavior for malformed or invalid entities while preventing excessive concurrent requests.

* **Documentation**
  * Updated sync and query guidance to reflect the new default page size and concurrency behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->