### PR TITLE
fix(list): one malformed entity no longer aborts a whole drive listing [CORE-5]

### DIFF
--- a/src/arfs/arfs_builders/arfs_builders.ts
+++ b/src/arfs/arfs_builders/arfs_builders.ts
@@ -23,6 +23,7 @@ import {
 	DriveKey
 } from '../../types';
 import { GatewayAPI } from '../../utils/gateway_api';
+import { InvalidUnixTimeException } from '../../types/exceptions';
 
 export interface ArFSMetadataEntityBuilderParams {
 	entityId: AnyEntityID;
@@ -120,7 +121,17 @@ export abstract class ArFSMetadataEntityBuilder<T extends ArFSEntity> {
 					this.entityType = value as EntityType;
 					break;
 				case 'Unix-Time':
-					this.unixTime = new UnixTime(+value);
+					// A single on-chain entity carrying a malformed Unix-Time (negative /
+					// non-integer / non-finite) must not abort a whole drive listing. The
+					// UnixTime constructor throws a plain Error here; rethrow it as a
+					// catchable InvalidUnixTimeException so LIST/enumeration loops can skip
+					// just this entity. WRITE paths don't go through this parser, so their
+					// strict UnixTime validation is unaffected.
+					try {
+						this.unixTime = new UnixTime(+value);
+					} catch {
+						throw new InvalidUnixTimeException(value);
+					}
 					break;
 				case 'Boost':
 					this.boost = new FeeMultiple(+value);

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -190,7 +190,7 @@ import {
 } from '../exports';
 import { Turbo } from './turbo';
 import { ArweaveSigner } from '@dha-team/arbundles';
-import { InvalidFileStateException } from '../types/exceptions';
+import { InvalidFileStateException, InvalidUnixTimeException } from '../types/exceptions';
 
 /** Utility class for holding the driveId and driveKey of a new drive */
 export class PrivateDriveKeyData {
@@ -1644,6 +1644,12 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 						return null;
 					}
 
+					// A single malformed Unix-Time must not abort the whole drive listing
+					if (e instanceof InvalidUnixTimeException) {
+						console.error(`Error building folder. Skipping... Error: ${e}`);
+						return null;
+					}
+
 					throw e;
 				}
 			});
