### PR TITLE
fix(gateway): bound 429 rate-limit retries + request timeout (fixes CLI upload hang)

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -63,6 +63,16 @@ export const defaultMaxConcurrentChunks = 32;
 export const INITIAL_ERROR_DELAY = 500; // 500ms
 
 /**
+ * Default per-request timeout (in ms) applied to the GatewayAPI's default axios
+ * instance. A hung or unresponsive gateway connection fails cleanly after this
+ * window (the resulting network error flows into the normal retry/backoff path)
+ * instead of waiting forever, which previously presented to users as an
+ * indefinite upload "hang". Callers can override via the `requestTimeoutMs`
+ * GatewayAPI constructor option, or by supplying their own `axiosInstance`.
+ */
+export const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 60_000; // 60 seconds
+
+/**
  *  These are errors from the `/chunk` endpoint on an Arweave
  *  node that we should never try to continue on
  */

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -73,6 +73,30 @@ export const INITIAL_ERROR_DELAY = 500; // 500ms
 export const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 60_000; // 60 seconds
 
 /**
+ * Default pause (in ms) applied after a gateway returns an HTTP 429 (rate limit)
+ * before the next request is attempted. Overridable via the GatewayAPI
+ * `rateLimitThrottleMS` constructor option (primarily to keep tests fast).
+ */
+export const DEFAULT_RATE_LIMIT_THROTTLE_MS = 60_000; // 60 seconds
+
+/**
+ * Default maximum number of times a persistent HTTP 429 (rate limit) response is
+ * waited out before the request gives up with a clear, actionable error.
+ *
+ * This bounds the rate-limit throttle loop: a gateway that returns 429 on EVERY
+ * request (e.g. arweave.net now rate-limits CLI traffic) would otherwise pause
+ * for {@link DEFAULT_RATE_LIMIT_THROTTLE_MS} and `continue` forever — the actual
+ * "CLI hangs / upload times out" bug. With this budget the throttle is finite
+ * (default 5 waits ≈ 5 minutes of tolerance) yet a transient throttle that
+ * clears within the budget still succeeds.
+ *
+ * NOTE: this budget is SEPARATE from `maxRetriesPerRequest` — a 429 does not
+ * consume an error retry, and a non-429 error does not consume a rate-limit
+ * retry. The two counters are intentionally independent.
+ */
+export const DEFAULT_MAX_RATE_LIMIT_RETRIES = 5;
+
+/**
  *  These are errors from the `/chunk` endpoint on an Arweave
  *  node that we should never try to continue on
  */

--- a/src/utils/gateway_api.test.ts
+++ b/src/utils/gateway_api.test.ts
@@ -7,7 +7,7 @@ import { describe } from 'mocha';
 import { spy, stub } from 'sinon';
 import { expectAsyncErrorThrow } from '../../tests/test_helpers';
 import { stubTransactionID } from '../types';
