### PR TITLE
feat(arfs): public-file pinning (pinPublicFile, by dataTxId)

### DIFF
--- a/src/ardrive.test.ts
+++ b/src/ardrive.test.ts
@@ -17,7 +17,7 @@ import { readJWKFile } from './utils/common';
 import { expectAsyncErrorThrow, TEST_WALLET_ADDRESS } from '../tests/test_helpers';
 import { WalletDAO } from './wallet_dao';
 import { ArFSTagSettings } from './arfs/arfs_tag_settings';
-import { fakeArweave, stubArweaveAddress, stubEntityID } from '../tests/stubs';
+import { fakeArweave, stubArweaveAddress, stubEntityID, stubEntityIDAlt } from '../tests/stubs';
 import { ArFSUploadPlanner } from './arfs/arfs_upload_planner';
 import { ArweaveSigner } from '@dha-team/arbundles';
 import { JWKWallet } from './jwk_wallet';
@@ -322,6 +322,69 @@ describe('ArDrive class', () => {
 
 			expect(infoSpy.called).to.equal(false);
 			expect(pinSpy.called).to.equal(false);
+		});
+
+		it('throws (before the public-drive guard or any write) when a supplied driveId does not own parentFolderId', async () => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const dao = (arDrive as any).arFsDao;
+			// The folder actually lives in stubEntityID's drive...
+			stub(dao, 'getDriveIdForFolderId').resolves(stubEntityID);
+			// ...but the caller asserts a DIFFERENT (e.g. public) drive. This must be rejected before
+			// the public-drive guard runs — otherwise a public driveId could smuggle a pin into a folder
+			// that really belongs to a private drive.
+			const publicDriveSpy = stub(dao, 'isPublicDrive').resolves(true);
+			const infoSpy = stub(dao, 'getInfoOfTxToBePinned').resolves();
+			const pinSpy = stub(dao, 'pinPublicFile').resolves();
+
+			await expectAsyncErrorThrow({
+				promiseToError: arDrive.pinPublicFile({
+					parentFolderId: stubEntityID,
+					dataTxId,
+					pinnedFileName: 'pinned.png',
+					driveId: stubEntityIDAlt
+				}),
+				errorMessage: `Supplied driveId (${stubEntityIDAlt}) does not own the destination folder (${stubEntityID}), which belongs to drive ${stubEntityID}`
+			});
+
+			// The mismatch is caught before the drive-privacy guard, the source lookup, or any post.
+			expect(publicDriveSpy.called).to.equal(false);
+			expect(infoSpy.called).to.equal(false);
+			expect(pinSpy.called).to.equal(false);
+		});
+
+		it('accepts a supplied driveId that matches the drive resolved from parentFolderId', async () => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const dao = (arDrive as any).arFsDao;
+			const resolveSpy = stub(dao, 'getDriveIdForFolderId').resolves(stubEntityID);
+			stub(dao, 'isPublicDrive').resolves(true);
+			stub(dao, 'getPublicEntityNamesInFolder').resolves([]);
+			stub(dao, 'getInfoOfTxToBePinned').resolves({
+				pinnedDataOwner: stubArweaveAddress(),
+				size: new ByteCount(2048),
+				dataContentType: 'image/png'
+			});
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			stub((arDrive as any).uploadPlanner, 'isTurboUpload').returns(true);
+			const pinStub = stub(dao, 'pinPublicFile').resolves({
+				fileId: stubEntityID,
+				dataTxId,
+				metaDataTxId: stubTransactionID,
+				dataCaches: [],
+				fastFinalityIndexes: []
+			});
+
+			const result = await arDrive.pinPublicFile({
+				parentFolderId: stubEntityID,
+				dataTxId,
+				pinnedFileName: 'pinned.png',
+				driveId: stubEntityID
+			});
+
+			expect(result.created.length).to.equal(1);
+			// The drive is always resolved from the folder, even when a (matching) driveId is supplied.
+			expect(resolveSpy.calledOnce).to.equal(true);
+			// The resolved drive is the one handed to the DAO write.
+			expect(`${pinStub.firstCall.args[0].driveId}`).to.equal(`${stubEntityID}`);
 		});
 
 		it('pins a public file: reuses the dataTxId, sets pinnedDataOwner, returns a new file entity', async () => {

--- a/src/ardrive.test.ts
+++ b/src/ardrive.test.ts
@@ -17,7 +17,7 @@ import { readJWKFile } from './utils/common';
 import { expectAsyncErrorThrow, TEST_WALLET_ADDRESS } from '../tests/test_helpers';
 import { WalletDAO } from './wallet_dao';
 import { ArFSTagSettings } from './arfs/arfs_tag_settings';
-import { fakeArweave, stubEntityID } from '../tests/stubs';
+import { fakeArweave, stubArweaveAddress, stubEntityID } from '../tests/stubs';
 import { ArFSUploadPlanner } from './arfs/arfs_upload_planner';
 import { ArweaveSigner } from '@dha-team/arbundles';
 import { JWKWallet } from './jwk_wallet';
@@ -297,6 +297,74 @@ describe('ArDrive class', () => {
 			);
 
 			expect((await arDriveWithWallet.getOwnerAddress()).toString()).to.equal(TEST_WALLET_ADDRESS);
+		});
+	});
+
+	describe('pinPublicFile function', () => {
+		const dataTxId = stubTransactionID;
+
+		it('throws (before any GQL lookup or post) when the destination drive is private', async () => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const dao = (arDrive as any).arFsDao;
+			stub(dao, 'getDriveIdForFolderId').resolves(stubEntityID);
+			stub(dao, 'isPublicDrive').resolves(false);
+			const infoSpy = stub(dao, 'getInfoOfTxToBePinned').resolves();
+			const pinSpy = stub(dao, 'pinPublicFile').resolves();
+
+			await expectAsyncErrorThrow({
+				promiseToError: arDrive.pinPublicFile({
+					parentFolderId: stubEntityID,
+					dataTxId,
+					pinnedFileName: 'pinned.png'
+				}),
+				errorMessage: 'Pinning is only supported for public drives'
+			});
+
+			expect(infoSpy.called).to.equal(false);
+			expect(pinSpy.called).to.equal(false);
+		});
+
+		it('pins a public file: reuses the dataTxId, sets pinnedDataOwner, returns a new file entity', async () => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const dao = (arDrive as any).arFsDao;
+			stub(dao, 'getDriveIdForFolderId').resolves(stubEntityID);
+			stub(dao, 'isPublicDrive').resolves(true);
+			stub(dao, 'getPublicEntityNamesInFolder').resolves([]);
+			stub(dao, 'getInfoOfTxToBePinned').resolves({
+				pinnedDataOwner: stubArweaveAddress(),
+				size: new ByteCount(2048),
+				dataContentType: 'image/png'
+			});
+			// Force the Turbo path so no AR cost estimation / wallet balance lookup is needed.
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			stub((arDrive as any).uploadPlanner, 'isTurboUpload').returns(true);
+			const pinStub = stub(dao, 'pinPublicFile').resolves({
+				fileId: stubEntityID,
+				dataTxId,
+				metaDataTxId: stubTransactionID,
+				dataCaches: [],
+				fastFinalityIndexes: []
+			});
+
+			const result = await arDrive.pinPublicFile({
+				parentFolderId: stubEntityID,
+				dataTxId,
+				pinnedFileName: 'pinned.png'
+			});
+
+			expect(result.created.length).to.equal(1);
+			expect(result.created[0].type).to.equal('file');
+			expect(`${result.created[0].entityId}`).to.equal(`${stubEntityID}`);
+			expect(`${result.created[0].dataTxId}`).to.equal(`${dataTxId}`);
+			expect(result.created[0].entityName).to.equal('pinned.png');
+
+			// The DAO receives pin metadata reusing the caller's dataTxId with a non-null pinnedDataOwner.
+			const daoArgs = pinStub.firstCall.args[0];
+			expect(`${daoArgs.dataTxId}`).to.equal(`${dataTxId}`);
+			const json = JSON.parse(daoArgs.transactionData.asTransactionData());
+			expect(json.pinnedDataOwner).to.equal(`${stubArweaveAddress()}`);
+			expect(json.dataTxId).to.equal(`${dataTxId}`);
+			expect(json.name).to.equal('pinned.png');
 		});
 	});
 });

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -1101,7 +1101,18 @@ export class ArDrive extends ArDriveAnonymous {
 	}: PinPublicFileParams): Promise<ArFSResult> {
 		assertValidArFSFileName(pinnedFileName);
 
-		const destDriveId = driveId ?? (await this.arFsDao.getDriveIdForFolderId(parentFolderId));
+		// Always resolve the destination drive from the folder that will actually contain the pin —
+		// never trust a caller-supplied driveId. A supplied driveId is treated as an ASSERTION: if it
+		// does not own parentFolderId we throw here, BEFORE the public-drive guard / GQL lookup / post,
+		// so a public driveId can never smuggle a pin (plaintext metadata JSON + ArFS-Pin tags) into a
+		// folder that actually lives in a PRIVATE drive. Mirrors movePublicFile / createPublicFolder,
+		// which resolve the drive from the folder unconditionally.
+		const destDriveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
+		if (driveId && !destDriveId.equals(driveId)) {
+			throw new Error(
+				`Supplied driveId (${driveId}) does not own the destination folder (${parentFolderId}), which belongs to drive ${destDriveId}`
+			);
+		}
 		const owner = await this.getOwnerAddress();
 
 		// Pinning is public-only (R1): a private destination would encrypt the metadata JSON and omit

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -17,6 +17,7 @@ import { isJWKWallet } from './jwk_wallet';
 import { ArFSPrivateFileToDownload, ArFSManifestToUpload, ArFSFileToUpload } from './arfs/arfs_file_wrapper';
 import {
 	ArFSPublicFileMetadataTransactionData,
+	ArFSPublicFilePinMetadataTransactionData,
 	ArFSPrivateFileMetadataTransactionData,
 	ArFSPublicFolderTransactionData,
 	ArFSPrivateFolderTransactionData,
@@ -34,6 +35,7 @@ import {
 	FeeMultiple,
 	ArweaveAddress,
 	ByteCount,
+	UnixTime,
 	AR,
 	FolderID,
 	Winston,
@@ -74,6 +76,7 @@ import {
 	BulkPrivateUploadParams,
 	CreatePublicFolderParams,
 	CreatePrivateFolderParams,
+	PinPublicFileParams,
 	CreatePublicDriveParams,
 	CreatePrivateDriveParams,
 	GetPrivateDriveParams,
@@ -1077,6 +1080,99 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// ArFSResult was empty, return expected empty manifest result
 		return emptyManifestResult;
+	}
+
+	/**
+	 * Pins an EXISTING public data transaction as a NEW public file entity in `parentFolderId`.
+	 *
+	 * A pin reuses the source data tx (`dataTxId`) verbatim — no data bytes are re-uploaded — and
+	 * mints a fresh fileId. Only the small metadata entity is posted (free under Turbo's <100KB
+	 * free tier). The produced entity carries the `ArFS-Pin`/`Pinned-Data-Tx` tags and a
+	 * `pinnedDataOwner` metadata field so it renders as a pin in ardrive-web (interop contract:
+	 * docs/product/PINNING-PLAN-2026-07-19.md §0). Public destinations only — a private drive throws
+	 * (its new fileId would mint a fileKey that cannot decrypt the source's bytes).
+	 */
+	public async pinPublicFile({
+		parentFolderId,
+		dataTxId,
+		pinnedFileName,
+		driveId,
+		conflictResolution
+	}: PinPublicFileParams): Promise<ArFSResult> {
+		assertValidArFSFileName(pinnedFileName);
+
+		const destDriveId = driveId ?? (await this.arFsDao.getDriveIdForFolderId(parentFolderId));
+		const owner = await this.getOwnerAddress();
+
+		// Pinning is public-only (R1): a private destination would encrypt the metadata JSON and omit
+		// the pin tags, and its freshly minted fileId yields a fileKey that cannot decrypt the source's
+		// data. Guard here, BEFORE any GQL lookup or post.
+		if (!(await this.arFsDao.isPublicDrive(destDriveId, owner))) {
+			throw new Error('Pinning is only supported for public drives');
+		}
+
+		// Assert that there are no duplicate names in the destination folder
+		const entityNamesInParentFolder = await this.arFsDao.getPublicEntityNamesInFolder(
+			parentFolderId,
+			owner,
+			destDriveId
+		);
+		if (entityNamesInParentFolder.includes(pinnedFileName)) {
+			if (conflictResolution === skipOnConflicts) {
+				return emptyArFSResult;
+			}
+			throw new Error(errorMessage.entityNameExists);
+		}
+
+		// Resolve the source tx's owner/size/content-type (the one genuinely-new capability).
+		const { pinnedDataOwner, size, dataContentType } = await this.arFsDao.getInfoOfTxToBePinned(dataTxId);
+
+		// lastModifiedDate is minted fresh at pin time, in MILLISECONDS (mirrors ardrive-web).
+		const pinTransactionData = new ArFSPublicFilePinMetadataTransactionData(
+			pinnedFileName,
+			size,
+			new UnixTime(Date.now()),
+			dataTxId,
+			dataContentType,
+			pinnedDataOwner
+		);
+
+		const metaDataBaseReward = this.uploadPlanner.isTurboUpload()
+			? undefined
+			: {
+					reward: (await this.estimateAndAssertCostOfMetaDataTx(pinTransactionData)).metaDataBaseReward,
+					feeMultiple: this.feeMultiple
+				};
+
+		const { fileId, metaDataTxId, metaDataTxReward, dataCaches, fastFinalityIndexes } =
+			await this.arFsDao.pinPublicFile({
+				transactionData: pinTransactionData,
+				dataTxId,
+				driveId: destDriveId,
+				parentFolderId,
+				metaDataBaseReward
+			});
+
+		const result: ArFSResult = {
+			created: [
+				{
+					type: 'file',
+					metadataTxId: metaDataTxId,
+					dataTxId,
+					entityId: fileId,
+					entityName: pinnedFileName,
+					dataCaches,
+					fastFinalityIndexes
+				}
+			],
+			tips: [],
+			fees: {}
+		};
+
+		if (metaDataTxReward) {
+			result.fees = { [`${metaDataTxId}`]: metaDataTxReward };
+		}
+		return result;
 	}
 
 	public async createPublicFolder({ folderName, parentFolderId }: CreatePublicFolderParams): Promise<ArFSResult> {

--- a/src/arfs/arfs_builders/arfs_file_builders.test.ts
+++ b/src/arfs/arfs_builders/arfs_file_builders.test.ts
@@ -76,6 +76,57 @@ describe('ArFSPublicFileBuilder', () => {
 		]);
 	});
 
+	it('leaves pinnedDataOwner / pinnedDataTxId undefined for a normal (non-pin) file', async () => {
+		const builder = ArFSPublicFileBuilder.fromArweaveNode(stubPublicFileGQLNode as GQLNodeInterface, gatewayApi);
+		stub(builder, 'getDataForTxID').resolves(stubPublicFileGetDataResult);
+
+		const fileMetaData = await builder.build(stubPublicFileGQLNode as GQLNodeInterface);
+
+		expect(fileMetaData.pinnedDataOwner).to.equal(undefined);
+		expect(fileMetaData.pinnedDataTxId).to.equal(undefined);
+	});
+
+	it('recognizes a pin: exposes pinnedDataOwner (from JSON) and pinnedDataTxId (from tag)', async () => {
+		const pinnedDataOwner = 'abcdefghijklmnopqrxtuvwxyz123456789ABCDEFGH';
+		const pinnedDataTx = 'yAogaGWWYgWO5xWZevb45Y7YRp7E9iDsvkJvfR7To9c';
+
+		const stubPinNode: Partial<GQLNodeInterface> = {
+			id: `${stubTxID}`,
+			tags: [
+				...(stubPublicFileGQLNode.tags ?? []),
+				{ name: 'ArFS-Pin', value: 'true' },
+				{ name: 'Pinned-Data-Tx', value: pinnedDataTx }
+			]
+		};
+
+		const pinJson = Buffer.from(
+			JSON.stringify({
+				name: 'pinned',
+				size: 2048,
+				lastModifiedDate: 1639073634269,
+				dataTxId: pinnedDataTx,
+				dataContentType: 'image/png',
+				pinnedDataOwner,
+				thumbnail: null,
+				assignedNames: null
+			})
+		);
+
+		const builder = ArFSPublicFileBuilder.fromArweaveNode(stubPinNode as GQLNodeInterface, gatewayApi);
+		stub(builder, 'getDataForTxID').resolves(pinJson);
+
+		const fileMetaData = await builder.build(stubPinNode as GQLNodeInterface);
+
+		expect(fileMetaData.pinnedDataOwner).to.equal(pinnedDataOwner);
+		expect(`${fileMetaData.pinnedDataTxId}`).to.equal(pinnedDataTx);
+		// The pinned data tx is the file's own dataTxId (parsed from the JSON) — it downloads as a normal file.
+		expect(`${fileMetaData.dataTxId}`).to.equal(pinnedDataTx);
+		// Pin markers must NOT leak into customMetaData (they are first-class / consumed).
+		expect(fileMetaData.customMetaDataJson?.pinnedDataOwner).to.equal(undefined);
+		expect(fileMetaData.customMetaDataGqlTags?.['ArFS-Pin']).to.equal(undefined);
+		expect(fileMetaData.customMetaDataGqlTags?.['Pinned-Data-Tx']).to.equal(undefined);
+	});
+
 	it('fromArweaveNode method throws an error File-Id tag is missing', () => {
 		const stubNodeWithoutFileId = {
 			...stubPublicFileGQLNode,

--- a/src/arfs/arfs_builders/arfs_file_builders.test.ts
+++ b/src/arfs/arfs_builders/arfs_file_builders.test.ts
@@ -132,10 +132,14 @@ describe('ArFSPublicFileBuilder', () => {
 		// Two DISTINCT, individually-VALID transaction ids: the tag references one tx, the JSON another.
 		const jsonDataTxId = `${stubTxID}`;
 		const taggedDataTxId = `${stubTxIDAlt}`;
+		// The metadata tx id is deliberately DISTINCT from the JSON dataTxId, so this test only
+		// passes if the builder compares the tag against the JSON dataTxId (not the node id).
+		const pinMetadataTxId = `${stubTxIDAlt}`;
 		expect(jsonDataTxId).to.not.equal(taggedDataTxId);
+		expect(pinMetadataTxId).to.not.equal(jsonDataTxId);
 
 		const stubMismatchedPinNode: Partial<GQLNodeInterface> = {
-			id: `${stubTxID}`,
+			id: pinMetadataTxId,
 			tags: [
 				...(stubPublicFileGQLNode.tags ?? []),
 				{ name: 'ArFS-Pin', value: 'true' },
@@ -172,9 +176,12 @@ describe('ArFSPublicFileBuilder', () => {
 	it('keeps pinnedDataTxId when the Pinned-Data-Tx tag matches the JSON dataTxId', async () => {
 		const pinnedDataOwner = 'abcdefghijklmnopqrxtuvwxyz123456789ABCDEFGH';
 		const matchingDataTxId = `${stubTxID}`;
+		// Metadata tx id distinct from the JSON dataTxId (see the mismatch test above).
+		const pinMetadataTxId = `${stubTxIDAlt}`;
+		expect(pinMetadataTxId).to.not.equal(matchingDataTxId);
 
 		const stubMatchedPinNode: Partial<GQLNodeInterface> = {
-			id: `${stubTxID}`,
+			id: pinMetadataTxId,
 			tags: [
 				...(stubPublicFileGQLNode.tags ?? []),
 				{ name: 'ArFS-Pin', value: 'true' },

--- a/src/arfs/arfs_builders/arfs_file_builders.test.ts
+++ b/src/arfs/arfs_builders/arfs_file_builders.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { fakeArweave, stubTxID } from '../../../tests/stubs';
+import { fakeArweave, stubTxID, stubTxIDAlt } from '../../../tests/stubs';
 import { expectAsyncErrorThrow } from '../../../tests/test_helpers';
 import { DriveSignatureType, GQLNodeInterface } from '../../types';
 import { VersionedDriveKey } from '../../types/entity_key';
@@ -125,6 +125,83 @@ describe('ArFSPublicFileBuilder', () => {
 		expect(fileMetaData.customMetaDataJson?.pinnedDataOwner).to.equal(undefined);
 		expect(fileMetaData.customMetaDataGqlTags?.['ArFS-Pin']).to.equal(undefined);
 		expect(fileMetaData.customMetaDataGqlTags?.['Pinned-Data-Tx']).to.equal(undefined);
+	});
+
+	it('clears pinnedDataTxId when the Pinned-Data-Tx tag disagrees with the JSON dataTxId', async () => {
+		const pinnedDataOwner = 'abcdefghijklmnopqrxtuvwxyz123456789ABCDEFGH';
+		// Two DISTINCT, individually-VALID transaction ids: the tag references one tx, the JSON another.
+		const jsonDataTxId = `${stubTxID}`;
+		const taggedDataTxId = `${stubTxIDAlt}`;
+		expect(jsonDataTxId).to.not.equal(taggedDataTxId);
+
+		const stubMismatchedPinNode: Partial<GQLNodeInterface> = {
+			id: `${stubTxID}`,
+			tags: [
+				...(stubPublicFileGQLNode.tags ?? []),
+				{ name: 'ArFS-Pin', value: 'true' },
+				{ name: 'Pinned-Data-Tx', value: taggedDataTxId }
+			]
+		};
+
+		const pinJson = Buffer.from(
+			JSON.stringify({
+				name: 'pinned',
+				size: 2048,
+				lastModifiedDate: 1639073634269,
+				dataTxId: jsonDataTxId,
+				dataContentType: 'image/png',
+				pinnedDataOwner,
+				thumbnail: null,
+				assignedNames: null
+			})
+		);
+
+		const builder = ArFSPublicFileBuilder.fromArweaveNode(stubMismatchedPinNode as GQLNodeInterface, gatewayApi);
+		stub(builder, 'getDataForTxID').resolves(pinJson);
+
+		const fileMetaData = await builder.build(stubMismatchedPinNode as GQLNodeInterface);
+
+		// The mismatched Pinned-Data-Tx is malformed and must not be trusted...
+		expect(fileMetaData.pinnedDataTxId).to.equal(undefined);
+		// ...while the file's own dataTxId (which downloads it) still comes from the JSON.
+		expect(`${fileMetaData.dataTxId}`).to.equal(jsonDataTxId);
+		// Pin recognition still works via the JSON pinnedDataOwner.
+		expect(fileMetaData.pinnedDataOwner).to.equal(pinnedDataOwner);
+	});
+
+	it('keeps pinnedDataTxId when the Pinned-Data-Tx tag matches the JSON dataTxId', async () => {
+		const pinnedDataOwner = 'abcdefghijklmnopqrxtuvwxyz123456789ABCDEFGH';
+		const matchingDataTxId = `${stubTxID}`;
+
+		const stubMatchedPinNode: Partial<GQLNodeInterface> = {
+			id: `${stubTxID}`,
+			tags: [
+				...(stubPublicFileGQLNode.tags ?? []),
+				{ name: 'ArFS-Pin', value: 'true' },
+				{ name: 'Pinned-Data-Tx', value: matchingDataTxId }
+			]
+		};
+
+		const pinJson = Buffer.from(
+			JSON.stringify({
+				name: 'pinned',
+				size: 2048,
+				lastModifiedDate: 1639073634269,
+				dataTxId: matchingDataTxId,
+				dataContentType: 'image/png',
+				pinnedDataOwner,
+				thumbnail: null,
+				assignedNames: null
+			})
+		);
+
+		const builder = ArFSPublicFileBuilder.fromArweaveNode(stubMatchedPinNode as GQLNodeInterface, gatewayApi);
+		stub(builder, 'getDataForTxID').resolves(pinJson);
+
+		const fileMetaData = await builder.build(stubMatchedPinNode as GQLNodeInterface);
+
+		expect(`${fileMetaData.pinnedDataTxId}`).to.equal(matchingDataTxId);
+		expect(`${fileMetaData.dataTxId}`).to.equal(matchingDataTxId);
 	});
 
 	it('fromArweaveNode method throws an error File-Id tag is missing', () => {

--- a/src/arfs/arfs_builders/arfs_file_builders.ts
+++ b/src/arfs/arfs_builders/arfs_file_builders.ts
@@ -39,6 +39,11 @@ export abstract class ArFSFileBuilder<T extends ArFSPublicFile | ArFSPrivateFile
 	dataTxId?: TransactionID;
 	dataContentType?: DataContentType;
 	isHidden?: boolean;
+	// Pin recognition (mirrors ardrive-web). `pinnedDataOwner` is read from the data JSON in
+	// buildEntity (the recognition key); `pinnedDataTxId` is promoted from the `Pinned-Data-Tx`
+	// tag below. Both stay undefined for a normal (non-pin) file.
+	pinnedDataOwner?: string;
+	pinnedDataTxId?: TransactionID;
 
 	getGqlQueryParameters(): GQLTagInterface[] {
 		return [
@@ -48,8 +53,33 @@ export abstract class ArFSFileBuilder<T extends ArFSPublicFile | ArFSPrivateFile
 	}
 
 	protected async parseFromArweaveNode(node?: GQLNodeInterface, owner?: ArweaveAddress): Promise<GQLTagInterface[]> {
+		const unparsedTags: GQLTagInterface[] = [];
 		const tags = await super.parseFromArweaveNode(node, owner);
-		return tags.filter((tag) => tag.name !== 'File-Id');
+		tags.forEach((tag) => {
+			const key = tag.name;
+			const { value } = tag;
+			switch (key) {
+				case 'File-Id':
+					// Already sourced from the GQL query parameters; drop it here.
+					break;
+				case 'Pinned-Data-Tx':
+					// Secondary pin signal — promote to a first-class field. Tolerate a malformed
+					// value (recognition still works via the JSON `pinnedDataOwner`).
+					try {
+						this.pinnedDataTxId = new TransactionID(value);
+					} catch {
+						// ignore an invalid Pinned-Data-Tx tag
+					}
+					break;
+				case 'ArFS-Pin':
+					// Consumed so it does not leak into customMetaData; recognition is via pinnedDataOwner.
+					break;
+				default:
+					unparsedTags.push(tag);
+					break;
+			}
+		});
+		return unparsedTags;
 	}
 
 	protected readonly protectedDataJsonKeys = [
@@ -58,7 +88,11 @@ export abstract class ArFSFileBuilder<T extends ArFSPublicFile | ArFSPrivateFile
 		'lastModifiedDate',
 		'dataTxId',
 		'dataContentType',
-		'isHidden'
+		'isHidden',
+		// Pin fields (first-class / intentionally-null) — keep them out of customMetaData.
+		'pinnedDataOwner',
+		'thumbnail',
+		'assignedNames'
 	];
 
 	// CORE-6: Enumerates which required top-level (pre-decryption) properties are absent, so
@@ -113,6 +147,9 @@ export class ArFSPublicFileBuilder extends ArFSFileBuilder<ArFSPublicFile> {
 			this.dataTxId = new TransactionID(dataJSON.dataTxId);
 			this.dataContentType = dataJSON.dataContentType || extToMime(this.name);
 			this.isHidden = typeof dataJSON.isHidden === 'boolean' ? dataJSON.isHidden : undefined;
+			// Pin recognition key: present (and non-null) iff this file entity is a pin. Read
+			// defensively — a non-pin file simply leaves it undefined (PINNING-PLAN §0.3).
+			this.pinnedDataOwner = typeof dataJSON.pinnedDataOwner === 'string' ? dataJSON.pinnedDataOwner : undefined;
 
 			const fileBuilderValidation = new FileBuilderValidation();
 			fileBuilderValidation.validateFileProperties(this);
@@ -140,6 +177,8 @@ export class ArFSPublicFileBuilder extends ArFSFileBuilder<ArFSPublicFile> {
 				this.customMetaData.metaDataJson
 			);
 			publicFile.isHidden = this.isHidden;
+			publicFile.pinnedDataOwner = this.pinnedDataOwner;
+			publicFile.pinnedDataTxId = this.pinnedDataTxId;
 			return Promise.resolve(publicFile);
 		}
 		// CORE-6: A file entity that is missing a required top-level property (a genuinely

--- a/src/arfs/arfs_builders/arfs_file_builders.ts
+++ b/src/arfs/arfs_builders/arfs_file_builders.ts
@@ -145,6 +145,13 @@ export class ArFSPublicFileBuilder extends ArFSFileBuilder<ArFSPublicFile> {
 			this.size = new ByteCount(dataJSON.size);
 			this.lastModifiedDate = new UnixTime(dataJSON.lastModifiedDate);
 			this.dataTxId = new TransactionID(dataJSON.dataTxId);
+			// Pin tx-id consistency: the `Pinned-Data-Tx` tag (promoted to `pinnedDataTxId` in
+			// parseFromArweaveNode) must reference the same tx as the JSON `dataTxId`. A mismatch is
+			// malformed — clear it, matching how an invalid `Pinned-Data-Tx` tag is dropped above, so we
+			// never report one tx in `pinnedDataTxId` while the file downloads another via `dataTxId`.
+			if (this.pinnedDataTxId && !this.pinnedDataTxId.equals(this.dataTxId)) {
+				this.pinnedDataTxId = undefined;
+			}
 			this.dataContentType = dataJSON.dataContentType || extToMime(this.name);
 			this.isHidden = typeof dataJSON.isHidden === 'boolean' ? dataJSON.isHidden : undefined;
 			// Pin recognition key: present (and non-null) iff this file entity is a pin. Read

--- a/src/arfs/arfs_entities.ts
+++ b/src/arfs/arfs_entities.ts
@@ -268,6 +268,14 @@ export abstract class ArFSFileOrFolderEntity<T extends 'file' | 'folder'>
 	// builders after construction to avoid threading through every positional entity constructor.
 	public isHidden?: boolean;
 
+	// Pin recognition (mirrors ardrive-web). A pin is an entity whose metadata-JSON `dataTxId`
+	// points at an existing data tx; `pinnedDataOwner` (owner of that source tx, parsed from the
+	// data JSON) is THE recognition key — non-null iff this is a pin. `pinnedDataTxId` is promoted
+	// from the `Pinned-Data-Tx` tag when present. Both are undefined for a normal (non-pin) file.
+	// Populated by the builders after construction (same rationale as `isHidden`).
+	public pinnedDataOwner?: string;
+	public pinnedDataTxId?: TransactionID;
+
 	constructor(
 		appName: string,
 		appVersion: string,
@@ -397,6 +405,8 @@ export class ArFSPublicFileWithPaths extends ArFSPublicFile implements ArFSWithP
 			entity.customMetaDataJson
 		);
 		this.isHidden = entity.isHidden;
+		this.pinnedDataOwner = entity.pinnedDataOwner;
+		this.pinnedDataTxId = entity.pinnedDataTxId;
 
 		this.path = `${hierarchy.pathToFolderId(entity.parentFolderId)}${entity.name}`;
 		this.txIdPath = `${hierarchy.txPathToFolderId(entity.parentFolderId)}${entity.txId}`;
@@ -485,6 +495,8 @@ export class ArFSPrivateFileWithPaths extends ArFSPrivateFile implements ArFSWit
 			entity.customMetaDataJson
 		);
 		this.isHidden = entity.isHidden;
+		this.pinnedDataOwner = entity.pinnedDataOwner;
+		this.pinnedDataTxId = entity.pinnedDataTxId;
 
 		this.path = `${hierarchy.pathToFolderId(entity.parentFolderId)}${entity.name}`;
 		this.txIdPath = `${hierarchy.txPathToFolderId(entity.parentFolderId)}${entity.txId}`;
@@ -535,6 +547,8 @@ export class ArFSPrivateFileKeyless extends ArFSPrivateFile {
 			entity.customMetaDataJson
 		);
 		this.isHidden = entity.isHidden;
+		this.pinnedDataOwner = entity.pinnedDataOwner;
+		this.pinnedDataTxId = entity.pinnedDataTxId;
 		// @ts-expect-error
 		delete this.driveKey;
 		// @ts-expect-error
@@ -603,6 +617,8 @@ export class ArFSPublicFolderWithPaths extends ArFSPublicFolder implements ArFSW
 			entity.customMetaDataJson
 		);
 		this.isHidden = entity.isHidden;
+		this.pinnedDataOwner = entity.pinnedDataOwner;
+		this.pinnedDataTxId = entity.pinnedDataTxId;
 
 		this.path = `${hierarchy.pathToFolderId(entity.parentFolderId)}${entity.name}`;
 		this.txIdPath = `${hierarchy.txPathToFolderId(entity.parentFolderId)}${entity.txId}`;
@@ -677,6 +693,8 @@ export class ArFSPrivateFolderWithPaths extends ArFSPrivateFolder implements ArF
 			entity.customMetaDataJson
 		);
 		this.isHidden = entity.isHidden;
+		this.pinnedDataOwner = entity.pinnedDataOwner;
+		this.pinnedDataTxId = entity.pinnedDataTxId;
 
 		this.path = `${hierarchy.pathToFolderId(entity.parentFolderId)}${entity.name}`;
 		this.txIdPath = `${hierarchy.txPathToFolderId(entity.parentFolderId)}${entity.txId}`;
@@ -718,6 +736,8 @@ export class ArFSPrivateFolderKeyless extends ArFSPrivateFolder {
 			entity.customMetaDataJson
 		);
 		this.isHidden = entity.isHidden;
+		this.pinnedDataOwner = entity.pinnedDataOwner;
+		this.pinnedDataTxId = entity.pinnedDataTxId;
 		// @ts-expect-error
 		delete this.driveKey;
 	}

--- a/src/arfs/arfs_entity_result_factory.ts
+++ b/src/arfs/arfs_entity_result_factory.ts
@@ -107,6 +107,12 @@ export interface ArFSMoveFileResult extends ArFSMoveEntityResult {
 	dataTxId: TransactionID;
 }
 
+/** Result of pinning a public file: a NEW fileId plus the reused (unchanged) data tx. */
+export interface ArFSPinPublicFileResult extends ArFSWriteResult {
+	fileId: FileID;
+	dataTxId: TransactionID;
+}
+
 export type ArFSRenameEntityResult = ArFSWriteResult;
 
 export interface ArFSRenameFileResult extends ArFSRenameEntityResult {

--- a/src/arfs/arfsdao.test.ts
+++ b/src/arfs/arfsdao.test.ts
@@ -26,7 +26,9 @@ import {
 	stubSmallFileToUpload,
 	stubSignedTransaction
 } from '../../tests/stubs';
-import { DriveKey, EID, FeeMultiple, FileID, FileKey, FolderID, W } from '../types';
+import { ByteCount, DriveKey, EID, FeeMultiple, FileID, FileKey, FolderID, UnixTime, W } from '../types';
+import { ArFSPublicFilePinMetadataTransactionData } from './tx/arfs_tx_data_types';
+import { ArFSPublicFilePinMetaDataPrototype } from './tx/arfs_prototypes';
 import { readJWKFile, BufferToString } from '../utils/common';
 import {
 	ArFSCache,
@@ -40,7 +42,7 @@ import { ArFSPrivateDrive, ArFSPrivateFile, ArFSPrivateFolder } from './arfs_ent
 import { ArFSPrivateFileBuilder } from './arfs_builders/arfs_file_builders';
 import { InvalidFileStateException } from '../types/exceptions';
 import { ArFSPublicFolderCacheKey, defaultArFSAnonymousCache, defaultCacheParams } from './arfsdao_anonymous';
-import { stub, SinonStub } from 'sinon';
+import { spy, stub, SinonStub } from 'sinon';
 import { expect } from 'chai';
 import { expectAsyncErrorThrow, getDecodedTags } from '../../tests/test_helpers';
 import { deriveFileKey, driveDecrypt, fileDecrypt } from '../utils/crypto';
@@ -1185,6 +1187,134 @@ describe('The ArFSDAO class', () => {
 			expect(+fileDataReward).to.equal(10);
 
 			expect(newMetaDataInfo).to.be.undefined;
+		});
+	});
+
+	describe('pin methods', () => {
+		const pinDataTxId = stubTxID; // the EXISTING data tx being pinned (43-char tx id)
+		const pinnedDataOwner = stubArweaveAddress();
+
+		const buildPinTxData = (): ArFSPublicFilePinMetadataTransactionData =>
+			new ArFSPublicFilePinMetadataTransactionData(
+				'pinned file',
+				new ByteCount(2048),
+				new UnixTime(1700000000000),
+				pinDataTxId,
+				'image/png',
+				pinnedDataOwner
+			);
+
+		describe('getInfoOfTxToBePinned', () => {
+			it('resolves owner, size and content type of the source tx from GQL', async () => {
+				stub(fakeGatewayApi, 'gqlRequest').resolves({
+					pageInfo: { hasNextPage: false },
+					edges: [
+						{
+							cursor: '',
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							node: {
+								id: `${pinDataTxId}`,
+								owner: { address: `${pinnedDataOwner}`, key: '' },
+								data: { size: 2048, type: 'image/png' },
+								tags: []
+								// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							} as any
+						}
+					]
+				});
+
+				const info = await arfsDao.getInfoOfTxToBePinned(pinDataTxId);
+				expect(`${info.pinnedDataOwner}`).to.equal(`${pinnedDataOwner}`);
+				expect(+info.size).to.equal(2048);
+				expect(info.dataContentType).to.equal('image/png');
+			});
+
+			it('falls back to the Content-Type tag when GQL data.type is empty', async () => {
+				stub(fakeGatewayApi, 'gqlRequest').resolves({
+					pageInfo: { hasNextPage: false },
+					edges: [
+						{
+							cursor: '',
+							node: {
+								id: `${pinDataTxId}`,
+								owner: { address: `${pinnedDataOwner}`, key: '' },
+								data: { size: 10, type: '' },
+								tags: [{ name: 'Content-Type', value: 'text/plain' }]
+								// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							} as any
+						}
+					]
+				});
+
+				const info = await arfsDao.getInfoOfTxToBePinned(pinDataTxId);
+				expect(info.dataContentType).to.equal('text/plain');
+			});
+
+			it('throws a clear error when the source data tx is not found', async () => {
+				stub(fakeGatewayApi, 'gqlRequest').resolves({ pageInfo: { hasNextPage: false }, edges: [] });
+				await expectAsyncErrorThrow({
+					promiseToError: arfsDao.getInfoOfTxToBePinned(pinDataTxId),
+					errorMessage: `The data transaction to be pinned ("${pinDataTxId}") could not be found on the gateway!`
+				});
+			});
+		});
+
+		describe('pinPublicFile', () => {
+			it('mints a NEW fileId, reuses the caller dataTxId, and posts metadata only (no data data-item)', async () => {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				const uploadMetaDataStub = stub(arfsDao as any, 'uploadMetaData').resolves({
+					id: stubTxIDAlt,
+					dataCaches: ['https://arweave.net'],
+					fastFinalityIndexes: ['https://arweave.net']
+				});
+				// A pin never builds a file DATA transaction/data-item (no getFileDataBuffer).
+				const fileDataTxSpy = spy(arfsDao['txPreparer'], 'prepareFileDataTx');
+				const fileDataItemSpy = spy(arfsDao['txPreparer'], 'prepareFileDataDataItem');
+
+				const result = await arfsDao.pinPublicFile({
+					transactionData: buildPinTxData(),
+					dataTxId: pinDataTxId,
+					driveId: stubEntityID,
+					parentFolderId: stubEntityIDAlt,
+					metaDataBaseReward: { reward: W(10) }
+				});
+
+				// New fileId (a fresh uuid), never the source's dataTxId
+				expect(`${result.fileId}`).to.match(entityIdRegex);
+				expect(`${result.fileId}`).to.not.equal(`${pinDataTxId}`);
+				// dataTxId passes through unchanged
+				expect(`${result.dataTxId}`).to.equal(`${pinDataTxId}`);
+				expect(`${result.metaDataTxId}`).to.equal(`${stubTxIDAlt}`);
+				// metadata-only
+				expect(fileDataTxSpy.called).to.equal(false);
+				expect(fileDataItemSpy.called).to.equal(false);
+				expect(uploadMetaDataStub.calledOnce).to.equal(true);
+			});
+
+			it('builds a pin prototype carrying the ArFS-Pin/Pinned-Data-Tx tags and pinnedDataOwner JSON', async () => {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				const uploadMetaDataStub = stub(arfsDao as any, 'uploadMetaData').resolves({ id: stubTxIDAlt });
+
+				await arfsDao.pinPublicFile({
+					transactionData: buildPinTxData(),
+					dataTxId: pinDataTxId,
+					driveId: stubEntityID,
+					parentFolderId: stubEntityIDAlt,
+					metaDataBaseReward: { reward: W(10) }
+				});
+
+				const prototype = uploadMetaDataStub.firstCall.args[0] as ArFSPublicFilePinMetaDataPrototype;
+				expect(prototype).to.be.instanceOf(ArFSPublicFilePinMetaDataPrototype);
+
+				const tags = prototype.gqlTags;
+				expect(tags.find((t) => t.name === 'ArFS-Pin')?.value).to.equal('true');
+				expect(tags.find((t) => t.name === 'Pinned-Data-Tx')?.value).to.equal(`${pinDataTxId}`);
+				expect(tags.find((t) => t.name === 'Entity-Type')?.value).to.equal('file');
+
+				const json = JSON.parse(prototype.objectData.asTransactionData() as string);
+				expect(json.pinnedDataOwner).to.equal(`${pinnedDataOwner}`);
+				expect(json.dataTxId).to.equal(`${pinDataTxId}`);
+			});
 		});
 	});
 });

--- a/src/arfs/arfsdao.test.ts
+++ b/src/arfs/arfsdao.test.ts
@@ -1215,7 +1215,8 @@ describe('The ArFSDAO class', () => {
 							node: {
 								id: `${pinDataTxId}`,
 								owner: { address: `${pinnedDataOwner}`, key: '' },
-								data: { size: 2048, type: 'image/png' },
+								// The real gateway returns data.size as a STRING (schema String!).
+								data: { size: '2048', type: 'image/png' },
 								tags: []
 								// eslint-disable-next-line @typescript-eslint/no-explicit-any
 							} as any
@@ -1238,7 +1239,8 @@ describe('The ArFSDAO class', () => {
 							node: {
 								id: `${pinDataTxId}`,
 								owner: { address: `${pinnedDataOwner}`, key: '' },
-								data: { size: 10, type: '' },
+								// STRING size + null type (both as a real gateway returns them).
+								data: { size: '10', type: null },
 								tags: [{ name: 'Content-Type', value: 'text/plain' }]
 								// eslint-disable-next-line @typescript-eslint/no-explicit-any
 							} as any
@@ -1255,6 +1257,53 @@ describe('The ArFSDAO class', () => {
 				await expectAsyncErrorThrow({
 					promiseToError: arfsDao.getInfoOfTxToBePinned(pinDataTxId),
 					errorMessage: `The data transaction to be pinned ("${pinDataTxId}") could not be found on the gateway!`
+				});
+			});
+
+			// Regression (Vector 5): the gateway returns data.size as a STRING (schema String!). A prior
+			// `new ByteCount(node.data.size)` threw on every real pin; a number-shaped stub hid it. This
+			// test fails against that code and passes with the Number() coercion.
+			it('coerces a string-shaped GQL data.size ("747") into the correct byte size', async () => {
+				stub(fakeGatewayApi, 'gqlRequest').resolves({
+					pageInfo: { hasNextPage: false },
+					edges: [
+						{
+							cursor: '',
+							node: {
+								id: `${pinDataTxId}`,
+								owner: { address: `${pinnedDataOwner}`, key: '' },
+								data: { size: '747', type: 'image/png' },
+								tags: []
+								// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							} as any
+						}
+					]
+				});
+
+				const info = await arfsDao.getInfoOfTxToBePinned(pinDataTxId);
+				expect(+info.size).to.equal(747);
+			});
+
+			it('throws a CLEAR error (not a cryptic ByteCount throw) when data.size is missing/garbage', async () => {
+				stub(fakeGatewayApi, 'gqlRequest').resolves({
+					pageInfo: { hasNextPage: false },
+					edges: [
+						{
+							cursor: '',
+							node: {
+								id: `${pinDataTxId}`,
+								owner: { address: `${pinnedDataOwner}`, key: '' },
+								data: { size: null, type: 'image/png' },
+								tags: []
+								// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							} as any
+						}
+					]
+				});
+
+				await expectAsyncErrorThrow({
+					promiseToError: arfsDao.getInfoOfTxToBePinned(pinDataTxId),
+					errorMessage: `Could not resolve the size of the source data tx to be pinned ("${pinDataTxId}") (gateway returned: null)`
 				});
 			});
 		});

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -25,6 +25,7 @@ import {
 	ArFSMovePrivateFileResult,
 	ArFSMovePublicFolderResult,
 	ArFSMovePrivateFolderResult,
+	ArFSPinPublicFileResult,
 	ArFSCreateBundledDriveResult,
 	ArFSCreatePrivateBundledDriveResult,
 	ArFSCreatePublicDriveResult,
@@ -54,6 +55,7 @@ import {
 	ArFSPrivateFolderMetaDataPrototype,
 	ArFSPrivateDriveMetaDataPrototype,
 	ArFSPublicFileMetaDataPrototype,
+	ArFSPublicFilePinMetaDataPrototype,
 	ArFSPrivateFileMetaDataPrototype,
 	ArFSDriveMetaDataPrototype,
 	ArFSPublicDriveMetaDataPrototype,
@@ -80,7 +82,7 @@ import {
 	fileConflictInfoMap,
 	folderToNameAndIdMap
 } from '../utils/mapper_functions';
-import { buildQuery, ASCENDING_ORDER, DESCENDING_ORDER } from '../utils/query';
+import { buildQuery, ASCENDING_ORDER, DESCENDING_ORDER, GQLQuery } from '../utils/query';
 import { buildDriveHistoryComposite, sortNodesNewestFirst } from '../snapshots';
 import { DataItem, bundleAndSignData, createData } from '@dha-team/arbundles';
 import { deriveDriveKey, deriveFileKey, driveDecrypt } from '../utils/crypto';
@@ -101,6 +103,8 @@ import { PrivateKeyData } from './private_key_data';
 import {
 	EID,
 	ArweaveAddress,
+	ByteCount,
+	DataContentType,
 	TxID,
 	W,
 	GQLEdgeInterface,
@@ -161,7 +165,9 @@ import {
 	ArFSPrepareObjectBundleParams,
 	ArFSPrepareObjectTransactionParams,
 	ArFSRetryPublicFileUploadParams,
-	ArFSFolderPrototypeFactory
+	ArFSFolderPrototypeFactory,
+	ArFSPinPublicFileParams,
+	PinnedTxInfo
 } from '../types/arfsdao_types';
 import {
 	CalculatedUploadPlan,
@@ -636,6 +642,90 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 
 		return {
 			dataTxId: originalMetaData.dataTxId,
+			metaDataTxId: id,
+			metaDataTxReward: metaDataBaseReward?.reward,
+			dataCaches,
+			fastFinalityIndexes
+		};
+	}
+
+	/**
+	 * Looks up the owner, byte size and content type of an EXISTING data transaction so it can
+	 * be pinned. Mirrors ardrive-web's `getInfoOfTxToBePinned` (arweave_service.dart). The
+	 * owner address becomes the pin's `pinnedDataOwner` (the recognition key, PINNING-PLAN §0.3).
+	 *
+	 * @remarks Content type is taken from GQL `data.type`; if the gateway does not report one it
+	 * falls back to the tx's own `Content-Type` tag (GQL already returns decoded tags), and finally
+	 * to `application/octet-stream`. No data bytes are fetched.
+	 */
+	public async getInfoOfTxToBePinned(dataTxId: TransactionID): Promise<PinnedTxInfo> {
+		const gqlQuery: GQLQuery = {
+			query: `query {
+				transactions(ids: ["${dataTxId}"], first: 1) {
+					edges {
+						node {
+							id
+							owner { address }
+							data { size type }
+							tags { name value }
+						}
+					}
+				}
+			}`
+		};
+
+		const transactions = await this.gatewayApi.gqlRequest(gqlQuery);
+		const edges: GQLEdgeInterface[] = transactions.edges;
+
+		if (!edges.length) {
+			throw new Error(`The data transaction to be pinned ("${dataTxId}") could not be found on the gateway!`);
+		}
+
+		const node = edges[0].node;
+
+		// A valid pin REQUIRES a resolvable owner (it is the recognition key). Fail loudly if absent.
+		if (!node.owner?.address) {
+			throw new Error(`The data transaction to be pinned ("${dataTxId}") has no resolvable owner address!`);
+		}
+		const pinnedDataOwner = new ArweaveAddress(node.owner.address);
+		const size = new ByteCount(node.data.size);
+
+		let dataContentType: DataContentType = node.data.type;
+		if (!dataContentType) {
+			dataContentType = node.tags.find((tag) => tag.name === 'Content-Type')?.value ?? 'application/octet-stream';
+		}
+
+		return { pinnedDataOwner, size, dataContentType };
+	}
+
+	/**
+	 * Posts a metadata-only "pin": a NEW public file entity whose `dataTxId` reuses an existing
+	 * data transaction (no data bytes are uploaded). Mirrors {@link movePublicFile} — it builds a
+	 * public file-metadata prototype and routes it through {@link uploadMetaData} (AR v2 when a
+	 * reward is supplied, otherwise Turbo) — but mints a FRESH fileId (never the source's) and
+	 * carries the pin tags/JSON via {@link ArFSPublicFilePinMetaDataPrototype}. The caller builds
+	 * `transactionData` from {@link getInfoOfTxToBePinned}. Public destinations only (the ArDrive
+	 * layer asserts this).
+	 */
+	async pinPublicFile({
+		transactionData,
+		dataTxId,
+		driveId,
+		parentFolderId,
+		metaDataBaseReward
+	}: ArFSPinPublicFileParams): Promise<ArFSPinPublicFileResult> {
+		// Mint a NEW file ID — a pin is a new ArFS entity, never a revision of the source (cf. createPublicFolder).
+		const fileId = EID(uuidv4());
+
+		const { id, dataCaches, fastFinalityIndexes } = await this.uploadMetaData(
+			new ArFSPublicFilePinMetaDataPrototype(transactionData, driveId, fileId, parentFolderId, dataTxId),
+			metaDataBaseReward
+		);
+
+		return {
+			fileId,
+			// The pinned data tx is reused verbatim — no bytes re-uploaded.
+			dataTxId,
 			metaDataTxId: id,
 			metaDataTxReward: metaDataBaseReward?.reward,
 			dataCaches,

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -688,7 +688,27 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 			throw new Error(`The data transaction to be pinned ("${dataTxId}") has no resolvable owner address!`);
 		}
 		const pinnedDataOwner = new ArweaveAddress(node.owner.address);
-		const size = new ByteCount(node.data.size);
+
+		// The Arweave GraphQL gateway returns `data.size` as a JSON STRING (schema `String!`, e.g. "747"),
+		// even though our GQLMetaDataInterface types it as `number`. ByteCount rejects non-integers, so
+		// coerce first and fail with a CLEAR error (rather than a cryptic ByteCount throw) if the gateway
+		// did not report a usable size.
+		const rawSize: unknown = node.data?.size;
+		const coercedSize = Number(rawSize);
+		if (
+			rawSize === null ||
+			rawSize === undefined ||
+			rawSize === '' ||
+			!Number.isInteger(coercedSize) ||
+			coercedSize < 0
+		) {
+			throw new Error(
+				`Could not resolve the size of the source data tx to be pinned ("${dataTxId}") (gateway returned: ${JSON.stringify(
+					rawSize
+				)})`
+			);
+		}
+		const size = new ByteCount(coercedSize);
 
 		let dataContentType: DataContentType = node.data.type;
 		if (!dataContentType) {

--- a/src/arfs/tx/arfs_pin_prototype.test.ts
+++ b/src/arfs/tx/arfs_pin_prototype.test.ts
@@ -1,0 +1,138 @@
+import { expect } from 'chai';
+import { ByteCount, GQLTagInterface, stubTransactionID, UnixTime } from '../../types';
+import { stubArweaveAddress, stubEntityID, stubEntityIDAlt, stubEntityIDAltTwo } from '../../../tests/stubs';
+import { ArFSPublicFilePinMetaDataPrototype } from './arfs_prototypes';
+import { ArFSPublicFilePinMetadataTransactionData } from './arfs_tx_data_types';
+
+// Fixed inputs so the interop golden vectors below are deterministic.
+const driveId = stubEntityID;
+const fileId = stubEntityIDAlt;
+const parentFolderId = stubEntityIDAltTwo;
+const dataTxId = stubTransactionID; // 43 zeros — the EXISTING data tx being pinned
+const pinnedDataOwner = stubArweaveAddress(); // owner of the source data tx (the recognition key)
+const size = new ByteCount(2048);
+const lastModifiedDateMs = new UnixTime(1700000000000); // MILLISECONDS, minted fresh at pin time
+const pinnedFileName = 'pinned photo.png';
+const dataContentType = 'image/png';
+
+const tagValue = (tags: GQLTagInterface[], name: string): string | undefined =>
+	tags.find((t) => t.name === name)?.value;
+
+describe('ArFSPublicFilePinMetadataTransactionData (pin metadata JSON)', () => {
+	const txData = new ArFSPublicFilePinMetadataTransactionData(
+		pinnedFileName,
+		size,
+		lastModifiedDateMs,
+		dataTxId,
+		dataContentType,
+		pinnedDataOwner
+	);
+
+	// INTEROP GOLDEN (load-bearing): the serialized bytes must match ardrive-web's pin JSON schema
+	// exactly (PINNING-PLAN §0.2) or ardrive-web will not render the entity as a pin.
+	it('serializes the exact interop pin JSON, byte-for-byte', () => {
+		const expected =
+			'{"name":"pinned photo.png","size":2048,"lastModifiedDate":1700000000000,' +
+			`"dataTxId":"${dataTxId}","dataContentType":"image/png",` +
+			`"pinnedDataOwner":"${pinnedDataOwner}","thumbnail":null,"assignedNames":null}`;
+		expect(txData.asTransactionData()).to.equal(expected);
+	});
+
+	it('emits the pin JSON keys in the ardrive-web order', () => {
+		const parsed = JSON.parse(txData.asTransactionData() as string);
+		expect(Object.keys(parsed)).to.deep.equal([
+			'name',
+			'size',
+			'lastModifiedDate',
+			'dataTxId',
+			'dataContentType',
+			'pinnedDataOwner',
+			'thumbnail',
+			'assignedNames'
+		]);
+	});
+
+	it('emits pinnedDataOwner (non-null) as the recognition key, plus explicit null thumbnail/assignedNames', () => {
+		const parsed = JSON.parse(txData.asTransactionData() as string);
+		expect(parsed.pinnedDataOwner).to.equal(`${pinnedDataOwner}`);
+		expect(parsed.pinnedDataOwner).to.not.equal(null);
+		expect(parsed).to.have.property('thumbnail', null);
+		expect(parsed).to.have.property('assignedNames', null);
+	});
+
+	it('passes the caller dataTxId through unchanged and uses milliseconds for lastModifiedDate', () => {
+		const parsed = JSON.parse(txData.asTransactionData() as string);
+		expect(parsed.dataTxId).to.equal(`${dataTxId}`);
+		expect(parsed.lastModifiedDate).to.equal(1700000000000);
+		expect(parsed.size).to.equal(2048);
+		expect(parsed.dataContentType).to.equal('image/png');
+	});
+
+	it('does NOT emit writeNotNull fields absent from a pin (isHidden/licenseTxId/fallbackTxId/originalOwner)', () => {
+		const parsed = JSON.parse(txData.asTransactionData() as string);
+		expect(parsed).to.not.have.property('isHidden');
+		expect(parsed).to.not.have.property('licenseTxId');
+		expect(parsed).to.not.have.property('fallbackTxId');
+		expect(parsed).to.not.have.property('originalOwner');
+	});
+});
+
+describe('ArFSPublicFilePinMetaDataPrototype (pin tags)', () => {
+	const prototype = ArFSPublicFilePinMetaDataPrototype.fromPin({
+		dataTxId,
+		pinnedDataOwner,
+		size,
+		dataContentType,
+		pinnedFileName,
+		lastModifiedDate: lastModifiedDateMs,
+		driveId,
+		fileId,
+		parentFolderId
+	});
+
+	// INTEROP GOLDEN (load-bearing): the tag set must include ardrive-web's pin markers
+	// (PINNING-PLAN §0.1). App-Name/App-Version/ArFS are added by the TxPreparer, NOT the prototype,
+	// and are NOT part of the recognition contract, so we deliberately do not assert them here.
+	it('emits the pin-specific tags ArFS-Pin=true and Pinned-Data-Tx=<dataTxId>', () => {
+		const tags = prototype.gqlTags;
+		expect(tagValue(tags, 'ArFS-Pin')).to.equal('true');
+		expect(tagValue(tags, 'Pinned-Data-Tx')).to.equal(`${dataTxId}`);
+	});
+
+	it('emits the standard public file-metadata tags for the destination entity', () => {
+		const tags = prototype.gqlTags;
+		expect(tagValue(tags, 'Entity-Type')).to.equal('file');
+		expect(tagValue(tags, 'Content-Type')).to.equal('application/json');
+		expect(tagValue(tags, 'Drive-Id')).to.equal(`${driveId}`);
+		expect(tagValue(tags, 'File-Id')).to.equal(`${fileId}`);
+		expect(tagValue(tags, 'Parent-Folder-Id')).to.equal(`${parentFolderId}`);
+		expect(tagValue(tags, 'Unix-Time')).to.match(/^\d+$/); // seconds since epoch
+	});
+
+	it('does not emit app tags at the prototype layer (not a recognition input, R2)', () => {
+		const tags = prototype.gqlTags;
+		expect(tagValue(tags, 'App-Name')).to.equal(undefined);
+		expect(tagValue(tags, 'App-Version')).to.equal(undefined);
+	});
+
+	it('fromPin and the direct constructor produce identical tags and JSON', () => {
+		const direct = new ArFSPublicFilePinMetaDataPrototype(
+			new ArFSPublicFilePinMetadataTransactionData(
+				pinnedFileName,
+				size,
+				lastModifiedDateMs,
+				dataTxId,
+				dataContentType,
+				pinnedDataOwner
+			),
+			driveId,
+			fileId,
+			parentFolderId,
+			dataTxId
+		);
+		// Unix-Time is minted per-instance from Date.now(), so exclude it from the equality check.
+		const withoutUnixTime = (tags: GQLTagInterface[]) => tags.filter((t) => t.name !== 'Unix-Time');
+		expect(withoutUnixTime(direct.gqlTags)).to.deep.equal(withoutUnixTime(prototype.gqlTags));
+		expect(direct.objectData.asTransactionData()).to.equal(prototype.objectData.asTransactionData());
+	});
+});

--- a/src/arfs/tx/arfs_prototypes.ts
+++ b/src/arfs/tx/arfs_prototypes.ts
@@ -11,9 +11,12 @@ import {
 	ArFSPublicDriveTransactionData,
 	ArFSPublicFileDataTransactionData,
 	ArFSPublicFileMetadataTransactionData,
+	ArFSPublicFilePinMetadataTransactionData,
 	ArFSPublicFolderTransactionData
 } from './arfs_tx_data_types';
 import {
+	ArweaveAddress,
+	ByteCount,
 	DataContentType,
 	DriveID,
 	FileID,
@@ -287,6 +290,83 @@ export class ArFSPublicFileMetaDataPrototype extends ArFSFileMetaDataPrototype {
 			fileId,
 			parentFolderId,
 			wrappedFile.customMetaData?.metaDataGqlTags
+		);
+	}
+}
+
+export interface ArFSPublicFilePinMetaDataPrototypeParams {
+	/** The EXISTING data tx being pinned (reused; no bytes uploaded). */
+	dataTxId: TransactionID;
+	/** Owner address of the SOURCE data tx — the pin recognition key (PINNING-PLAN §0.3). */
+	pinnedDataOwner: ArweaveAddress;
+	/** Byte size of the source data (from GQL `data.size`). */
+	size: ByteCount;
+	/** Content type of the source data (from GQL `data.type`, or a fallback). */
+	dataContentType: DataContentType;
+	pinnedFileName: string;
+	/** Minted fresh at pin time, in MILLISECONDS (mirrors ardrive-web). */
+	lastModifiedDate: UnixTime;
+	driveId: DriveID;
+	/** Freshly minted file id — never the source's. */
+	fileId: FileID;
+	parentFolderId: FolderID;
+}
+
+/**
+ * Prototype for a PUBLIC file *pin*. Identical to a public file-metadata entity except
+ * that it appends the two pin-specific tags — `ArFS-Pin=true` and `Pinned-Data-Tx` — as
+ * first-class *protected* tags (they are not in the base file protected set, so this is
+ * purely additive). Matches ardrive-web's on-chain tag set (PINNING-PLAN §0.1). Public
+ * only: a private destination would encrypt the metadata JSON and omit these tags.
+ */
+export class ArFSPublicFilePinMetaDataPrototype extends ArFSFileMetaDataPrototype {
+	readonly contentType: ContentType = JSON_CONTENT_TYPE;
+
+	constructor(
+		readonly objectData: ArFSPublicFilePinMetadataTransactionData,
+		readonly driveId: DriveID,
+		readonly fileId: FileID,
+		readonly parentFolderId: FolderID,
+		private readonly pinnedDataTxId: TransactionID,
+		readonly customMetaDataTags: CustomMetaDataGqlTags = {}
+	) {
+		super(customMetaDataTags);
+	}
+
+	protected get protectedTags(): GQLTagInterface[] {
+		const tags = super.protectedTags;
+
+		// Appended last, mirroring ardrive-web (pin_file_bloc.dart:325/329). Public only.
+		tags.push({ name: 'ArFS-Pin', value: 'true' });
+		tags.push({ name: 'Pinned-Data-Tx', value: `${this.pinnedDataTxId}` });
+
+		return tags;
+	}
+
+	public static fromPin({
+		dataTxId,
+		pinnedDataOwner,
+		size,
+		dataContentType,
+		pinnedFileName,
+		lastModifiedDate,
+		driveId,
+		fileId,
+		parentFolderId
+	}: ArFSPublicFilePinMetaDataPrototypeParams): ArFSPublicFilePinMetaDataPrototype {
+		return new ArFSPublicFilePinMetaDataPrototype(
+			new ArFSPublicFilePinMetadataTransactionData(
+				pinnedFileName,
+				size,
+				lastModifiedDate,
+				dataTxId,
+				dataContentType,
+				pinnedDataOwner
+			),
+			driveId,
+			fileId,
+			parentFolderId,
+			dataTxId
 		);
 	}
 }

--- a/src/arfs/tx/arfs_tx_data_types.ts
+++ b/src/arfs/tx/arfs_tx_data_types.ts
@@ -1,5 +1,6 @@
 import { driveEncrypt, fileEncrypt, deriveFileKey } from '../../utils/crypto';
 import {
+	ArweaveAddress,
 	CipherIV,
 	DataContentType,
 	FileID,
@@ -272,6 +273,53 @@ export class ArFSPublicFileMetadataTransactionData extends ArFSFileMetadataTrans
 			this.baseDataJson,
 			this.dataJsonCustomMetaData
 		);
+	}
+
+	asTransactionData(): string {
+		return JSON.stringify(this.fullDataJson);
+	}
+}
+
+/**
+ * Data JSON for a PUBLIC file *pin*.
+ *
+ * A pin is an ArFS file-metadata entity whose `dataTxId` points at an EXISTING data
+ * transaction — no data bytes are re-uploaded. This mirrors ardrive-web's pin JSON
+ * (`file_entity.g.dart`): on top of the standard public-file fields it emits the
+ * recognition key `pinnedDataOwner` (the owner address of the SOURCE data tx) plus an
+ * explicit `thumbnail: null` and `assignedNames: null`.
+ *
+ * The key ORDER below is byte-significant: ardrive-web recognizes a pin by
+ * `pinnedDataOwner != null` in this JSON (NOT by the tags), so this field must be
+ * present and camelCase, and the serialized shape must match the interop contract
+ * (see docs/product/PINNING-PLAN-2026-07-19.md §0.2). `lastModifiedDate` is in
+ * MILLISECONDS (minted fresh at pin time), while the `Unix-Time` *tag* is in seconds.
+ */
+export class ArFSPublicFilePinMetadataTransactionData extends ArFSFileMetadataTransactionData {
+	private readonly fullDataJson: EntityMetaDataTransactionData;
+
+	constructor(
+		private readonly name: string,
+		private readonly size: ByteCount,
+		private readonly lastModifiedDate: UnixTime,
+		private readonly dataTxId: TransactionID,
+		private readonly dataContentType: DataContentType,
+		private readonly pinnedDataOwner: ArweaveAddress
+	) {
+		super();
+
+		// Insertion order matches ardrive-web's serialized pin JSON exactly (PINNING-PLAN §0.2).
+		// JSON.stringify preserves string-key insertion order, so this reproduces the on-chain bytes.
+		this.fullDataJson = {
+			name: this.name,
+			size: +this.size,
+			lastModifiedDate: +this.lastModifiedDate,
+			dataTxId: `${this.dataTxId}`,
+			dataContentType: this.dataContentType,
+			pinnedDataOwner: `${this.pinnedDataOwner}`,
+			thumbnail: null,
+			assignedNames: null
+		};
 	}
 
 	asTransactionData(): string {

--- a/src/types/ardrive_types.ts
+++ b/src/types/ardrive_types.ts
@@ -105,6 +105,19 @@ export interface CreatePublicFolderParams {
 }
 export type CreatePrivateFolderParams = CreatePublicFolderParams & WithDriveKey;
 
+export interface PinPublicFileParams {
+	/** Destination folder for the new pinned file entity. */
+	parentFolderId: FolderID;
+	/** The EXISTING data transaction to pin — its bytes are reused, never re-uploaded. */
+	dataTxId: TransactionID;
+	/** Name for the new pinned file (validated via assertValidArFSFileName). */
+	pinnedFileName: string;
+	/** Destination drive id; resolved from `parentFolderId` when omitted. */
+	driveId?: DriveID;
+	/** Name-conflict behavior in the destination folder. `skip` yields an empty result; otherwise a duplicate name throws. */
+	conflictResolution?: FileNameConflictResolution;
+}
+
 export interface UploadParams {
 	parentFolderId: FolderID;
 	conflictResolution?: FileNameConflictResolution;

--- a/src/types/arfsdao_types.ts
+++ b/src/types/arfsdao_types.ts
@@ -1,6 +1,15 @@
 import { DataItem } from '@dha-team/arbundles';
 import Transaction from 'arweave/node/lib/transaction';
-import { FolderID, DriveID, RewardSettings, GQLTagInterface, FileID, ArweaveAddress } from '.';
+import {
+	FolderID,
+	DriveID,
+	RewardSettings,
+	GQLTagInterface,
+	FileID,
+	ArweaveAddress,
+	ByteCount,
+	DataContentType
+} from '.';
 import {
 	ArFSObjectMetadataPrototype,
 	CreateDriveMetaDataFactory,
@@ -9,6 +18,7 @@ import {
 	ArFSFolderTransactionData,
 	ArFSPublicFolderTransactionData,
 	ArFSPrivateFolderTransactionData,
+	ArFSPublicFilePinMetadataTransactionData,
 	PrivateDriveKeyData,
 	ArFSFileOrFolderEntity,
 	ArFSObjectTransactionData,
@@ -106,6 +116,27 @@ export type ArFSTxResult<R> = {
 	result: R;
 	transactions: Transaction[];
 };
+
+/** GQL-sourced info about the source data tx being pinned (owner/size/content-type). */
+export interface PinnedTxInfo {
+	/** Owner address of the SOURCE data tx — the pin recognition key (PINNING-PLAN §0.3). */
+	pinnedDataOwner: ArweaveAddress;
+	/** Byte size of the source data (GQL `data.size`). */
+	size: ByteCount;
+	/** Content type of the source data (GQL `data.type`, or Content-Type-tag fallback). */
+	dataContentType: DataContentType;
+}
+
+/** Parameters for the ArFSDAO.pinPublicFile metadata-only post. */
+export interface ArFSPinPublicFileParams {
+	/** Pre-built pin metadata JSON (name/size/lastModifiedDate/dataTxId/contentType/pinnedDataOwner). */
+	transactionData: ArFSPublicFilePinMetadataTransactionData;
+	/** The EXISTING data tx being pinned (unchanged; also emitted as the Pinned-Data-Tx tag). */
+	dataTxId: TransactionID;
+	driveId: DriveID;
+	parentFolderId: FolderID;
+	metaDataBaseReward?: RewardSettings;
+}
 
 /** Generic parameters for move file and move folder ArFSDAO methods */
 export interface ArFSMoveParams<


### PR DESCRIPTION
Adds ArFS **pinning** to core-js: create a public File entity whose data pointer references an **existing** data transaction — no bytes re-uploaded. Mirrors ardrive-web's on-chain format so pins created here render as pins in ardrive-web (and vice-versa).

## What's added
- **`ARDrive.pinPublicFile({ parentFolderId, dataTxId, pinnedFileName, driveId?, conflictResolution? }): Promise<ArFSResult>`** — public-only (asserts the destination drive is public before any GQL/post), mints a new fileId, posts **metadata only** (reuses `uploadMetaData`; the data path is never touched).
- **GQL source lookup** (`ArFSDAO.getInfoOfTxToBePinned`) for the source tx's `owner.address` → `pinnedDataOwner`, `data.size` → `size`, `data.type` → `dataContentType` (Content-Type-tag / octet-stream fallback).
- **Interop-exact metadata**: tags `ArFS-Pin=true` + `Pinned-Data-Tx=<dataTxId>`; JSON `{name, size, lastModifiedDate(ms), dataTxId, dataContentType, pinnedDataOwner, thumbnail:null, assignedNames:null}` — the `pinnedDataOwner` field is the recognition key ardrive-web reads.
- **Read recognition**: `pinnedDataOwner` / `pinnedDataTxId` surfaced on `ArFSPublicFile` (undefined for a normal file; not leaked into customMetaData).

## Scope / notes
- **Public-only** (intrinsic): a pin mints a new fileId → new fileKey, which can't decrypt data encrypted under the source's key. Private pinning would need an ArFS-standard scheme (out of scope).
- **Pin-by-dataTxId** only; pin-by-fileId (resolve dataTxId from an ArFS fileId, for a manual UI) is a deferred follow-up.

## Verification
- 18 unit tests (metadata-only / new-fileId / dataTxId passthrough / GQL sourcing / read recognition / private-guard) + a byte-for-byte interop golden test. `yarn typecheck` / `build` / `lint` clean; suite green (only the pre-existing environmental ArLocal integration test fails — no local node).
- Adversarial review caught + fixed a production bug: the Arweave gateway returns `data.size` as a **string** (`String!`); `ByteCount` rejected it. Now coerced with a clear guard, and the GQL test fixtures use the real string shape + a regression test.

Live interop round-trip (create a real public pin, confirm ardrive-web renders it) is the recommended supervised check before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pinning existing public data transactions as files without re-uploading the underlying data.
  * Added filename validation, duplicate-name conflict handling, and private-drive protection.
  * Pinned files retain source ownership, size, content type, and transaction details.
  * Added pin metadata to file entities and results, including the new file ID and reused transaction ID.
* **Bug Fixes**
  * Improved validation and error reporting for missing or invalid transaction metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->