### PR TITLE
feat(download): bounded-concurrency parallel folder downloads

### DIFF
--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -87,6 +87,7 @@ import { deriveDriveKey, deriveFileKey, driveDecrypt } from '../utils/crypto';
 import {
 	DEFAULT_APP_NAME,
 	DEFAULT_APP_VERSION,
+	DEFAULT_DOWNLOAD_CONCURRENCY,
 	authTagLength,
 	defaultMaxConcurrentChunks,
 	ENCRYPTED_DATA_PLACEHOLDER,
@@ -2635,21 +2636,17 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 			const absoluteLocalFolderPath = joinPath(destFolderPath, relativeFolderPath);
 			folderWrapper.ensureFolderExistence(absoluteLocalFolderPath);
 
-			// download child files into the folder
+			// download child files into the folder with bounded concurrency so at
+			// most DEFAULT_DOWNLOAD_CONCURRENCY downloads are ever in flight at once
 			const childrenFiles = childFiles.filter(
 				(file) => `${file.parentFolderId}` === `${folder.entityId}` /* FIXME: use the `equals` method */
 			);
-			for (const file of childrenFiles) {
+			await mapWithConcurrency(childrenFiles, DEFAULT_DOWNLOAD_CONCURRENCY, async (file) => {
 				const relativeFilePath = folderWrapper.getRelativePathOf(
 					privateEntityWithPathsKeylessFactory(file, hierarchy).path
 				);
 				const absoluteLocalFilePath = joinPath(destFolderPath, relativeFilePath);
 
-				/*
-				 * FIXME: Downloading all files at once consumes a lot of resources.
-				 * TODO: Implement a download manager for downloading in parallel
-				 * Doing it sequentially for now
-				 */
 				const dataStream = await this.getPrivateDataStream(file);
 				const fileKey = await deriveFileKey(`${file.fileId}`, driveKey);
 				const fileCipherIVResult = cipherIVMap[`${file.dataTxId}`];
@@ -2665,7 +2662,7 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 					decryptingStream
 				);
 				await fileWrapper.write();
-			}
+			});
 		}
 	}
 

--- a/src/arfs/arfsdao_anonymous.ts
+++ b/src/arfs/arfsdao_anonymous.ts
@@ -29,7 +29,12 @@ import { ArFSPublicFolderBuilder } from './arfs_builders/arfs_folder_builders';
 import { ArFSPublicFileBuilder } from './arfs_builders/arfs_file_builders';
 import { ArFSDriveEntity, ArFSPublicDrive, ArFSPublicFile, ArFSPublicFolder } from './arfs_entities';
 import { PrivateKeyData } from './private_key_data';
-import { DEFAULT_APP_NAME, DEFAULT_APP_VERSION, MAX_CONCURRENT_ENTITY_FETCHES } from '../utils/constants';
+import {
+	DEFAULT_APP_NAME,
+	DEFAULT_APP_VERSION,
+	DEFAULT_DOWNLOAD_CONCURRENCY,
+	MAX_CONCURRENT_ENTITY_FETCHES
+} from '../utils/constants';
 import { mapWithConcurrency } from '../utils/concurrency';
 import axios, { AxiosRequestConfig } from 'axios';
 import { Readable } from 'stream';
@@ -777,25 +782,21 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 			const absoluteLocalFolderPath = joinPath(destFolderPath, relativeFolderPath);
 			folderWrapper.ensureFolderExistence(absoluteLocalFolderPath);
 
-			// download child files into the folder
+			// download child files into the folder with bounded concurrency so at
+			// most DEFAULT_DOWNLOAD_CONCURRENCY downloads are ever in flight at once
 			const childrenFiles = childrenFileEntities.filter(
 				(file) => `${file.parentFolderId}` === `${folder.entityId}` /* FIXME: use the `equals` method */
 			);