-import { FATAL_CHUNK_UPLOAD_ERRORS } from './constants';
+import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS, FATAL_CHUNK_UPLOAD_ERRORS } from './constants';
 import { GatewayAPI } from './gateway_api';
 
 describe('GatewayAPI class', () => {
@@ -186,6 +186,128 @@ describe('GatewayAPI class', () => {
 				promiseToError: gatewayApi.getTransaction(stubTransactionID),
 				errorMessage: 'Transaction could not be found from the gateway: (Status: 400) Bad Error'
 			});
+		});
+	});
+
+	describe('gqlRequest method', () => {
+		// (a) The ar.io ClickHouse row/byte read-limit error (TOO_MANY_ROWS, code 158)
+		// is permanent, so it must fail fast without exhausting the 8 default retries.
+		it('fails fast on a row-limit / TOO_MANY_ROWS error without exhausting retries and surfaces an actionable message', async () => {
+			const rowLimitBody = {
+				data: null,
+				errors: [
+					{
+						message:
+							'Code: 158. DB::Exception: Limit for rows or bytes to read exceeded, ' +
+							'max rows: 10.00 million: While executing MergeTreeThread. (TOO_MANY_ROWS)',
+						path: ['transactions'],
+						locations: [{ line: 1, column: 1 }],
+						extensions: { code: '158' }
+					}
+				]
+			};
+			const axiosSpy = stub(axiosInstance, 'post').resolves({ status: 200, data: rowLimitBody });
+
+			// Default maxRetriesPerRequest (8) — a retry-happy config would call post 9 times.
+			const gatewayApi = new GatewayAPI({ gatewayUrl, axiosInstance, initialErrorDelayMS: 1 });
+
+			let caught: Error | null = null;
+			try {
+				await gatewayApi.gqlRequest({} as any);
+			} catch (err) {
+				caught = err as Error;
+			}
+
+			expect(caught, 'expected gqlRequest to throw').to.be.instanceOf(Error);
+			expect(caught?.message).to.contain('scanned too many rows');
+			expect(caught?.message).to.contain('owner');
+			// Exactly one request — proves the error was treated as fatal, not retried 8x.
+			expect(axiosSpy.callCount).to.equal(1);
+		});
+
+		it('detects the row-limit error via extensions code 158 alone', async () => {
+			const rowLimitBody = {
+				data: null,
+				errors: [{ message: 'internal error', path: [], locations: [], extensions: { code: '158' } }]
+			};
+			const axiosSpy = stub(axiosInstance, 'post').resolves({ status: 200, data: rowLimitBody });
+			const gatewayApi = new GatewayAPI({ gatewayUrl, axiosInstance });
+
+			let caught: Error | null = null;
+			try {
+				await gatewayApi.gqlRequest({} as any);
+			} catch (err) {
+				caught = err as Error;
+			}
+
+			expect(caught?.message).to.contain('scanned too many rows');
+			expect(axiosSpy.callCount).to.equal(1);
+		});
+
+		// (e) The pre-existing statement-timeout handling must be preserved unchanged.
+		it('preserves the statement-timeout behavior (fails fast with the timed-out message)', async () => {
+			const timeoutBody = {
+				data: null,
+				errors: [
+					{
+						message: 'canceling statement due to statement timeout',
+						path: ['transactions'],
+						locations: [{ line: 1, column: 1 }],
+						extensions: { code: '0' }
+					}
+				]
+			};
+			const axiosSpy = stub(axiosInstance, 'post').resolves({ status: 200, data: timeoutBody });
+			const gatewayApi = new GatewayAPI({ gatewayUrl, axiosInstance });
+
+			await expectAsyncErrorThrow({
+				promiseToError: gatewayApi.gqlRequest({} as any),
+				errorMessage: 'GQL Error: GQL Query has been timed out.'
+			});
+
+			expect(axiosSpy.callCount).to.equal(1);
+		});
+	});
+
+	describe('request timeout configuration', () => {
+		// (b) The default axios instance is created with a bounded request timeout.
+		it('creates its default axios instance with the default request timeout', () => {
+			const gatewayApi = new GatewayAPI({ gatewayUrl });
+			expect((gatewayApi as any).axiosInstance.defaults.timeout).to.equal(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS);
+		});
+
+		it('creates its default axios instance with a caller-provided request timeout', () => {
+			const gatewayApi = new GatewayAPI({ gatewayUrl, requestTimeoutMs: 12_345 });
+			expect((gatewayApi as any).axiosInstance.defaults.timeout).to.equal(12_345);
+		});
+
+		// (c) A caller-supplied axios instance is used as-is and never modified.
+		it('uses an externally-supplied axios instance unmodified', () => {
+			const external = axios.create();
+			const originalTimeout = external.defaults.timeout;
+
+			const gatewayApi = new GatewayAPI({ gatewayUrl, axiosInstance: external, requestTimeoutMs: 999 });
+
+			// Same instance reference — not replaced.
+			expect((gatewayApi as any).axiosInstance).to.equal(external);
+			// requestTimeoutMs did NOT clobber the caller's timeout config.
+			expect(external.defaults.timeout).to.equal(originalTimeout);
+		});
+
+		// (d) A transient network/timeout error (rejected promise) still retries then succeeds.
+		it('retries a transient network/timeout error and then succeeds', async () => {
+			const timeoutError = Object.assign(new Error('timeout of 60000ms exceeded'), { code: 'ECONNABORTED' });
+			const axiosSpy = stub(axiosInstance, 'post')
+				.onCall(0)
+				.rejects(timeoutError)
+				.onCall(1)
+				.resolves({ status: 200 });
+
+			const gatewayApi = new GatewayAPI({ gatewayUrl, axiosInstance, initialErrorDelayMS: 1 });
+
+			await gatewayApi.postToEndpoint('');
+
+			expect(axiosSpy.callCount).to.equal(2);
 		});
 	});
 });

--- a/src/utils/gateway_api.test.ts
+++ b/src/utils/gateway_api.test.ts
@@ -248,6 +248,45 @@ describe('GatewayAPI class', () => {
 			expect(axiosSpy.callCount).to.equal(1);
 		});
 