@@ -1699,6 +1705,12 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 					return this.caches.privateFileCache.put(cacheKey, Promise.resolve(file));
 				} catch (e) {
 					if (e instanceof InvalidFileStateException) {
+						console.error(`Error building file. Skipping... Error: ${e}`);
+						return null;
+					}
+
+					// A single malformed Unix-Time must not abort the whole drive listing
+					if (e instanceof InvalidUnixTimeException) {
 						console.error(`Error building file. Skipping... Error: ${e}`);
 						return null;
 					}

--- a/src/arfs/arfsdao_anonymous.test.ts
+++ b/src/arfs/arfsdao_anonymous.test.ts
@@ -507,5 +507,100 @@ describe('ArFSDAOAnonymous class', () => {
 			expect(`${files[0].fileId}`).to.equal(fileId1);
 			expect(`${files[1].fileId}`).to.equal(fileId3);
 		});
+
+		// CORE-5: one on-chain entity carrying a malformed Unix-Time must not abort the whole
+		// listing. Previously `new UnixTime(+value)` threw a raw Error that no skip-clause caught,
+		// so a single bad entity killed the entire drive reconstruction (found live on drive a173761d).
+		it('skips entities with a malformed Unix-Time and returns the valid ones', async () => {
+			const fileId1 = '9f7038c7-26bd-4856-a843-8de24b828d4e';
+			const badFileId = '1f7038c7-26bd-4856-a843-8de24b828d4e';
+			const fileId3 = '2f7038c7-26bd-4856-a843-8de24b828d4e';
+
+			const validMetaData = Buffer.from(
+				JSON.stringify({
+					name: '2',
+					size: 2048,
+					lastModifiedDate: 1639073634269,
+					dataTxId: 'yAogaGWWYgWO5xWZevb45Y7YRp7E9iDsvkJvfR7To9c',
+					dataContentType: 'text/plain'
+				})
+			);
+			ArFSPublicFileBuilderStub.resolves(validMetaData);
+
+			const mockGQLResponse = {
+				edges: [
+					{
+						cursor: 'cursor1',
+						node: {
+							id: `${stubTxID}`,
+							tags: [
+								{ name: 'App-Name', value: 'ArDrive-CLI' },
+								{ name: 'App-Version', value: '1.2.0' },
+								{ name: 'ArFS', value: '0.15' },
+								{ name: 'Content-Type', value: 'application/json' },
+								{ name: 'Drive-Id', value: 'e93cf9c4-5f20-4d7a-87c4-034777cbb51e' },
+								{ name: 'Entity-Type', value: 'file' },
+								{ name: 'Unix-Time', value: '1639073846' },
+								{ name: 'Parent-Folder-Id', value: '6c312b3e-4778-4a18-8243-f2b346f5e7cb' },
+								{ name: 'File-Id', value: fileId1 }
+							],
+							owner: { address: 'vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI' }
+						}
+					},
+					{
+						// Malformed entity: negative Unix-Time — the UnixTime constructor rejects it.
+						cursor: 'cursor2',
+						node: {
+							id: `${stubTxIDAlt}`,
+							tags: [
+								{ name: 'App-Name', value: 'ArDrive-CLI' },
+								{ name: 'App-Version', value: '1.2.0' },
+								{ name: 'ArFS', value: '0.15' },
+								{ name: 'Content-Type', value: 'application/json' },
+								{ name: 'Drive-Id', value: 'e93cf9c4-5f20-4d7a-87c4-034777cbb51e' },
+								{ name: 'Entity-Type', value: 'file' },
+								{ name: 'Unix-Time', value: '-1' },
+								{ name: 'Parent-Folder-Id', value: '6c312b3e-4778-4a18-8243-f2b346f5e7cb' },
+								{ name: 'File-Id', value: badFileId }
+							],
+							owner: { address: 'vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI' }
+						}
+					},
+					{
+						cursor: 'cursor3',
+						node: {
+							id: `${stubTxIDAltTwo}`,
+							tags: [
+								{ name: 'App-Name', value: 'ArDrive-CLI' },
+								{ name: 'App-Version', value: '1.2.0' },
+								{ name: 'ArFS', value: '0.15' },
+								{ name: 'Content-Type', value: 'application/json' },
+								{ name: 'Drive-Id', value: 'e93cf9c4-5f20-4d7a-87c4-034777cbb51e' },
+								{ name: 'Entity-Type', value: 'file' },
+								{ name: 'Unix-Time', value: '1639073846' },
+								{ name: 'Parent-Folder-Id', value: '6c312b3e-4778-4a18-8243-f2b346f5e7cb' },
+								{ name: 'File-Id', value: fileId3 }
+							],
+							owner: { address: 'vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI' }
+						}
+					}
+				],
+				pageInfo: {
+					hasNextPage: false
+				}
+			};
+			gqlRequestStub.resolves(mockGQLResponse);
+
+			const folderIds = [EID('6c312b3e-4778-4a18-8243-f2b346f5e7cb')];
+			const owner = ADDR('vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI');
+			const driveId = EID('e93cf9c4-5f20-4d7a-87c4-034777cbb51e');
+
+			// Must NOT throw "Unix time must be a positive integer!" — the bad entity is skipped.
+			const files = await dao.getPublicFilesWithParentFolderIds(folderIds, owner, driveId, true);
+
+			expect(files).to.have.lengthOf(2);
+			expect(`${files[0].fileId}`).to.equal(fileId1);
+			expect(`${files[1].fileId}`).to.equal(fileId3);
+		});
 	});
 });

--- a/src/arfs/arfsdao_anonymous.ts
+++ b/src/arfs/arfsdao_anonymous.ts
@@ -27,7 +27,7 @@ import { alphabeticalOrder } from '../utils/sort_functions';
 import { ArFSPublicFileWithPaths, ArFSPublicFolderWithPaths, publicEntityWithPathsFactory } from '../exports';
 import { gatewayUrlForArweave } from '../utils/common';
 import { GatewayAPI } from '../utils/gateway_api';
-import { InvalidFileStateException } from '../types/exceptions';
+import { InvalidFileStateException, InvalidUnixTimeException } from '../types/exceptions';
 
 export abstract class ArFSDAOType {
 	protected abstract readonly arweave: Arweave;
@@ -293,6 +293,12 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 						return null;
 					}
 
+					// A single malformed Unix-Time must not abort the whole drive listing
+					if (e instanceof InvalidUnixTimeException) {
+						console.error(`Error building file. Skipping... Error: ${e}`);
+						return null;
+					}
+
 					throw e;
 				}
 			});