-			for (const file of childrenFiles) {
+			await mapWithConcurrency(childrenFiles, DEFAULT_DOWNLOAD_CONCURRENCY, async (file) => {
 				const relativeFilePath = folderWrapper.getRelativePathOf(
 					publicEntityWithPathsFactory(file, hierarchy).path
 				);
 				const absoluteLocalFilePath = joinPath(destFolderPath, relativeFilePath);
 
-				/*
-				 * FIXME: Downloading all files at once consumes a lot of resources.
-				 * TODO: Implement a download manager for downloading in parallel
-				 * Doing it sequentially for now
-				 */
 				const dataStream = await this.getPublicDataStream(file.dataTxId);
 				const fileWrapper = new ArFSPublicFileToDownload(file, dataStream, absoluteLocalFilePath);
 				await fileWrapper.write();
-			}
+			});
 		}
 	}
 }

--- a/src/arfs/folder_download_concurrency.test.ts
+++ b/src/arfs/folder_download_concurrency.test.ts
@@ -1,0 +1,251 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import Arweave from 'arweave';
+import { expect } from 'chai';
+import { stub, SinonStub } from 'sinon';
+import { Readable } from 'stream';
+import {
+	getStubDriveKey,
+	stubArweaveAddress,
+	stubPublicFile,
+	stubPublicFolder,
+	stubPrivateFile,
+	stubPrivateFolder,
+	stubTxID
+} from '../../tests/stubs';
+import { DriveKey, EID, FolderID } from '../types';
+import { RootFolderID } from './arfs_builders/arfs_folder_builders';
+import { ArFSDAOAnonymous } from './arfsdao_anonymous';
+import { ArFSDAO } from './arfsdao';
+import { ArFSPublicFile, ArFSPrivateFile } from './arfs_entities';
+import { FolderHierarchy } from './folder_hierarchy';
+import { ArFSFolderToDownload, ArFSPublicFileToDownload, ArFSPrivateFileToDownload } from './arfs_file_wrapper';
+import { DEFAULT_DOWNLOAD_CONCURRENCY } from '../utils/constants';
+import { readJWKFile } from '../utils/common';
+
+const fakeArweave = Arweave.init({
+	host: 'localhost',
+	port: 443,
+	protocol: 'https',
+	timeout: 600000
+});
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Deterministic, unique entity IDs derived from an index. Uses a valid v4 UUID
+// layout (version nibble 4, variant nibble 8) so uuid.parse in deriveFileKey accepts it.
+const idFromIndex = (i: number): FolderID => EID(`00000000-0000-4000-8000-${i.toString(16).padStart(12, '0')}`);
+
+const ROOT_FOLDER_ID = idFromIndex(1);
+const FILE_COUNT = 12; // > DEFAULT_DOWNLOAD_CONCURRENCY so the pool can saturate
+
+/**
+ * A concurrency tracker used to prove the download pool is truly bounded: every
+ * mocked data-stream fetch bumps a live in-flight counter, holds it for an
+ * artificial delay so tasks overlap, then releases it.
+ */
+class ConcurrencyTracker {
+	inFlight = 0;
+	maxInFlight = 0;
+	totalCalls = 0;
+
+	async track<T>(fn: () => Promise<T>): Promise<T> {
+		this.inFlight++;
+		this.totalCalls++;
+		this.maxInFlight = Math.max(this.maxInFlight, this.inFlight);
+		try {
+			await delay(20);
+			return await fn();
+		} finally {
+			this.inFlight--;
+		}
+	}
+}
+
+describe('bounded-concurrency folder downloads', () => {
+	describe('ArFSDAOAnonymous.downloadPublicFolder', () => {
+		let dao: ArFSDAOAnonymous;
+		let ensureFolderStub: SinonStub;
+		let writeStub: SinonStub;
+
+		const owner = stubArweaveAddress();
+		const rootFolder = stubPublicFolder({
+			folderId: ROOT_FOLDER_ID,
+			parentFolderId: new RootFolderID(),
+			folderName: 'root'
+		});
+
+		const files: ArFSPublicFile[] = Array.from({ length: FILE_COUNT }, (_, i) =>
+			stubPublicFile({
+				fileId: idFromIndex(100 + i),
+				parentFolderId: ROOT_FOLDER_ID,
+				fileName: `file-${i}.txt`,
+				dataTxId: stubTxID
+			})
+		);
+
+		beforeEach(() => {
+			dao = new ArFSDAOAnonymous(fakeArweave);
+			stub(dao, 'getPublicFolder').resolves(rootFolder);
+			stub(dao, 'getAllFoldersOfPublicDrive').resolves([rootFolder]);
+			stub(dao, 'getPublicFilesWithParentFolderIds').resolves(files);
+			// Never touch the real filesystem.
+			ensureFolderStub = stub(ArFSFolderToDownload.prototype, 'ensureFolderExistence').returns(undefined);
+			writeStub = stub(ArFSPublicFileToDownload.prototype, 'write').resolves();
+		});
+
+		afterEach(() => {
+			ensureFolderStub.restore();
+			writeStub.restore();
+		});
+
+		it('writes every file and never exceeds DEFAULT_DOWNLOAD_CONCURRENCY in-flight downloads', async () => {
+			const tracker = new ConcurrencyTracker();
+			const getStreamStub = stub(dao, 'getPublicDataStream').callsFake(async () =>
+				tracker.track(async () => Readable.from(Buffer.from('data')))
+			);
+
+			await dao.downloadPublicFolder({
+				folderId: ROOT_FOLDER_ID,
+				destFolderPath: '/tmp/ardrive-test-dl',
+				maxDepth: 1,
+				owner
+			});
+
+			// (a) all files written
+			expect(writeStub.callCount).to.equal(FILE_COUNT);
+			expect(getStreamStub.callCount).to.equal(FILE_COUNT);
+			expect(tracker.totalCalls).to.equal(FILE_COUNT);
+			// (b) concurrency truly bounded, and the pool saturates to the limit
+			expect(tracker.maxInFlight).to.be.at.most(DEFAULT_DOWNLOAD_CONCURRENCY);
+			expect(tracker.maxInFlight).to.equal(DEFAULT_DOWNLOAD_CONCURRENCY);
+			expect(tracker.inFlight).to.equal(0);
+		});
+
+		it('rejects the whole operation if any file download fails', async () => {
+			let callCount = 0;
+			stub(dao, 'getPublicDataStream').callsFake(async () => {
+				callCount++;
+				if (callCount === 3) {
+					throw new Error('network exploded');
+				}
+				return Readable.from(Buffer.from('data'));
+			});
+
+			let error: Error | undefined;
+			try {
+				await dao.downloadPublicFolder({
+					folderId: ROOT_FOLDER_ID,
+					destFolderPath: '/tmp/ardrive-test-dl',
+					maxDepth: 1,
+					owner
+				});
+			} catch (e) {
+				error = e as Error;
+			}
+			expect(error).to.be.instanceOf(Error);
+			expect(error?.message).to.equal('network exploded');
+		});
+	});
+
+	describe('ArFSDAO.downloadPrivateFolder', () => {
+		const wallet = readJWKFile('./test_wallet.json');
+		let dao: ArFSDAO;
+		let driveKey: DriveKey;
+		let ensureFolderStub: SinonStub;
+		let writeStub: SinonStub;
+		let rootFolder: Awaited<ReturnType<typeof stubPrivateFolder>>;
+		let files: ArFSPrivateFile[];
+
+		const owner = stubArweaveAddress();
+		// 16 zero-bytes base64 — a structurally valid Cipher-IV for StreamDecrypt construction.
+		const validCipherIV = Buffer.alloc(16).toString('base64');
+
+		beforeEach(async () => {
+			driveKey = await getStubDriveKey();
+			rootFolder = await stubPrivateFolder({
+				folderId: ROOT_FOLDER_ID,
+				parentFolderId: new RootFolderID(),
+				folderName: 'root'
+			});
+			files = [];
+			for (let i = 0; i < FILE_COUNT; i++) {
+				files.push(
+					await stubPrivateFile({
+						fileId: idFromIndex(100 + i),
+						parentFolderId: ROOT_FOLDER_ID,
+						fileName: `file-${i}.txt`,
+						dataTxId: stubTxID
+					})
+				);
+			}
+
+			dao = new ArFSDAO(wallet, fakeArweave, true, 'ArFSDAO-Test', '1.0');
+			const hierarchy = FolderHierarchy.newFromEntities([rootFolder]);
+			stub(dao, 'getPrivateFolder').resolves(rootFolder);
+			stub(dao, 'separatedHierarchyOfFolder').resolves({
+				hierarchy,
+				childFiles: files,
+				childFolders: []
+			});
+			stub(dao, 'getCipherIVOfPrivateTransactionIDs').resolves(
+				files.map((file) => ({ txId: file.dataTxId, cipherIV: validCipherIV }))
+			);
+			stub(dao, 'getAuthTagForPrivateFile').resolves(Buffer.alloc(16));
+			ensureFolderStub = stub(ArFSFolderToDownload.prototype, 'ensureFolderExistence').returns(undefined);
+			writeStub = stub(ArFSPrivateFileToDownload.prototype, 'write').resolves();
+		});
+
+		afterEach(() => {
+			ensureFolderStub.restore();
+			writeStub.restore();
+		});
+
+		it('writes every file and never exceeds DEFAULT_DOWNLOAD_CONCURRENCY in-flight downloads', async () => {
+			const tracker = new ConcurrencyTracker();
+			const getStreamStub = stub(dao, 'getPrivateDataStream').callsFake(async () =>
+				tracker.track(async () => Readable.from(Buffer.from('data')))
+			);
+
+			await dao.downloadPrivateFolder({
+				folderId: ROOT_FOLDER_ID,
+				destFolderPath: '/tmp/ardrive-test-dl-priv',
+				maxDepth: 1,
+				driveKey,
+				owner
+			});
+
+			expect(writeStub.callCount).to.equal(FILE_COUNT);
+			expect(getStreamStub.callCount).to.equal(FILE_COUNT);
+			expect(tracker.totalCalls).to.equal(FILE_COUNT);
+			expect(tracker.maxInFlight).to.be.at.most(DEFAULT_DOWNLOAD_CONCURRENCY);
+			expect(tracker.maxInFlight).to.equal(DEFAULT_DOWNLOAD_CONCURRENCY);
+			expect(tracker.inFlight).to.equal(0);
+		});
+
+		it('rejects the whole operation if any file download fails', async () => {
+			let callCount = 0;
+			stub(dao, 'getPrivateDataStream').callsFake(async () => {
+				callCount++;
+				if (callCount === 3) {
+					throw new Error('private network exploded');
+				}
+				return Readable.from(Buffer.from('data'));
+			});
+
+			let error: Error | undefined;
+			try {
+				await dao.downloadPrivateFolder({
+					folderId: ROOT_FOLDER_ID,
+					destFolderPath: '/tmp/ardrive-test-dl-priv',
+					maxDepth: 1,
+					driveKey,
+					owner
+				});
+			} catch (e) {
+				error = e as Error;
+			}
+			expect(error).to.be.instanceOf(Error);
+			expect(error?.message).to.equal('private network exploded');
+		});
+	});
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -132,6 +132,13 @@ export const authTagLength = 16;
 export const defaultMaxConcurrentChunks = 32;
 
 /**
+ * Maximum number of files downloaded in parallel when recursively downloading a
+ * folder (public or private). Bounds resource usage (open sockets, file handles,
+ * memory) while still being meaningfully faster than a fully sequential download.
+ */
+export const DEFAULT_DOWNLOAD_CONCURRENCY = 5;
+
+/**
  * Error delay for the first failed request for a transaction header post or chunk upload
  * Subsequent requests will delay longer with an exponential back off strategy
  */


### PR DESCRIPTION
## What & why

Recursive folder downloads (public **and** private) fetched each file **sequentially** — `for (const file of childrenFiles) { const stream = await getXDataStream(...); await write(); }` — with a `doing it sequentially for now / TODO parallel` FIXME in both `downloadPublicFolder` (`arfsdao_anonymous.ts`) and `downloadPrivateFolder` (`arfsdao.ts`).

This **carries forward the idea from the now-closed #262** (credit **@kunstmusik**, #262), implemented so concurrency is **truly bounded**.

## The fix vs #262's eager-start bug

#262 parallelized the public path with `childrenFiles.map(async …)` and awaited the promises in `Promise.all` batches. That does **not** cap in-flight downloads: `.map` synchronously invokes every async body, and each runs up to its first `await` (`getPublicDataStream`) **immediately** — so all downloads start at once and `Promise.all` merely *awaits* them in groups. The eager-start defeats the intended limit.

This PR uses a real **worker pool** instead:

- New self-contained `src/utils/concurrency.ts`:
  ```ts
  mapWithConcurrency<T, R>(items, limit, fn): Promise<R[]>
  ```
  Workers pull from a shared cursor, so **at most `limit` tasks are ever pending**. Results stay **index-ordered** regardless of settle order, and the **first rejection propagates** (fail-fast; no further tasks started). Kept independent of #275 so this PR is independently mergeable (a comment notes it may later reconcile with #275's GraphQL concurrency helper).
- `DEFAULT_DOWNLOAD_CONCURRENCY = 5` added to `constants.ts`.
- **Both** `downloadPublicFolder` and `downloadPrivateFolder` now drive the per-folder file-download loop through `mapWithConcurrency`. Everything else — path/hierarchy computation, the folder-creation step before downloads, and error semantics (a failed download rejects the operation) — is unchanged.

## Tests

- **`src/utils/concurrency.test.ts`** — the key guarantee: a task fn bumps a live in-flight counter (with an artificial delay so tasks overlap); the observed **max in-flight never exceeds `limit`** (and saturates to it), every item is processed exactly once, results are index-ordered. Plus: a rejecting task fails the whole call, fail-fast (no new tasks after a rejection), `limit > count`, and empty array.
- **`src/arfs/folder_download_concurrency.test.ts`** — for **both** public and private folder downloads (data-stream + `write` mocked, concurrency tracked): (a) all files get written, (b) **at most `DEFAULT_DOWNLOAD_CONCURRENCY` `getXDataStream` calls are in flight at once** (peak observed = 5), (c) a failing download rejects the operation.

`yarn build` (tsc prod) is green. Full `yarn test`: **872 passing, 15 pending, 1 failing** — the sole failure is the pre-existing ArLocal integration `before all` env failure (no local node), unrelated to this change.

## End-to-end evidence (anonymous, no wallet, no funds)

Real public-folder downloads via the built code:

- **turbo-gateway.com** (as requested) — downloaded a real recent public folder for owner `iKryOe…RjA`: **1 file, 117 760 bytes**, on disk, correct count, non-zero. Peak in-flight = 1 (single file).
- **Multi-file bound demonstration** — downloaded a real **20-file** public folder to disk. turbo-gateway only retains this owner's freshest single-file uploads, so this ran against a full-history gateway:
  ```
  === E2E RESULT (gateway=ardrive.net) ===
  Drive: "ArDrive Desktop Drive"
  downloadPublicFolder() returned in: 52662 ms
  PEAK concurrent in-flight downloads: 5 (limit = 5)
  Expected file count: 20
  Downloaded file count: 20   (all non-zero)
  E2E PASSED: 20 files on disk, all non-zero, peak concurrency 5 <= 5.
  ```
  The pool caps at exactly 5 concurrent real network streams — the bound #262 never actually enforced.

Do not merge yet — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhthUpcW83csH1FWtaELZD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Folder downloads now process multiple files concurrently while limiting simultaneous downloads to protect system resources.
  * Download results remain consistent with the original file order.

* **Bug Fixes**
  * Folder downloads now stop promptly when a file download fails and report the first encountered error.

* **Tests**
  * Added coverage for concurrency limits, ordering, empty inputs, invalid limits, and download failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->