+		// Regression (CodeRabbit finding 1): a PARTIAL response carrying BOTH `data` AND a
+		// row-limit error must FAIL FAST and NOT return the truncated data. Previously the
+		// check lived inside `if (!data.data)`, so a partial response skipped it.
+		it('fails fast on a row-limit error even when partial data is present (does not return truncated data)', async () => {
+			const partialBody = {
+				data: {
+					transactions: {
+						edges: [{ node: { id: 'partial-tx-should-not-be-returned' } }],
+						pageInfo: { hasNextPage: true }
+					}
+				},
+				errors: [
+					{
+						message:
+							'Code: 158. DB::Exception: Limit for rows or bytes to read exceeded, ' +
+							'max rows: 10.00 million. (TOO_MANY_ROWS)',
+						path: ['transactions'],
+						locations: [{ line: 1, column: 1 }],
+						extensions: { code: '158' }
+					}
+				]
+			};
+			const axiosSpy = stub(axiosInstance, 'post').resolves({ status: 200, data: partialBody });
+			const gatewayApi = new GatewayAPI({ gatewayUrl, axiosInstance });
+
+			let caught: Error | null = null;
+			let returned: unknown = 'unset';
+			try {
+				returned = await gatewayApi.gqlRequest({} as any);
+			} catch (err) {
+				caught = err as Error;
+			}
+
+			expect(caught, 'expected a throw, not a return of partial data').to.be.instanceOf(Error);
+			expect(caught?.message).to.contain('scanned too many rows');
+			expect(returned, 'must NOT return the partial/truncated transactions').to.equal('unset');
+			expect(axiosSpy.callCount).to.equal(1);
+		});
+
 		// (e) The pre-existing statement-timeout handling must be preserved unchanged.
 		it('preserves the statement-timeout behavior (fails fast with the timed-out message)', async () => {
 			const timeoutBody = {
@@ -458,6 +497,39 @@ describe('GatewayAPI class', () => {
 			expect(error?.message).to.contain('2 retries');
 			expect(throttleSpy.callCount).to.equal(2); // bounded by the configured value
 			expect(axiosSpy.callCount).to.equal(3); // 2 throttled + 1 that throws
+		});
+
+		// Regression (CodeRabbit finding 2): a rejected request (network error / the axios
+		// timeout this PR added) that follows a 429 must NOT inherit the stale 429 status.
+		// It must take the error-retry/backoff path (no 60s throttle) and NOT consume the
+		// rate-limit budget. maxRateLimitRetries = 1 makes this sharp: if the rejection were
+		// misread as a 2nd 429 it would exceed the budget and throw instead of succeeding.
+		it('treats a post-429 rejection as a normal error, not a 429: 429 -> rejection -> 200 succeeds (finding 2)', async () => {
+			clock = useFakeTimers();
+			const timeoutError = Object.assign(new Error('timeout of 60000ms exceeded'), { code: 'ECONNABORTED' });
+			const axiosSpy = stub(axiosInstance, 'post')
+				.onCall(0)
+				.resolves({ status: 429, statusText: 'Too Many Requests' })
+				.onCall(1)
+				.rejects(timeoutError)
+				.onCall(2)
+				.resolves({ status: 200 });
+			const gatewayApi = new GatewayAPI({
+				gatewayUrl,
+				axiosInstance,
+				maxRateLimitRetries: 1,
+				initialErrorDelayMS: 1
+			});
+			const throttleSpy = spy(gatewayApi as any, 'rateLimitThrottle');
+
+			const { ok, error } = await runToCompletion(gatewayApi.postToEndpoint(''), clock);
+
+			expect(error, 'the rejection must not surface as a rate-limit failure').to.equal(null);
+			expect(ok, '429 -> rejection -> 200 must SUCCEED').to.equal(true);
+			// Only the single genuine 429 throttled; the rejection took the error/backoff
+			// path (NOT a 60s wait) and did NOT consume the rate-limit budget.
+			expect(throttleSpy.callCount).to.equal(1);
+			expect(axiosSpy.callCount).to.equal(3);
 		});
 	});
 });

--- a/src/utils/gateway_api.test.ts
+++ b/src/utils/gateway_api.test.ts
@@ -4,10 +4,14 @@ import Transaction from 'arweave/node/lib/transaction';
 import axios from 'axios';
 import { expect } from 'chai';
 import { describe } from 'mocha';
-import { spy, stub } from 'sinon';
+import { spy, stub, useFakeTimers } from 'sinon';
 import { expectAsyncErrorThrow } from '../../tests/test_helpers';
 import { stubTransactionID } from '../types';