@@ -339,6 +345,12 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 				} catch (e) {
 					// If the folder is broken, skip it
 					if (e instanceof SyntaxError) {
+						console.error(`Error building folder. Skipping... Error: ${e}`);
+						return null;
+					}
+
+					// A single malformed Unix-Time must not abort the whole drive listing
+					if (e instanceof InvalidUnixTimeException) {
 						console.error(`Error building folder. Skipping... Error: ${e}`);
 						return null;
 					}

--- a/src/types/exceptions.ts
+++ b/src/types/exceptions.ts
@@ -12,6 +12,25 @@ export class InvalidFileStateException extends Error {
 	}
 }
 
+/**
+ * Thrown when a single on-chain entity carries a missing/malformed `Unix-Time` tag
+ * (negative, non-integer, non-finite, or otherwise unparseable) while its metadata is
+ * being reconstructed from GQL during a LIST/enumeration.
+ *
+ * Enumeration loops catch this to SKIP the one bad entity rather than abort the whole
+ * drive listing. The strict `UnixTime` validation is preserved for WRITE paths — this
+ * only makes the read/enumeration path resilient to a single malformed entity.
+ */
+export class InvalidUnixTimeException extends Error {
+	readonly rawValue: string;
+
+	constructor(rawValue: string) {
+		super(`Invalid Unix-Time tag value: "${rawValue}"`);
+		this.rawValue = rawValue;
+		this.name = 'InvalidUnixTimeException';
+	}
+}
+
 export class FileBuilderValidation {
 	private missingProperties: string[] = [];
 


### PR DESCRIPTION
## Bug

A single on-chain entity carrying a malformed `Unix-Time` tag aborts the **entire** drive listing.

While reconstructing a file/folder entity from GQL during `listPublicFolder` / `listPrivateFolder`, `arfs_builders.ts` runs `new UnixTime(+value)`. For a negative / non-integer / non-finite value the `UnixTime` constructor throws a plain `Error('Unix time must be a positive integer!')`. None of the enumeration loops' skip clauses (which catch `SyntaxError` / `InvalidFileStateException`) catch a plain `Error`, so it propagates and one bad entity kills the whole drive reconstruction. This is **gateway-independent**.

**Live evidence (2026-07-05, UAT-SYNC-READ-PERMA):** the owner's real public drive `a173761d` hard-errored mid-`listPublicFolder` with exactly this message, blocking the drive from loading at all.

## Fix

Make the LIST/enumeration path resilient to one malformed entity while keeping strict `UnixTime` validation on WRITE paths:

- Add a catchable `InvalidUnixTimeException` (`src/types/exceptions.ts`).
- `ArFSMetadataEntityBuilder.parseFromArweaveNode` now wraps `new UnixTime(+value)` and rethrows a malformed `Unix-Time` as `InvalidUnixTimeException`. WRITE paths don't go through this GQL parser (they build `UnixTime` from `Date.now()` via prototypes), so their strict validation is untouched.
- All four listing enumeration loops skip `InvalidUnixTimeException` and continue, matching the existing `SyntaxError` / `InvalidFileStateException` skip convention:
  - `getPublicFilesWithParentFolderIds`, `getAllFoldersOfPublicDrive` (`arfsdao_anonymous.ts`)
  - `getPrivateFilesWithParentFolderIds`, `getAllFoldersOfPrivateDrive` (`arfsdao.ts`)

**Resilience approach:** SKIP the one bad entity (log + continue), not coerce to a fabricated timestamp — consistent with core-js's existing broken-entity handling and honest (no invented dates).

## Test

`src/arfs/arfsdao_anonymous.test.ts` — new case: a file list containing one entity with `Unix-Time: '-1'` now returns the other two valid files instead of throwing. Modeled on the adjacent `skips invalid files and continues processing` test.

## Verify

- `yarn build`: green.
- `yarn test` (full suite): **676 passing**, incl. the new test and the pre-existing `skips invalid files` test. The lone failure is the pre-existing `ArLocal Integration Tests` `before all` hook (`fetch failed` — requires a live ArLocal server / network; environmental, unrelated to this change).

Base branch `master` (same as PR #275). **Owner-gated for merge — do not merge without owner review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RW9Vws7Mo5ETnP8ZHuGaFB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed Unix time values so a single bad record no longer breaks folder or file listings.
  * Public and private drive listings now skip invalid entries and continue returning the remaining valid results.
  * Added regression coverage to ensure listings remain stable when one item contains an invalid timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->