### PR TITLE
chore(release): 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.0] - 2026-07-15
+
+### Added
+
+- **Bounded-concurrency parallel folder downloads.** `downloadPublicFolder` and
+  `downloadPrivateFolder` now download a folder's files with a bounded worker pool
+  (`mapWithConcurrency`, `DEFAULT_DOWNLOAD_CONCURRENCY = 5`) instead of one-at-a-time,
+  so at most 5 downloads are ever in flight at once — faster folder downloads without
+  unbounded parallelism. A failing download still rejects the operation. (Carries forward
+  the idea from #262, implemented with a true concurrency cap.)
+
+### Fixed
+
+- **Gateway request no longer hangs indefinitely on a rate-limiting or slow gateway.**
+  `GatewayAPI` now applies a bounded request timeout (`DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS`)
+  and bounds the HTTP 429 rate-limit wait loop (`DEFAULT_MAX_RATE_LIMIT_RETRIES`, default 5)
+  so a gateway that returns 429 on every request fails fast with a clear, actionable error
+  instead of pausing 60s and retrying forever. A rejected/timed-out request also resets the
+  stale response status so it isn't misclassified as another 429. GraphQL responses that trip
+  the gateway's row-scan limit (`TOO_MANY_ROWS`) fail fast with an actionable message even when
+  a partial `data` field is present. Transient-throttle tolerance is preserved (a 429 that
+  clears within the budget still succeeds).
+
 ### Changed
 
 - **Bounded per-batch entity-fetch concurrency (CORE-9)**: turning a page of GraphQL

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ardrive-core-js",
-	"version": "4.1.0",
+	"version": "4.2.0",
 	"description": "ArDrive Core contains the essential back end application features to support the ArDrive CLI and Desktop apps, such as file management, Permaweb upload/download, wallet management and other common functions.",
 	"main": "./lib/exports.js",
 	"types": "./lib/exports.d.ts",


### PR DESCRIPTION
Release **4.2.0** — bundles the merged work since 4.1.0 for npm publish.

## Changes
- **Added:** bounded-concurrency parallel folder downloads (#279)
- **Fixed:** gateway request hang — bounded 429 retries + request timeout + `TOO_MANY_ROWS` fail-fast (#278)
- **Changed:** GraphQL page size 100→1000, tunable via `setGqlPageSize` (CORE-7); bounded per-batch entity-fetch concurrency (CORE-9) (#275)

## Diff
- `package.json`: 4.1.0 → 4.2.0
- `CHANGELOG.md`: `[Unreleased]` → `[4.2.0]` + the download-parallelism entry

## To publish (owner)
Merge this → ensure npm auth (OIDC trusted publisher or `NPM_TOKEN`) → push tag `v4.2.0`. The publish workflow (#277) verifies the tag matches `package.json`, builds `lib/` + `dist/web/`, checks the tarball, and publishes with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved folder downloads by limiting simultaneous file transfers for more reliable performance.

* **Bug Fixes**
  * Added request timeouts to prevent gateway operations from hanging indefinitely.
  * Improved handling of rate limits, transient throttling, and partial GraphQL errors.
  * Ensured failed or timed-out requests correctly reset their status.

* **Chores**
  * Updated the package version to 4.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->