-import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS, FATAL_CHUNK_UPLOAD_ERRORS } from './constants';
+import {
+	DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+	DEFAULT_MAX_RATE_LIMIT_RETRIES,
+	FATAL_CHUNK_UPLOAD_ERRORS
+} from './constants';
 import { GatewayAPI } from './gateway_api';
 
 describe('GatewayAPI class', () => {
@@ -308,6 +312,152 @@ describe('GatewayAPI class', () => {
 			await gatewayApi.postToEndpoint('');
 
 			expect(axiosSpy.callCount).to.equal(2);
+		});
+	});
+
+	describe('rate limit (429) retry bounding', () => {
+		// These tests exercise the REAL retry loop against a stubbed axios, driving the
+		// (default 60s) rate-limit throttle with sinon FAKE TIMERS so there is no real
+		// sleeping. `clock.runAllAsync()` advances every scheduled timer AND flushes the
+		// promise microtasks between them, so the loop runs to completion in real-time ms.
+
+		// Explicitly restore the fake clock after each test so it can never leak into
+		// other suites (the global sinon.restore() would too, but relying on it is
+		// fragile under reordered/parallel runs).
+		let clock: ReturnType<typeof useFakeTimers> | undefined;
+		afterEach(() => {
+			clock?.restore();
+			clock = undefined;
+		});
+
+		// Helper: kick off a request, drive all fake timers to completion, and report the
+		// settled outcome without triggering an unhandled-rejection warning.
+		async function runToCompletion(promise: Promise<unknown>, activeClock: ReturnType<typeof useFakeTimers>) {
+			const settled = promise.then(
+				() => ({ ok: true as const, error: null as Error | null }),
+				(error: Error) => ({ ok: false as const, error })
+			);
+			await activeClock.runAllAsync();
+			return settled;
+		}
+
+		// (a) A gateway that returns 429 on EVERY request must throw the clear rate-limit
+		// error after EXACTLY maxRateLimitRetries throttles — and must NOT loop forever.
+		it('throws a clear error after exactly maxRateLimitRetries throttles on a persistent 429 (no infinite loop)', async () => {
+			clock = useFakeTimers();
+			const axiosSpy = stub(axiosInstance, 'post').resolves({ status: 429, statusText: 'Too Many Requests' });
+			const gatewayApi = new GatewayAPI({ gatewayUrl, axiosInstance }); // default maxRateLimitRetries = 5
+			const throttleSpy = spy(gatewayApi as any, 'rateLimitThrottle');
+
+			const { ok, error } = await runToCompletion(gatewayApi.postToEndpoint(''), clock);
+
+			expect(ok, 'expected the persistent 429 to REJECT, not hang or resolve').to.equal(false);
+			expect(error).to.be.instanceOf(Error);
+			expect(error?.message).to.contain('rate limiting');
+			expect(error?.message).to.contain('HTTP 429');
+			expect(error?.message).to.contain(`${DEFAULT_MAX_RATE_LIMIT_RETRIES}`);
+			// Exactly 5 throttles, then the 6th 429 attempt throws — a FINITE, bounded loop.
+			expect(throttleSpy.callCount).to.equal(DEFAULT_MAX_RATE_LIMIT_RETRIES);
+			expect(axiosSpy.callCount).to.equal(DEFAULT_MAX_RATE_LIMIT_RETRIES + 1);
+		});
+
+		// (b) Transient-throttle tolerance is PRESERVED: a 429 that clears within the
+		// budget must still succeed (no regression — our app/harness wait out arweave.net).
+		it('succeeds when a transient 429 clears within the budget (429, 429, then 200)', async () => {
+			clock = useFakeTimers();
+			const axiosSpy = stub(axiosInstance, 'post')
+				.onCall(0)
+				.resolves({ status: 429, statusText: 'Too Many Requests' })
+				.onCall(1)
+				.resolves({ status: 429, statusText: 'Too Many Requests' })
+				.onCall(2)
+				.resolves({ status: 200 });
+			const gatewayApi = new GatewayAPI({ gatewayUrl, axiosInstance });
+			const throttleSpy = spy(gatewayApi as any, 'rateLimitThrottle');
+
+			const { ok, error } = await runToCompletion(gatewayApi.postToEndpoint(''), clock);
+
+			expect(error, 'transient 429 must not surface an error').to.equal(null);
+			expect(ok, 'a transient 429 that clears must still SUCCEED').to.equal(true);
+			expect(throttleSpy.callCount).to.equal(2); // waited out both 429s
+			expect(axiosSpy.callCount).to.equal(3); // 429, 429, 200
+		});
+
+		// (c) The rate-limit counter and the error-retry counter are INDEPENDENT.
+		// (c1) A 429 bound is reached even though the (ample) error budget is untouched —
+		// and an intervening 5xx error did NOT consume a rate-limit retry.
+		it('bounds 429s on their own budget, independent of an ample error budget (c1)', async () => {
+			clock = useFakeTimers();
+			// One transient 500, then a persistent 429. maxRateLimitRetries = 2 hits first;
+			// maxRetriesPerRequest = 8 stays far from exhaustion.
+			const axiosSpy = stub(axiosInstance, 'post')
+				.onCall(0)
+				.resolves({ status: 500, statusText: 'Server Error' })
+				.resolves({ status: 429, statusText: 'Too Many Requests' });
+			const gatewayApi = new GatewayAPI({
+				gatewayUrl,
+				axiosInstance,
+				maxRetriesPerRequest: 8,
+				maxRateLimitRetries: 2,
+				initialErrorDelayMS: 1
+			});
+			const throttleSpy = spy(gatewayApi as any, 'rateLimitThrottle');
+
+			const { ok, error } = await runToCompletion(gatewayApi.postToEndpoint(''), clock);
+
+			expect(ok).to.equal(false);
+			// The RATE-LIMIT error is thrown (not the generic max-retries error) — proving
+			// the 429 budget bounded the loop while the error budget was still ample.
+			expect(error?.message).to.contain('rate limiting');
+			expect(throttleSpy.callCount).to.equal(2); // exactly maxRateLimitRetries throttles
+			// 1 (500) + 3 (429 x3: 2 throttled then the 3rd throws) = 4 total requests.
+			expect(axiosSpy.callCount).to.equal(4);
+		});
+
+		// (c2) The error budget is exhausted normally even though a 429 occurred first —
+		// proving the 429 did NOT consume an error retry.
+		it('bounds errors on their own budget; a 429 does not consume an error retry (c2)', async () => {
+			clock = useFakeTimers();
+			// One transient 429, then a persistent 500. maxRetriesPerRequest = 2 governs.
+			const axiosSpy = stub(axiosInstance, 'post')
+				.onCall(0)
+				.resolves({ status: 429, statusText: 'Too Many Requests' })
+				.resolves({ status: 500, statusText: 'Server Error' });
+			const gatewayApi = new GatewayAPI({
+				gatewayUrl,
+				axiosInstance,
+				maxRetriesPerRequest: 2,
+				maxRateLimitRetries: 8,
+				initialErrorDelayMS: 1
+			});
+			const throttleSpy = spy(gatewayApi as any, 'rateLimitThrottle');
+
+			const { ok, error } = await runToCompletion(gatewayApi.postToEndpoint(''), clock);
+
+			expect(ok).to.equal(false);
+			// Generic max-retries error (NOT the rate-limit one) — the error budget governed.
+			expect(error?.message).to.contain('Request to gateway has failed');
+			expect(error?.message).to.not.contain('rate limiting');
+			expect(throttleSpy.callCount).to.equal(1); // the single 429 was waited out once
+			// 1 (429) + 3 (500: maxRetriesPerRequest=2 → 3 attempts) = 4 total requests.
+			// If the 429 had consumed an error retry, there would be fewer 500 attempts.
+			expect(axiosSpy.callCount).to.equal(4);
+		});
+
+		// (d) maxRateLimitRetries is configurable via the constructor.
+		it('honors a configurable maxRateLimitRetries', async () => {
+			clock = useFakeTimers();
+			const axiosSpy = stub(axiosInstance, 'post').resolves({ status: 429, statusText: 'Too Many Requests' });
+			const gatewayApi = new GatewayAPI({ gatewayUrl, axiosInstance, maxRateLimitRetries: 2 });
+			const throttleSpy = spy(gatewayApi as any, 'rateLimitThrottle');
+
+			const { ok, error } = await runToCompletion(gatewayApi.postToEndpoint(''), clock);
+
+			expect(ok).to.equal(false);
+			expect(error?.message).to.contain('rate limiting');
+			expect(error?.message).to.contain('2 retries');
+			expect(throttleSpy.callCount).to.equal(2); // bounded by the configured value
+			expect(axiosSpy.callCount).to.equal(3); // 2 throttled + 1 that throws
 		});
 	});
 });

--- a/src/utils/gateway_api.ts
+++ b/src/utils/gateway_api.ts
@@ -4,7 +4,13 @@ import { ArFSMetadataCache } from '../arfs/arfs_metadata_cache';
 import { Chunk } from '../arfs/multi_chunk_tx_uploader';
 import { TransactionID } from '../types';
 import GQLResultInterface, { GQLTransactionsResultInterface } from '../types/gql_Types';
-import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS, FATAL_CHUNK_UPLOAD_ERRORS, INITIAL_ERROR_DELAY } from './constants';
+import {
+	DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+	DEFAULT_MAX_RATE_LIMIT_RETRIES,
+	DEFAULT_RATE_LIMIT_THROTTLE_MS,
+	FATAL_CHUNK_UPLOAD_ERRORS,
+	INITIAL_ERROR_DELAY
+} from './constants';
 import { GQLQuery } from './query';
 
 interface GatewayAPIConstParams {
@@ -19,11 +25,23 @@ interface GatewayAPIConstParams {
 	 * is used as-is and this value is ignored (the caller owns its timeout config).
 	 */
 	requestTimeoutMs?: number;
+	/**
+	 * Maximum number of times a persistent HTTP 429 (rate limit) response is waited
+	 * out before failing with a clear error. Bounds the rate-limit throttle loop so
+	 * a gateway that 429s every request fails cleanly instead of pausing forever.
+	 * Independent of `maxRetriesPerRequest`. Defaults to
+	 * {@link DEFAULT_MAX_RATE_LIMIT_RETRIES}.
+	 */
+	maxRateLimitRetries?: number;
+	/**
+	 * Pause (ms) after a 429 before retrying. Overridable primarily to keep tests
+	 * fast. Defaults to {@link DEFAULT_RATE_LIMIT_THROTTLE_MS} (60s).
+	 */
+	rateLimitThrottleMS?: number;
 	axiosInstance?: AxiosInstance;
 }
 
 const rateLimitStatus = 429;
-const rateLimitTimeout = 60_000; // 60 seconds
 
 // With the current default error delay and max retries, we expect the following wait times after each request sent:
 
@@ -55,6 +73,8 @@ export class GatewayAPI {
 	private initialErrorDelayMS: number;
 	private fatalErrors: string[];
 	private validStatusCodes: number[];
+	private maxRateLimitRetries: number;
+	private rateLimitThrottleMS: number;
 	private axiosInstance: AxiosInstance;
 
 	constructor({
@@ -63,6 +83,8 @@ export class GatewayAPI {
 		initialErrorDelayMS = INITIAL_ERROR_DELAY,
 		fatalErrors = FATAL_CHUNK_UPLOAD_ERRORS,
 		validStatusCodes = [200, 202],
+		maxRateLimitRetries = DEFAULT_MAX_RATE_LIMIT_RETRIES,
+		rateLimitThrottleMS = DEFAULT_RATE_LIMIT_THROTTLE_MS,
 		// NOTE: `requestTimeoutMs` is destructured BEFORE `axiosInstance` so its
 		// resolved default is available to the `axiosInstance` default initializer
 		// below. The timeout is therefore applied only to the default instance we
@@ -75,6 +97,8 @@ export class GatewayAPI {
 		this.initialErrorDelayMS = initialErrorDelayMS;
 		this.fatalErrors = fatalErrors;
 		this.validStatusCodes = validStatusCodes;
+		this.maxRateLimitRetries = maxRateLimitRetries;
+		this.rateLimitThrottleMS = rateLimitThrottleMS;
 		this.axiosInstance = axiosInstance;
 	}
 
@@ -217,6 +241,11 @@ export class GatewayAPI {
 		request: () => Promise<AxiosResponse<T>>
 	): Promise<AxiosResponse<T>> {
 		let retryNumber = 0;
+		// Tracked SEPARATELY from `retryNumber`: a 429 (rate limit) is waited out on
+		// its own bounded budget and does not consume the error-retry budget (and
+		// vice versa). This bound is what prevents a gateway that returns 429 on
+		// every request from pausing `rateLimitThrottleMS` and looping forever.
+		let rateLimitRetries = 0;
 
 		while (retryNumber <= this.maxRetriesPerRequest) {
 			const response = await this.tryRequest<T>(request);
@@ -230,7 +259,16 @@ export class GatewayAPI {
 			this.throwIfFatalError();
 
 			if (this.lastRespStatus === rateLimitStatus) {
-				// When rate limited by the gateway, we will wait without incrementing retry count
+				// When rate limited by the gateway, we wait WITHOUT incrementing the
+				// error-retry count — but bound the number of waits so a persistent
+				// 429 fails cleanly instead of hanging forever.
+				if (rateLimitRetries >= this.maxRateLimitRetries) {
+					throw new Error(
+						`Gateway is rate limiting (HTTP 429) and did not recover after ` +
+							`${this.maxRateLimitRetries} retries; try a different --gateway or wait and retry.`
+					);
+				}
+				rateLimitRetries++;
 				await this.rateLimitThrottle();
 				continue;
 			}
@@ -291,10 +329,10 @@ export class GatewayAPI {
 		console.error(
 			`Gateway has returned a ${
 				this.lastRespStatus
-			} status which means your IP is being rate limited. Pausing for ${(rateLimitTimeout / 1000).toFixed(
+			} status which means your IP is being rate limited. Pausing for ${(this.rateLimitThrottleMS / 1000).toFixed(
 				1
 			)} seconds before trying next request...`
 		);
-		await new Promise((res) => setTimeout(res, rateLimitTimeout));
+		await new Promise((res) => setTimeout(res, this.rateLimitThrottleMS));
 	}
 }

--- a/src/utils/gateway_api.ts
+++ b/src/utils/gateway_api.ts
@@ -143,6 +143,31 @@ export class GatewayAPI {
 				});
 			}
 
+			// The ar.io gateways enforce a ClickHouse read limit (~10M rows/bytes).
+			// A heavy/under-scoped query trips this and returns a permanent error
+			// (message "Limit for rows or bytes to read exceeded ... TOO_MANY_ROWS",
+			// extensions code 158 / INTERNAL_SERVER_ERROR). This is NOT transient, so
+			// we fail fast with an actionable message instead of pointlessly retrying.
+			//
+			// Checked BEFORE the `!data.data` branch: a PARTIAL response can carry BOTH
+			// `data` AND a row-limit error, and silently returning that truncated data
+			// would drop entities. A row-limit error must always fail fast.
+			const isRowLimitError = data.errors?.some(
+				(error) =>
+					error.message.includes('Limit for rows or bytes to read exceeded') ||
+					error.message.includes('TOO_MANY_ROWS') ||
+					error.extensions?.code === '158'
+			);
+
+			if (isRowLimitError) {
+				throw new Error(
+					'The GraphQL query scanned too many rows and was rejected by the gateway ' +
+						'(row/byte read limit exceeded). This usually means the query was under-scoped ' +
+						'against a very large drive or folder. Scope the query by owner and/or drive ID ' +
+						'(or narrow the block/time range) and try again.'
+				);
+			}
+
 			if (!data.data) {
 				const isTimeoutError = data.errors?.some((error) =>
 					error.message.includes('canceling statement due to statement timeout')
@@ -150,27 +175,6 @@ export class GatewayAPI {
 
 				if (isTimeoutError) {
 					throw new Error('GQL Query has been timed out.');
-				}
-
-				// The ar.io gateways enforce a ClickHouse read limit (~10M rows/bytes).
-				// A heavy/under-scoped query trips this and returns a permanent error
-				// (message "Limit for rows or bytes to read exceeded ... TOO_MANY_ROWS",
-				// extensions code 158 / INTERNAL_SERVER_ERROR). This is NOT transient, so
-				// we fail fast with an actionable message instead of pointlessly retrying.
-				const isRowLimitError = data.errors?.some(
-					(error) =>
-						error.message.includes('Limit for rows or bytes to read exceeded') ||
-						error.message.includes('TOO_MANY_ROWS') ||
-						error.extensions?.code === '158'
-				);
-
-				if (isRowLimitError) {
-					throw new Error(
-						'The GraphQL query scanned too many rows and was rejected by the gateway ' +
-							'(row/byte read limit exceeded). This usually means the query was under-scoped ' +
-							'against a very large drive or folder. Scope the query by owner and/or drive ID ' +
-							'(or narrow the block/time range) and try again.'
-					);
 				}
 
 				throw new Error('No data was returned from the GQL request.');
@@ -303,6 +307,12 @@ export class GatewayAPI {
 
 			this.lastError = resp.statusText ?? resp;
 		} catch (err) {
+			// A rejected request (network error, incl. the axios request timeout) has NO
+			// HTTP status. Reset lastRespStatus so a prior 429 doesn't leave it stale —
+			// otherwise the retry loop would misread this rejection as another rate-limit
+			// (429) response, wrongly 60s-throttle it, and consume the rate-limit budget
+			// instead of the normal error-retry/backoff budget.
+			this.lastRespStatus = 0;
 			this.lastError = err instanceof Error ? err.message : `${err}`; // stringify error if unknown type
 		}
 

--- a/src/utils/gateway_api.ts
+++ b/src/utils/gateway_api.ts
@@ -4,7 +4,7 @@ import { ArFSMetadataCache } from '../arfs/arfs_metadata_cache';
 import { Chunk } from '../arfs/multi_chunk_tx_uploader';
 import { TransactionID } from '../types';
 import GQLResultInterface, { GQLTransactionsResultInterface } from '../types/gql_Types';
-import { FATAL_CHUNK_UPLOAD_ERRORS, INITIAL_ERROR_DELAY } from './constants';
+import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS, FATAL_CHUNK_UPLOAD_ERRORS, INITIAL_ERROR_DELAY } from './constants';
 import { GQLQuery } from './query';
 
 interface GatewayAPIConstParams {
@@ -13,6 +13,12 @@ interface GatewayAPIConstParams {
 	initialErrorDelayMS?: number;
 	fatalErrors?: string[];
 	validStatusCodes?: number[];
+	/**
+	 * Per-request timeout (ms) applied ONLY when this class creates its own default
+	 * axios instance. When a caller supplies their own `axiosInstance`, that instance
+	 * is used as-is and this value is ignored (the caller owns its timeout config).
+	 */
+	requestTimeoutMs?: number;
 	axiosInstance?: AxiosInstance;
 }
 
@@ -57,7 +63,12 @@ export class GatewayAPI {
 		initialErrorDelayMS = INITIAL_ERROR_DELAY,
 		fatalErrors = FATAL_CHUNK_UPLOAD_ERRORS,
 		validStatusCodes = [200, 202],
-		axiosInstance = axios.create({ validateStatus: undefined })
+		// NOTE: `requestTimeoutMs` is destructured BEFORE `axiosInstance` so its
+		// resolved default is available to the `axiosInstance` default initializer
+		// below. The timeout is therefore applied only to the default instance we
+		// create — a caller-supplied `axiosInstance` is used unmodified.
+		requestTimeoutMs = DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+		axiosInstance = axios.create({ validateStatus: undefined, timeout: requestTimeoutMs })
 	}: GatewayAPIConstParams) {
 		this.gatewayUrl = gatewayUrl;
 		this.maxRetriesPerRequest = maxRetriesPerRequest;
@@ -115,6 +126,27 @@ export class GatewayAPI {
 
 				if (isTimeoutError) {
 					throw new Error('GQL Query has been timed out.');
+				}
+
+				// The ar.io gateways enforce a ClickHouse read limit (~10M rows/bytes).
+				// A heavy/under-scoped query trips this and returns a permanent error
+				// (message "Limit for rows or bytes to read exceeded ... TOO_MANY_ROWS",
+				// extensions code 158 / INTERNAL_SERVER_ERROR). This is NOT transient, so
+				// we fail fast with an actionable message instead of pointlessly retrying.
+				const isRowLimitError = data.errors?.some(
+					(error) =>
+						error.message.includes('Limit for rows or bytes to read exceeded') ||
+						error.message.includes('TOO_MANY_ROWS') ||
+						error.extensions?.code === '158'
+				);
+
+				if (isRowLimitError) {
+					throw new Error(
+						'The GraphQL query scanned too many rows and was rejected by the gateway ' +
+							'(row/byte read limit exceeded). This usually means the query was under-scoped ' +
+							'against a very large drive or folder. Scope the query by owner and/or drive ID ' +
+							'(or narrow the block/time range) and try again.'
+					);
 				}
 
 				throw new Error('No data was returned from the GQL request.');


### PR DESCRIPTION
## Evidence / repro

A Discord user hit a **"gateway timeout" / indefinite hang while uploading via the CLI**. Live-wire forensics on `GatewayAPI` (`src/utils/gateway_api.ts`) root-caused it to the **429 rate-limit retry loop**, plus two smaller robustness gaps. This PR now carries **two real fixes + one defense-in-depth**:

### (B) THE hang — an unbounded 429 rate-limit loop *(the actual bug)*

arweave.net now **rate-limits CLI traffic and returns HTTP 429 on every request**. The retry loop's 429 branch did:

```ts
if (this.lastRespStatus === rateLimitStatus) {
    await this.rateLimitThrottle(); // 60s sleep
    continue;                        // ← no counter incremented → loops FOREVER
}
```

So a persistently-429 gateway looped **forever at 60s per iteration**. The axios request `timeout` (cause C below) does **not** help this: each 429 *response* is fast — it's the 60s **SLEEP between them** that accumulates, so it needs its own bound.

### (C) Slow data-tx fetches — no request timeout

The axios instance was `axios.create({ validateStatus: undefined })` with **no `timeout`**, so a slow/hung connection (e.g. a large data-tx GET) could wait indefinitely.

### (defense-in-depth) Permanent row-limit errors were retried 8×

ar.io gateways enforce a ClickHouse **~10M-row scan limit**; a heavy/under-scoped GraphQL query returns a permanent `TOO_MANY_ROWS` (code `158`) error that was retried up to `maxRetriesPerRequest = 8`. core-js's own queries don't trip this, so it's kept as **harmless defense-in-depth**, not the reported bug.

## Fix (minimal, surgical, backward-compatible)

**1. Bounded 429 rate-limit RETRY COUNT — the fix for the hang.**
- New `DEFAULT_MAX_RATE_LIMIT_RETRIES = 5` constant + optional `maxRateLimitRetries` constructor field (mirrors `maxRetriesPerRequest`).
- The 429 branch now tracks a **separate** `rateLimitRetries` counter; once it exceeds the budget it throws a **clear, actionable** error:
  > `Gateway is rate limiting (HTTP 429) and did not recover after N retries; try a different --gateway or wait and retry.`
- The two counters stay **independent**: a 429 does **not** consume the error-retry budget and an error does **not** consume a rate-limit retry (preserves the existing "429 doesn't consume error retries" intent — just makes it *finite*).
- **Transient-throttle tolerance preserved:** a 429 that clears within the budget still **succeeds** (default `5 × 60s ≈ 5 min` — our desktop app and on-chain test harness deliberately wait out arweave.net 429s, so this must not regress).
- The throttle duration is now injectable (`rateLimitThrottleMS`, default 60s) — a small, justified testability tweak so tests and the e2e don't sleep for real minutes.

**2. Bounded request timeout — for slow data-tx fetches.**
- `DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 60_000` + a `requestTimeoutMs` option, applied **only** to the axios instance this class creates (`axios.create({ validateStatus: undefined, timeout: requestTimeoutMs })`). A caller-supplied `axiosInstance` is used **unmodified**. A timeout is a network error, so it flows into the existing retry/backoff path (a transient slow response retries) while a truly dead connection can no longer hang forever.

**3. Row-limit error is FATAL / non-retryable (defense-in-depth).**
- `gqlRequest` now detects the ClickHouse signals — `Limit for rows or bytes to read exceeded` **OR** `TOO_MANY_ROWS` **OR** `extensions.code === '158'` — and **fails fast** with an actionable message instead of burning 8 retries.

Everything else is unchanged: statement-timeout handling, exponential backoff, `validStatusCodes`, fatal chunk-upload errors. Only additions to the public surface are the optional `maxRateLimitRetries`, `rateLimitThrottleMS`, `requestTimeoutMs` constructor fields and their constants.

> **Out of scope (tracked separately):** gateway fail-over and changing the default gateway. This PR makes a persistent 429 fail *fast and clearly* so the operator can switch gateways; it does not switch automatically.

## Tests (`src/utils/gateway_api.test.ts`, mocha/chai/sinon, fully stubbed — no live gateway)

**Rate-limit bounding (new, sinon FAKE TIMERS — no real sleeping):**
- Persistent 429 → throws the clear rate-limit error after **exactly** `maxRateLimitRetries` throttles and does **not** loop forever.
- `429, 429, 200` → **succeeds** (transient-throttle tolerance preserved, no regression).
- Rate-limit counter and error-retry counter are **independent** (a mix of 429s and 5xx errors bounds each on its own budget).
- `maxRateLimitRetries` is **configurable** via the constructor.

**Carried from the earlier commit:** `TOO_MANY_ROWS`/code-`158` fails fast without exhausting retries; default & caller-provided request timeout; externally-supplied `axiosInstance` used unmodified; transient network/timeout error retries then succeeds; statement-timeout path unchanged.

**Full end-to-end (real local HTTP 429 server, real axios, real timers, real error propagation — NOT mocked internals):**

```
=== Scenario 1: gateway returns 429 on EVERY request ===
  requests made:  4   (3 throttled + 1 that throws)
  elapsed:        806 ms   (≈ 3 × 200ms throttle; NOT infinite)
  thrown message: GQL Error: Gateway is rate limiting (HTTP 429) and did not
                  recover after 3 retries; try a different --gateway or wait and retry.
  PASS: infinite 60s-pause hang converted to a bounded, clean failure.

=== Scenario 2 (control): 429, 429, then 200 ===
  requests made:  3   (2 throttled + 1 success)
  elapsed:        444 ms
  succeeded:      true
  PASS: transient 429 waited out and the REAL path SUCCEEDED (no regression).
```

## Verification

- `yarn build` (tsc, `tsconfig.prod.json`): **green**.
- Full suite (parallel, matches `yarn test`): **874 passing, 15 pending, 1 failing** — the single failure is the `ArLocal Integration Tests` `before all` hook (`fetch failed`, requires a live local arlocal node), pre-existing and unrelated to this change.
- New GatewayAPI rate-limit suite + e2e: **all passing**.

## Impact

`GatewayAPI` is shared by **CLI, desktop, and web**, so all three benefit. Owner-gated for merge — please do not merge without owner review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhthUpcW83csH1FWtaELZD
