### PR TITLE
fix(crypto): decrypt AES-256-CTR private files (large streamed files) + stop silent skip

### DIFF
--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -1533,7 +1533,9 @@ export class ArDrive extends ArDriveAnonymous {
 		const fileKey = await deriveFileKey(`${fileId}`, driveKey);
 		// Read the DATA transaction's own Cipher/Cipher-IV. ardrive-web encrypts streamed (large)
 		// file data with AES256-CTR (no auth tag) even when the file's metadata is AES256-GCM, so
-		// branch on the data tx's cipher: CTR has no auth tag to fetch (absent Cipher => GCM).
+		// branch on the data tx's cipher: CTR has no auth tag to fetch (absent Cipher => GCM). The
+		// data stream itself still covers the full CTR ciphertext — the +16/-16 range cancellation is
+		// documented in getPrivateDataStream.
 		const [dataTxCipherResult] = await this.arFsDao.getCipherIVOfPrivateTransactionIDs([privateFile.dataTxId]);
 		const fileCipherIV = dataTxCipherResult.cipherIV;
 		const dataCipher = dataTxCipherResult.cipher ?? CIPHER_AES_256_GCM;

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -28,7 +28,7 @@ import {
 import { ArFSDAO } from './arfs/arfsdao';
 import { IncrementalSyncOptions, IncrementalSyncResult, DriveSyncState } from './types/sync_types';
 import { CommunityOracle } from './community/community_oracle';
-import { deriveFileKey } from './utils/crypto';
+import { CIPHER_AES_256_CTR, CIPHER_AES_256_GCM, deriveFileKey } from './utils/crypto';
 import { ARDataPriceEstimator } from './pricing/ar_data_price_estimator';
 import {
 	FeeMultiple,
@@ -1531,9 +1531,15 @@ export class ArDrive extends ArDriveAnonymous {
 		const fullPath = joinPath(destFolderPath, outputFileName);
 		const data = await this.arFsDao.getPrivateDataStream(privateFile);
 		const fileKey = await deriveFileKey(`${fileId}`, driveKey);
-		const fileCipherIV = await this.arFsDao.getPrivateTransactionCipherIV(privateFile.dataTxId);
-		const authTag = await this.arFsDao.getAuthTagForPrivateFile(privateFile);
-		const decipher = new StreamDecrypt(fileCipherIV, fileKey, authTag);
+		// Read the DATA transaction's own Cipher/Cipher-IV. ardrive-web encrypts streamed (large)
+		// file data with AES256-CTR (no auth tag) even when the file's metadata is AES256-GCM, so
+		// branch on the data tx's cipher: CTR has no auth tag to fetch (absent Cipher => GCM).
+		const [dataTxCipherResult] = await this.arFsDao.getCipherIVOfPrivateTransactionIDs([privateFile.dataTxId]);
+		const fileCipherIV = dataTxCipherResult.cipherIV;
+		const dataCipher = dataTxCipherResult.cipher ?? CIPHER_AES_256_GCM;
+		const authTag =
+			dataCipher === CIPHER_AES_256_CTR ? null : await this.arFsDao.getAuthTagForPrivateFile(privateFile);
+		const decipher = new StreamDecrypt(fileCipherIV, fileKey, authTag, dataCipher);
 		const fileToDownload = new ArFSPrivateFileToDownload(privateFile, data, fullPath, decipher);
 		await fileToDownload.write();
 	}

--- a/src/arfs/arfs_builders/arfs_drive_builders.ts
+++ b/src/arfs/arfs_builders/arfs_drive_builders.ts
@@ -222,7 +222,12 @@ export class ArFSPrivateDriveBuilder extends ArFSDriveBuilder<ArFSPrivateDrive> 
 		) {
 			const txData = await this.getDataForTxID(this.txId);
 			const dataBuffer = Buffer.from(txData);
-			const decryptedDriveBuffer: Buffer = await driveDecrypt(this.cipherIV, this.driveKey, dataBuffer);
+			const decryptedDriveBuffer: Buffer = await driveDecrypt(
+				this.cipherIV,
+				this.driveKey,
+				dataBuffer,
+				this.cipher
+			);
 			const decryptedDriveString: string = BufferToString(decryptedDriveBuffer);
 			const decryptedDriveJSON: DriveMetaDataTransactionData = await JSON.parse(decryptedDriveString);
 

--- a/src/arfs/arfs_builders/arfs_file_builders.ts
+++ b/src/arfs/arfs_builders/arfs_file_builders.ts
@@ -220,7 +220,7 @@ export class ArFSPrivateFileBuilder extends ArFSFileBuilder<ArFSPrivateFile> {
 				throw new InvalidFileStateException(['fileKey']);
 			}
 
-			const decryptedFileBuffer: Buffer = await fileDecrypt(this.cipherIV, fileKey, dataBuffer);
+			const decryptedFileBuffer: Buffer = await fileDecrypt(this.cipherIV, fileKey, dataBuffer, this.cipher);
 			const decryptedFileString: string = BufferToString(decryptedFileBuffer);
 			const decryptedFileJSON: FileMetaDataTransactionData = await JSON.parse(decryptedFileString);
 
@@ -270,7 +270,7 @@ export class ArFSPrivateFileBuilder extends ArFSFileBuilder<ArFSPrivateFile> {
 		// listing. Throw the semantically-correct InvalidFileStateException instead — which
 		// getPrivateFilesWithParentFolderIds already skips — naming the missing properties
 		// (e.g. `cipher`). This runs BEFORE any decryption, so it does not mask a decryption
-		// failure (those surface as a SyntaxError from the fileDecrypt "Error" sentinel).
+		// failure (those now surface as a typed EntityDecryptionError thrown by fileDecrypt).
 		throw new InvalidFileStateException(this.getMissingRequiredProperties());
 	}
 

--- a/src/arfs/arfs_builders/arfs_folder_builders.ts
+++ b/src/arfs/arfs_builders/arfs_folder_builders.ts
@@ -181,7 +181,12 @@ export class ArFSPrivateFolderBuilder extends ArFSFolderBuilder<ArFSPrivateFolde
 			const txData = await this.getDataForTxID(this.txId);
 			const dataBuffer = Buffer.from(txData);
 
-			const decryptedFolderBuffer: Buffer = await fileDecrypt(this.cipherIV, this.driveKey, dataBuffer);
+			const decryptedFolderBuffer: Buffer = await fileDecrypt(
+				this.cipherIV,
+				this.driveKey,
+				dataBuffer,
+				this.cipher
+			);
 			const decryptedFolderString: string = BufferToString(decryptedFolderBuffer);
 			const decryptedFolderJSON = await JSON.parse(decryptedFolderString);
 

--- a/src/arfs/arfsdao.test.ts
+++ b/src/arfs/arfsdao.test.ts
@@ -26,7 +26,7 @@ import {
 	stubSmallFileToUpload,
 	stubSignedTransaction
 } from '../../tests/stubs';
-import { DriveKey, EID, FeeMultiple, FileID, FileKey, FolderID, W } from '../types';
+import { ByteCount, DriveKey, EID, EntityKey, FeeMultiple, FileID, FileKey, FolderID, W } from '../types';
 import { readJWKFile, BufferToString } from '../utils/common';
 import {
 	ArFSCache,
@@ -43,8 +43,12 @@ import { ArFSPublicFolderCacheKey, defaultArFSAnonymousCache, defaultCacheParams
 import { stub, SinonStub } from 'sinon';
 import { expect } from 'chai';
 import { expectAsyncErrorThrow, getDecodedTags } from '../../tests/test_helpers';
-import { deriveFileKey, driveDecrypt, fileDecrypt } from '../utils/crypto';
+import { CIPHER_AES_256_CTR, deriveFileKey, driveDecrypt, fileDecrypt } from '../utils/crypto';
+import { StreamDecrypt } from '../utils/stream_decrypt';
 import { DataItem } from '@dha-team/arbundles';
+import axios from 'axios';
+import { Readable, pipeline } from 'stream';
+import { promisify } from 'util';
 import { ArFSTagSettings } from './arfs_tag_settings';
 import { BundleResult, FileResult, FolderResult } from './arfs_entity_result_factory';
 import { NameConflictInfo } from '../utils/mapper_functions';
@@ -735,6 +739,68 @@ describe('The ArFSDAO class', () => {
 			);
 
 			expect(files).to.have.lengthOf(0);
+		});
+	});
+
+	// FIX C (CodeRabbit): the CTR download range `encryptedDataSize - authTagLength` is CORRECT via
+	// cancellation, not a bug. This drives the REAL getPrivateDataStream (axios intercepted at the
+	// default adapter — no network) for a CTR file and proves the requested range spans the FULL CTR
+	// ciphertext (offset 0, length == plaintext), then that those exact bytes decrypt to plaintext.
+	describe('getPrivateDataStream — AES-256-CTR download range covers the full ciphertext [aes-ctr]', () => {
+		// Same golden vector as crypto_aes_ctr.test.ts / stream_decrypt.test.ts.
+		const goldenKey = new EntityKey(
+			Buffer.from('000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f', 'hex')
+		);
+		const goldenNonce = Buffer.from('ardrive-ctr!', 'utf8'); // 12-byte Cipher-IV
+		const goldenCipherIV = goldenNonce.toString('base64');
+		const goldenPlaintext = 'The quick brown fox jumps over 13 lazy ArDrive dogs, spanning several AES blocks!!';
+		const GOLDEN_CTR_CIPHERTEXT_HEX =
+			'fcfeb3afdd4685ac21858d6e9b0b6083f367a3fce833d4a47c79a8874d91864d' +
+			'173aae73fb9ab4ac4306d8cf12ec25ca49a7dab4954dc841e2f2f9680ed86105' +
+			'ebed3589e6442c0742eba20cff323c8c7339';
+		const goldenCiphertext = Buffer.from(GOLDEN_CTR_CIPHERTEXT_HEX, 'hex');
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		let originalAdapter: any;
+		beforeEach(() => {
+			originalAdapter = axios.defaults.adapter;
+		});
+		afterEach(() => {
+			axios.defaults.adapter = originalAdapter;
+		});
+
+		it('requests bytes=0-(size-1) — the full CTR ciphertext — and those bytes decrypt to plaintext', async () => {
+			// CTR ciphertext length == plaintext length (no auth tag, no block padding).
+			expect(goldenCiphertext.length).to.equal(Buffer.byteLength(goldenPlaintext));
+
+			// A private file whose plaintext size IS the golden size. encryptedDataSize = size + 16,
+			// so the production range math yields bytes=0-(size-1) after the -authTagLength cancels.
+			const file = await stubPrivateFile({ dataTxId: stubTxID });
+			file.size = new ByteCount(goldenCiphertext.length);
+
+			let capturedRange: string | undefined;
+			axios.defaults.adapter = async (config) => {
+				capturedRange = config.headers?.Range;
+				return {
+					data: Readable.from(goldenCiphertext),
+					status: 206,
+					statusText: 'Partial Content',
+					headers: {},
+					config
+				};
+			};
+
+			const stream = await arfsDao.getPrivateDataStream(file);
+
+			// (1) Range is offset 0 and spans exactly `size` bytes == the full CTR ciphertext.
+			expect(capturedRange).to.equal(`bytes=0-${goldenCiphertext.length - 1}`);
+
+			// (2) The streamed bytes decrypt correctly through the production CTR stream path.
+			const decrypt = new StreamDecrypt(goldenCipherIV, goldenKey, null, CIPHER_AES_256_CTR);
+			const chunks: Buffer[] = [];
+			decrypt.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+			await promisify(pipeline)(stream, decrypt);
+			expect(Buffer.concat(chunks).toString('utf8')).to.equal(goldenPlaintext);
 		});
 	});
 

--- a/src/arfs/arfsdao.test.ts
+++ b/src/arfs/arfsdao.test.ts
@@ -779,6 +779,15 @@ describe('The ArFSDAO class', () => {
 			// so the production range math yields bytes=0-(size-1) after the -authTagLength cancels.
 			const file = await stubPrivateFile({ dataTxId: stubTxID });
 			file.size = new ByteCount(goldenCiphertext.length);
+			// Bind the CTR decrypt params onto the entity so the test reads cipher/cipherIV/fileKey
+			// off `file` rather than standalone constants (the props are readonly in production, hence
+			// the cast). NB: the real download path sources the cipher from the data-tx Cipher tag,
+			// not this entity field — this binding is for test intent/regression coverage only.
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const ctrFile = file as any;
+			ctrFile.cipher = CIPHER_AES_256_CTR;
+			ctrFile.cipherIV = goldenCipherIV;
+			ctrFile.fileKey = goldenKey;
 
 			let capturedRange: string | undefined;
 			axios.defaults.adapter = async (config) => {
@@ -797,8 +806,9 @@ describe('The ArFSDAO class', () => {
 			// (1) Range is offset 0 and spans exactly `size` bytes == the full CTR ciphertext.
 			expect(capturedRange).to.equal(`bytes=0-${goldenCiphertext.length - 1}`);
 
-			// (2) The streamed bytes decrypt correctly through the production CTR stream path.
-			const decrypt = new StreamDecrypt(goldenCipherIV, goldenKey, null, CIPHER_AES_256_CTR);
+			// (2) The streamed bytes decrypt correctly through the production CTR stream path,
+			// with the decrypt params read off the file entity (see the binding above).
+			const decrypt = new StreamDecrypt(file.cipherIV, file.fileKey, null, file.cipher);
 			const chunks: Buffer[] = [];
 			decrypt.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
 			await promisify(pipeline)(stream, decrypt);

--- a/src/arfs/arfsdao.test.ts
+++ b/src/arfs/arfsdao.test.ts
@@ -38,7 +38,7 @@ import {
 import { PromiseCache } from '@ardrive/ardrive-promise-cache';
 import { ArFSPrivateDrive, ArFSPrivateFile, ArFSPrivateFolder } from './arfs_entities';
 import { ArFSPrivateFileBuilder } from './arfs_builders/arfs_file_builders';
-import { InvalidFileStateException } from '../types/exceptions';
+import { EntityDecryptionError, InvalidFileStateException } from '../types/exceptions';
 import { ArFSPublicFolderCacheKey, defaultArFSAnonymousCache, defaultCacheParams } from './arfsdao_anonymous';
 import { stub, SinonStub } from 'sinon';
 import { expect } from 'chai';
@@ -606,10 +606,8 @@ describe('The ArFSDAO class', () => {
 
 			const goodFile = await stubPrivateFile({ fileId: EID(fileId1), parentFolderId, driveId: listDriveId });
 
-			// build() is invoked in edge order. Simulate the live failure mode: the first
-			// (good) file builds normally; the second file's data fails to decrypt, so
-			// fileDecrypt() returns the "Error" sentinel buffer and JSON.parse() throws a
-			// SyntaxError inside the builder.
+			// build() is invoked in edge order. The first (good) file builds normally; the second
+			// file's data decrypts to non-JSON, so JSON.parse() throws a SyntaxError in the builder.
 			buildStub = stub(ArFSPrivateFileBuilder.prototype, 'build');
 			buildStub.onFirstCall().resolves(goodFile);
 			buildStub.onSecondCall().rejects(new SyntaxError(`Unexpected token 'E', "Error" is not valid JSON`));
@@ -623,6 +621,38 @@ describe('The ArFSDAO class', () => {
 			);
 
 			// The listing completes (does NOT throw) and returns the healthy file, the broken one skipped.
+			expect(files).to.have.lengthOf(1);
+			expect(`${files[0].fileId}`).to.equal(fileId1);
+		});
+
+		it('surfaces a genuine decrypt failure (EntityDecryptionError) per-entity without aborting the listing or dropping the whole drive [aes-ctr]', async () => {
+			// After the sentinel-kill, fileDecrypt() THROWS a typed EntityDecryptionError on a real
+			// decrypt failure instead of returning a bogus Buffer('Error'). The enumeration must
+			// catch it per-entity: the good file still lists, the drive listing does NOT crash, and
+			// the failure is honestly reported (not a silent skip masquerading as invalid metadata).
+			gqlRequestStub = stub(fakeGatewayApi, 'gqlRequest');
+			gqlRequestStub.resolves({
+				edges: [
+					buildFileEdge(`${stubTxID}`, fileId1, 'cursor1'),
+					buildFileEdge(`${stubTxIDAlt}`, fileId2, 'cursor2')
+				],
+				pageInfo: { hasNextPage: false }
+			});
+
+			const goodFile = await stubPrivateFile({ fileId: EID(fileId1), parentFolderId, driveId: listDriveId });
+
+			buildStub = stub(ArFSPrivateFileBuilder.prototype, 'build');
+			buildStub.onFirstCall().resolves(goodFile);
+			buildStub.onSecondCall().rejects(new EntityDecryptionError('AES256-CTR', 'file'));
+
+			const files = await arfsDao.getPrivateFilesWithParentFolderIds(
+				[parentFolderId],
+				stubDriveKey,
+				stubArweaveAddress(),
+				listDriveId,
+				true
+			);
+
 			expect(files).to.have.lengthOf(1);
 			expect(`${files[0].fileId}`).to.equal(fileId1);
 		});

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -2230,6 +2230,13 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 	 * @returns {Promise<Readable>}
 	 */
 	async getPrivateDataStream(privateFile: ArFSPrivateFile): Promise<Readable> {
+		// Range-calc note (CTR safety): `encryptedDataSize` = plaintextSize + authTagLength (it
+		// models a trailing GCM auth tag), and this range subtracts `authTagLength` back off — so the
+		// requested range is exactly [0, plaintextSize). For GCM that is the ciphertext MINUS its
+		// trailing tag (fetched separately by getAuthTagForPrivateFile). For CTR the +authTagLength in
+		// `encryptedDataSize` and the -authTagLength here CANCEL: a CTR tx has no tag and its
+		// ciphertext length == plaintextSize, so this range spans the FULL CTR ciphertext. The
+		// cancellation is deliberate and load-bearing — do NOT "simplify" it away.
 		const dataLength = privateFile.encryptedDataSize;
 		const authTagIndex = +dataLength - authTagLength;
 		const dataTxUrl = `${gatewayUrlForArweave(this.arweave).href}${privateFile.dataTxId}`;
@@ -2680,7 +2687,9 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 					throw new Error(`Could not find the CipherIV for the private file with ID ${file.fileId}`);
 				}
 				// AES256-CTR (ardrive-web streamed large files) has no auth tag; only fetch one
-				// for the authenticated GCM path (absent Cipher => GCM default).
+				// for the authenticated GCM path (absent Cipher => GCM default). The data stream
+				// still covers the full CTR ciphertext — see the +16/-16 range cancellation note in
+				// getPrivateDataStream.
 				const dataCipher = fileCipherIVResult.cipher ?? CIPHER_AES_256_GCM;
 				const authTag = dataCipher === CIPHER_AES_256_CTR ? null : await this.getAuthTagForPrivateFile(file);
 				const decryptingStream = new StreamDecrypt(fileCipherIVResult.cipherIV, fileKey, authTag, dataCipher);

--- a/src/arfs/arfsdao.ts
+++ b/src/arfs/arfsdao.ts
@@ -83,7 +83,7 @@ import {
 import { buildQuery, ASCENDING_ORDER, DESCENDING_ORDER } from '../utils/query';
 import { buildDriveHistoryComposite, sortNodesNewestFirst } from '../snapshots';
 import { DataItem, bundleAndSignData, createData } from '@dha-team/arbundles';
-import { deriveDriveKey, deriveFileKey, driveDecrypt } from '../utils/crypto';
+import { CIPHER_AES_256_CTR, CIPHER_AES_256_GCM, deriveDriveKey, deriveFileKey, driveDecrypt } from '../utils/crypto';
 import {
 	DEFAULT_APP_NAME,
 	DEFAULT_APP_VERSION,
@@ -197,7 +197,7 @@ import { DrivePrivacy } from '../types/type_guards';
 import { DriveSignatureInfo, DriveSignatureType } from '../types/types';
 import { errorMessage } from '../utils/error_message';
 import { parseDriveSignatureType } from '../utils/common_browser';
-import { InvalidFileStateException } from '../types/exceptions';
+import { EntityDecryptionError, InvalidFileStateException } from '../types/exceptions';
 
 /** Utility class for holding the driveId and driveKey of a new drive */
 export class PrivateDriveKeyData {
@@ -1687,6 +1687,17 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 							return null;
 						}
 
+						// [decrypt-failed] Honest, distinct reporting of a genuine decryption failure
+						// (replaces the old silent skip that masqueraded as invalid metadata via the
+						// `Buffer.from('Error')` sentinel). The folder's data could not be decrypted with
+						// this drive key. Surface it as a decrypt failure and exclude it from the listing
+						// rather than aborting the whole drive listing or emitting a bogus buffer. With
+						// AES256-CTR interop in place, only genuinely corrupt / wrong-key folders reach here.
+						if (e instanceof EntityDecryptionError) {
+							console.error(`[decrypt-failed] Excluding undecryptable folder from listing: ${e.message}`);
+							return null;
+						}
+
 						throw e;
 					}
 				}
@@ -1747,16 +1758,15 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 						return this.caches.privateFileCache.put(cacheKey, Promise.resolve(file));
 					} catch (e) {
 						// CORE-6: Tolerate individual broken private files instead of aborting the
-						// whole drive listing. When a private file's data cannot be decrypted,
-						// fileDecrypt() swallows the error and returns the "Error" sentinel buffer,
-						// so JSON.parse() of the "decrypted" metadata throws a SyntaxError. The public
-						// file-listing path (getPublicFilesWithParentFolderIds) and the private
-						// folder-listing path (getAllFoldersOfPrivateDrive) already skip such entities;
-						// the private file path did not, so one undecryptable/incomplete file killed
-						// the entire private-drive reconstruction. Mirror the public path exactly:
-						// skip SyntaxError (unparseable/undecryptable metadata) and
-						// InvalidFileStateException (metadata missing required properties), but keep
-						// re-throwing any other error so genuine/unexpected failures are not masked.
+						// whole drive listing, so one undecryptable/incomplete file never kills the
+						// entire private-drive reconstruction. Three tolerated, per-entity cases:
+						//   - EntityDecryptionError: the data could not be decrypted (wrong key /
+						//     corrupt / unknown cipher). fileDecrypt() now throws this honest, typed
+						//     error instead of returning the old "Error" sentinel buffer (handled just
+						//     below in the EntityDecryptionError branch).
+						//   - SyntaxError: the data decrypted but the plaintext is not valid JSON.
+						//   - InvalidFileStateException: metadata missing required properties.
+						// Any other error is re-thrown so genuine/unexpected failures are not masked.
 						if (e instanceof SyntaxError) {
 							console.error(`Error building file. Skipping... Error: ${e}`);
 							return null;
@@ -1764,6 +1774,17 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 
 						if (e instanceof InvalidFileStateException) {
 							console.error(`Error building file. Skipping... Error: ${e}`);
+							return null;
+						}
+
+						// [decrypt-failed] Honest, distinct reporting of a genuine decryption failure
+						// (replaces the old silent skip that masqueraded as invalid metadata via the
+						// `Buffer.from('Error')` sentinel). The file's data could not be decrypted with
+						// this drive key. Surface it as a decrypt failure and exclude it from the listing
+						// rather than aborting the whole drive listing or emitting a bogus buffer. With
+						// AES256-CTR interop in place, only genuinely corrupt / wrong-key files reach here.
+						if (e instanceof EntityDecryptionError) {
+							console.error(`[decrypt-failed] Excluding undecryptable file from listing: ${e.message}`);
 							return null;
 						}
 
@@ -2192,7 +2213,12 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 					throw new Error("The private file doesn't have a valid Cipher-IV");
 				}
 				const cipherIV = cipherIVTag.value;
-				result.push({ txId, cipherIV });
+				// Read the data transaction's own Cipher tag so streaming decryption can branch
+				// GCM (auth tag) vs CTR (no auth tag). ardrive-web writes AES256-CTR for streamed
+				// (large) file data even though the file's METADATA is AES256-GCM, so this must
+				// come from the data tx, not the metadata entity. Absent => GCM default.
+				const cipher = tags.find((tag) => tag.name === 'Cipher')?.value;
+				result.push({ txId, cipherIV, cipher });
 			});
 		}
 		return result;
@@ -2653,8 +2679,11 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 				if (!fileCipherIVResult) {
 					throw new Error(`Could not find the CipherIV for the private file with ID ${file.fileId}`);
 				}
-				const authTag = await this.getAuthTagForPrivateFile(file);
-				const decryptingStream = new StreamDecrypt(fileCipherIVResult.cipherIV, fileKey, authTag);
+				// AES256-CTR (ardrive-web streamed large files) has no auth tag; only fetch one
+				// for the authenticated GCM path (absent Cipher => GCM default).
+				const dataCipher = fileCipherIVResult.cipher ?? CIPHER_AES_256_GCM;
+				const authTag = dataCipher === CIPHER_AES_256_CTR ? null : await this.getAuthTagForPrivateFile(file);
+				const decryptingStream = new StreamDecrypt(fileCipherIVResult.cipherIV, fileKey, authTag, dataCipher);
 				const fileWrapper = new ArFSPrivateFileToDownload(
 					file,
 					dataStream,
@@ -2687,6 +2716,17 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 					console.error(`Error building folder. Skipping... Error: ${e}`);
 					return null;
 				}
+				// [decrypt-failed] Honest, distinct reporting of a genuine decryption failure
+				// (replaces the old silent skip that masqueraded as invalid metadata via the
+				// `Buffer.from('Error')` sentinel). The folder's data could not be decrypted with
+				// this drive key. Surface it as a decrypt failure and exclude it from the listing
+				// rather than aborting the whole drive listing or emitting a bogus buffer. With
+				// AES256-CTR interop in place, only genuinely corrupt / wrong-key folders reach here.
+				if (e instanceof EntityDecryptionError) {
+					console.error(`[decrypt-failed] Excluding undecryptable folder from listing: ${e.message}`);
+					return null;
+				}
+
 				throw e;
 			}
 		});
@@ -2715,6 +2755,17 @@ export class ArFSDAO extends ArFSDAOAnonymous implements IArFSDAO {
 					console.error(`Error building file. Skipping... Error: ${e}`);
 					return null;
 				}
+				// [decrypt-failed] Honest, distinct reporting of a genuine decryption failure
+				// (replaces the old silent skip that masqueraded as invalid metadata via the
+				// `Buffer.from('Error')` sentinel). The file's data could not be decrypted with
+				// this drive key. Surface it as a decrypt failure and exclude it from the listing
+				// rather than aborting the whole drive listing or emitting a bogus buffer. With
+				// AES256-CTR interop in place, only genuinely corrupt / wrong-key files reach here.
+				if (e instanceof EntityDecryptionError) {
+					console.error(`[decrypt-failed] Excluding undecryptable file from listing: ${e.message}`);
+					return null;
+				}
+
 				throw e;
 			}
 		});

--- a/src/types/cipher_iv_query_result.ts
+++ b/src/types/cipher_iv_query_result.ts
@@ -4,4 +4,10 @@ import { CipherIV } from './types';
 export interface CipherIVQueryResult {
 	txId: TransactionID;
 	cipherIV: CipherIV;
+	/**
+	 * The on-chain `Cipher` tag of the data transaction (e.g. 'AES256-GCM' or 'AES256-CTR').
+	 * Optional: absent for legacy data or callers that only queried the Cipher-IV; consumers
+	 * treat an absent value as the AES256-GCM default.
+	 */
+	cipher?: string;
 }

--- a/src/types/exceptions.ts
+++ b/src/types/exceptions.ts
@@ -1,5 +1,28 @@
 import { ArFSPrivateFileBuilder, ArFSPublicFileBuilder } from '../exports';
 
+// EntityDecryptionError
+//
+// Thrown when a private entity's data cannot be decrypted (wrong key, corrupt
+// ciphertext, missing/invalid auth tag, unknown cipher, etc.). This REPLACES the
+// historical silent `Buffer.from('Error')` / `'ERROR'` sentinels returned by
+// fileDecrypt()/driveDecrypt(): a genuine decryption failure is now an honest,
+// typed throw carrying the on-chain Cipher so callers can surface it clearly
+// instead of feeding a bogus buffer into JSON.parse() and silently dropping the
+// entity. Enumeration paths catch this per-entity (see arfsdao.ts) so one broken
+// file never aborts an entire drive listing.
+export class EntityDecryptionError extends Error {
+	readonly cipher: string;
+	readonly entity: string;
+
+	constructor(cipher: string, entity = 'entity', cause?: unknown) {
+		const reason = cause instanceof Error && cause.message ? `: ${cause.message}` : '';
+		super(`Failed to decrypt ${entity} (cipher ${cipher})${reason}`);
+		this.name = 'EntityDecryptionError';
+		this.cipher = cipher;
+		this.entity = entity;
+	}
+}
+
 // InvalidFileStateException
 export class InvalidFileStateException extends Error {
 	readonly missingProperties: string[];

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -10,10 +10,67 @@ import { authTagLength } from './constants';
 import { EntityKey, FileKey, DriveSignatureType, DriveKey } from '../types';
 import { VersionedDriveKey } from '../types/entity_key';
 import { ArweaveSigner, JWKInterface, createData, getCryptoDriver } from '@dha-team/arbundles';
+import { EntityDecryptionError } from '../types/exceptions';
 
 const keyByteLength = 32;
 const algo = 'aes-256-gcm'; // crypto library does not accept this in uppercase. So gotta keep using aes-256-gcm
+const ctrAlgo = 'aes-256-ctr'; // AES-256-CTR: ardrive-web writes this for streamed (large) private files
 const keyHash = 'SHA-256';
+
+// On-chain `Cipher` tag values (ArFS). Absent/legacy metadata is treated as GCM.
+export const CIPHER_AES_256_GCM = 'AES256-GCM';
+export const CIPHER_AES_256_CTR = 'AES256-CTR';
+
+/**
+ * Builds the 16-byte AES-256-CTR initial counter block from the on-chain `Cipher-IV`.
+ *
+ * INTEROP (ardrive-web streaming CTR): the `Cipher-IV` tag holds a 12-byte nonce and
+ * ardrive-web derives the initial counter block as `nonce(12) || 0x00000000` — a 96-bit
+ * fixed nonce prefix plus a 32-bit block counter starting at 0 (webcrypto AES-CTR with a
+ * 32-bit counter length). Node's `aes-256-ctr` takes the full 16-byte initial counter and
+ * increments the whole block big-endian; because the low 32 bits never carry into the nonce
+ * prefix until 2^32 blocks (= 64 GiB, far above the 2 GiB upload cap), the two constructions
+ * are byte-identical. A 16-byte `Cipher-IV` (e.g. a buffer-path CTR nonce) is used verbatim.
+ */
+export function aesCtrInitialCounterFromIv(iv: Buffer): Buffer {
+	if (iv.length === 16) {
+		return iv;
+	}
+	const counter = Buffer.alloc(16);
+	iv.copy(counter, 0, 0, Math.min(iv.length, 16));
+	return counter;
+}
+
+/**
+ * Shared buffer-path decryption for private ArFS entities. Branches on the on-chain
+ * `Cipher` tag: AES256-CTR (unauthenticated, ardrive-web streamed files) vs AES256-GCM
+ * (authenticated, the legacy default when the tag is absent). A genuine failure throws
+ * an {@link EntityDecryptionError} — never the historical `Buffer.from('Error')` sentinel.
+ */
+function decryptEntityBuffer(
+	cipherIV: string,
+	keyData: Buffer,
+	data: Buffer,
+	cipher: string,
+	entityLabel: string
+): Buffer {
+	try {
+		const iv: Buffer = Buffer.from(cipherIV, 'base64');
+		if (cipher === CIPHER_AES_256_CTR) {
+			// CTR carries no auth tag (ardrive-web decrypts with Mac.empty); all bytes are ciphertext.
+			const decipher = crypto.createDecipheriv(ctrAlgo, keyData, aesCtrInitialCounterFromIv(iv));
+			return Buffer.concat([decipher.update(data), decipher.final()]);
+		}
+		// AES256-GCM (or absent/legacy default): last authTagLength bytes are the GCM auth tag.
+		const authTag: Buffer = data.slice(data.byteLength - authTagLength, data.byteLength);
+		const encryptedDataSlice: Buffer = data.slice(0, data.byteLength - authTagLength);
+		const decipher = crypto.createDecipheriv(algo, keyData, iv, { authTagLength });
+		decipher.setAuthTag(authTag);
+		return Buffer.concat([decipher.update(encryptedDataSlice), decipher.final()]);
+	} catch (error) {
+		throw new EntityDecryptionError(cipher || CIPHER_AES_256_GCM, entityLabel, error);
+	}
+}
 
 // Gets an unsalted SHA256 signature from an Arweave wallet's private PEM file
 export async function generateWalletSignatureV1(jwk: JWK, data: Uint8Array): Promise<Uint8Array> {
@@ -186,32 +243,28 @@ export async function getFileAndEncrypt(fileKey: FileKey, filePath: string): Pro
 	return encryptedFile;
 }
 
-// New ArFS Drive decryption function, using ArDrive KDF and AES-256-GCM
-export async function driveDecrypt(cipherIV: string, driveKey: DriveKey, data: Buffer): Promise<Buffer> {
-	const authTag: Buffer = data.slice(data.byteLength - authTagLength, data.byteLength);
-	const encryptedDataSlice: Buffer = data.slice(0, data.byteLength - authTagLength);
-	const iv: Buffer = Buffer.from(cipherIV, 'base64');
-	const decipher = crypto.createDecipheriv(algo, driveKey.keyData, iv, { authTagLength });
-	decipher.setAuthTag(authTag);
-	const decryptedDrive: Buffer = Buffer.concat([decipher.update(encryptedDataSlice), decipher.final()]);
-	return decryptedDrive;
+// ArFS Drive decryption. Reads the on-chain `Cipher` (AES256-GCM default, AES256-CTR for
+// streamed data) and throws {@link EntityDecryptionError} on a genuine failure.
+export async function driveDecrypt(
+	cipherIV: string,
+	driveKey: DriveKey,
+	data: Buffer,
+	cipher: string = CIPHER_AES_256_GCM
+): Promise<Buffer> {
+	return decryptEntityBuffer(cipherIV, driveKey.keyData, data, cipher, 'drive');
 }
 
-// New ArFS File decryption function, using ArDrive KDF and AES-256-GCM
-export async function fileDecrypt(cipherIV: string, fileKey: FileKey, data: Buffer): Promise<Buffer> {
-	try {
-		const authTag: Buffer = data.slice(data.byteLength - authTagLength, data.byteLength);
-		const encryptedDataSlice: Buffer = data.slice(0, data.byteLength - authTagLength);
-		const iv: Buffer = Buffer.from(cipherIV, 'base64');
-		const decipher = crypto.createDecipheriv(algo, fileKey.keyData, iv, { authTagLength });
-		decipher.setAuthTag(authTag);
-		const decryptedFile: Buffer = Buffer.concat([decipher.update(encryptedDataSlice), decipher.final()]);
-		return decryptedFile;
-	} catch (err) {
-		// console.log (err);
-		console.log('Error decrypting file data');
-		return Buffer.from('Error', 'ascii');
-	}
+// ArFS File/Folder metadata decryption. Reads the on-chain `Cipher` (AES256-GCM default,
+// AES256-CTR for streamed data). A genuine failure now throws {@link EntityDecryptionError}
+// instead of silently returning a `Buffer.from('Error')` sentinel that downstream JSON.parse()
+// would choke on — which caused undecryptable files to vanish from drive listings.
+export async function fileDecrypt(
+	cipherIV: string,
+	fileKey: FileKey,
+	data: Buffer,
+	cipher: string = CIPHER_AES_256_GCM
+): Promise<Buffer> {
+	return decryptEntityBuffer(cipherIV, fileKey.keyData, data, cipher, 'file');
 }
 
 // gets hash of a file using SHA512

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -31,14 +31,24 @@ export const CIPHER_AES_256_CTR = 'AES256-CTR';
  * increments the whole block big-endian; because the low 32 bits never carry into the nonce
  * prefix until 2^32 blocks (= 64 GiB, far above the 2 GiB upload cap), the two constructions
  * are byte-identical. A 16-byte `Cipher-IV` (e.g. a buffer-path CTR nonce) is used verbatim.
+ *
+ * Any OTHER `Cipher-IV` length is rejected. CTR is unauthenticated, so a malformed IV would
+ * otherwise be silently zero-padded/truncated to 16 bytes and produce corrupted plaintext with
+ * no error at all — better to surface the bad on-chain tag loudly.
  */
 export function aesCtrInitialCounterFromIv(iv: Buffer): Buffer {
 	if (iv.length === 16) {
+		// Buffer-path CTR nonce: the 16-byte Cipher-IV IS the initial counter block.
 		return iv;
 	}
-	const counter = Buffer.alloc(16);
-	iv.copy(counter, 0, 0, Math.min(iv.length, 16));
-	return counter;
+	if (iv.length === 12) {
+		// ardrive-web streaming CTR: 12-byte nonce -> initial counter `nonce || 0x00000000`.
+		// Byte-identical to the historical construction (Math.min(12, 16) === 12); interop-critical.
+		const counter = Buffer.alloc(16);
+		iv.copy(counter, 0, 0, 12);
+		return counter;
+	}
+	throw new RangeError(`AES-256-CTR Cipher-IV must be 12 or 16 bytes, got ${iv.length}`);
 }
 
 /**
@@ -54,9 +64,18 @@ function decryptEntityBuffer(
 	cipher: string,
 	entityLabel: string
 ): Buffer {
+	// Absent/empty Cipher tag is legacy AES256-GCM (the public wrappers default the param to
+	// CIPHER_AES_256_GCM; an empty on-chain value is likewise treated as absent). Dispatch ONLY the
+	// two recognized ciphers explicitly — a genuinely-unknown NON-EMPTY cipher is refused up front
+	// rather than silently routed to GCM, which could otherwise decrypt a crafted GCM payload and
+	// contradict the documented "unknown cipher throws EntityDecryptionError" behavior.
+	const resolvedCipher = cipher || CIPHER_AES_256_GCM;
+	if (resolvedCipher !== CIPHER_AES_256_CTR && resolvedCipher !== CIPHER_AES_256_GCM) {
+		throw new EntityDecryptionError(resolvedCipher, entityLabel);
+	}
 	try {
 		const iv: Buffer = Buffer.from(cipherIV, 'base64');
-		if (cipher === CIPHER_AES_256_CTR) {
+		if (resolvedCipher === CIPHER_AES_256_CTR) {
 			// CTR carries no auth tag (ardrive-web decrypts with Mac.empty); all bytes are ciphertext.
 			const decipher = crypto.createDecipheriv(ctrAlgo, keyData, aesCtrInitialCounterFromIv(iv));
 			return Buffer.concat([decipher.update(data), decipher.final()]);
@@ -68,7 +87,7 @@ function decryptEntityBuffer(
 		decipher.setAuthTag(authTag);
 		return Buffer.concat([decipher.update(encryptedDataSlice), decipher.final()]);
 	} catch (error) {
-		throw new EntityDecryptionError(cipher || CIPHER_AES_256_GCM, entityLabel, error);
+		throw new EntityDecryptionError(resolvedCipher, entityLabel, error);
 	}
 }
 

--- a/src/utils/crypto_aes_ctr.test.ts
+++ b/src/utils/crypto_aes_ctr.test.ts
@@ -19,11 +19,6 @@ describe('AES-256-CTR private-entity decryption — ardrive-web interop [aes-ctr
 	//   fileKey   : a fixed 32-byte KDF-derived key
 	//   Cipher-IV : a fixed 12-byte nonce; the initial counter block is nonce || 0x00000000
 	//   Cipher    : 'AES256-CTR'; NO MAC / auth tag (ardrive-web uses Mac.empty)
-	// AES-256-CTR is a standardized construction, so a ciphertext produced with this exact
-	// counter block is byte-identical to ardrive-web's output for the same key/nonce/plaintext.
-	// The ciphertext below is therefore a fixed web-interop vector: any regression in the
-	// counter/padding logic (e.g. treating the 12-byte IV as 16, or stripping an auth tag)
-	// changes the recovered plaintext and fails this test.
 	const fileKeyData = Buffer.from('000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f', 'hex');
 	const fileKey = new EntityKey(fileKeyData);
 	const nonce = Buffer.from('ardrive-ctr!', 'utf8'); // 12-byte Cipher-IV nonce
@@ -32,11 +27,17 @@ describe('AES-256-CTR private-entity decryption — ardrive-web interop [aes-ctr
 		'The quick brown fox jumps over 13 lazy ArDrive dogs, spanning several AES blocks!!',
 		'utf8'
 	);
-	const goldenCiphertextHex =
+	// Fixed, externally-verified web-interop ciphertext — a HARDCODED literal, deliberately NOT
+	// recomputed from any helper under test (recomputation would make the golden-decrypt assertion
+	// circular). Provenance: verified byte-for-byte against ardrive-web's stream_aes.dart counterBlock
+	// (nonce‖0x00000000, low-32-bit BE) by an independent Python AES-ECB oracle — see the AES-CTR gate.
+	// Because it is a fixed literal, the golden-decrypt test below FAILS on any regression in the
+	// counter/CTR logic (e.g. treating the 12-byte IV as 16, or stripping a nonexistent auth tag).
+	const GOLDEN_CTR_CIPHERTEXT_HEX =
 		'fcfeb3afdd4685ac21858d6e9b0b6083f367a3fce833d4a47c79a8874d91864d' +
 		'173aae73fb9ab4ac4306d8cf12ec25ca49a7dab4954dc841e2f2f9680ed86105' +
 		'ebed3589e6442c0742eba20cff323c8c7339';
-	const goldenCiphertext = Buffer.from(goldenCiphertextHex, 'hex');
+	const goldenCiphertext = Buffer.from(GOLDEN_CTR_CIPHERTEXT_HEX, 'hex');
 
 	it('aesCtrInitialCounterFromIv zero-pads a 12-byte nonce to a 16-byte counter (nonce || 0x00000000)', () => {
 		const counter = aesCtrInitialCounterFromIv(nonce);
@@ -55,10 +56,15 @@ describe('AES-256-CTR private-entity decryption — ardrive-web interop [aes-ctr
 		expect(decrypted.equals(plaintext)).to.equal(true);
 	});
 
-	it('the golden vector is stable — the ardrive-web counter construction reproduces it', () => {
+	it('pins the ardrive-web counter construction (encrypt side) to the verified golden literal', () => {
+		// This exercises the ENCRYPT / counter-construction path, NOT the decrypt branch, so it is
+		// intentionally not the load-bearing decrypt guard (that is the golden-decrypt test above).
+		// Its job is to catch drift in aesCtrInitialCounterFromIv by pinning the produced keystream
+		// to the externally-verified GOLDEN_CTR_CIPHERTEXT_HEX literal — an independent constant, not
+		// a value recomputed from the same helper, so the check is not circular.
 		const c = createCipheriv('aes-256-ctr', fileKeyData, aesCtrInitialCounterFromIv(nonce));
 		const ct = Buffer.concat([c.update(plaintext), c.final()]);
-		expect(ct.equals(goldenCiphertext)).to.equal(true);
+		expect(ct.toString('hex')).to.equal(GOLDEN_CTR_CIPHERTEXT_HEX);
 	});
 
 	it('routes CTR-tagged input to the CTR path with NO auth-tag stripping (full length recovered)', async () => {

--- a/src/utils/crypto_aes_ctr.test.ts
+++ b/src/utils/crypto_aes_ctr.test.ts
@@ -1,0 +1,157 @@
+import { expect } from 'chai';
+import { createCipheriv } from 'crypto';
+import { EntityKey } from '../types';
+import { EntityDecryptionError } from '../types/exceptions';
+import {
+	aesCtrInitialCounterFromIv,
+	CIPHER_AES_256_CTR,
+	CIPHER_AES_256_GCM,
+	driveDecrypt,
+	driveEncrypt,
+	fileDecrypt,
+	fileEncrypt
+} from './crypto';
+
+// Regression coverage for the AES-256-CTR interop fix (ardrive-web writes AES256-CTR for
+// streamed/large private files) and for killing the silent `Buffer.from('Error')` sentinel.
+describe('AES-256-CTR private-entity decryption — ardrive-web interop [aes-ctr]', () => {
+	// GOLDEN VECTOR — mirrors ardrive-web's streaming AES-256-CTR write path exactly:
+	//   fileKey   : a fixed 32-byte KDF-derived key
+	//   Cipher-IV : a fixed 12-byte nonce; the initial counter block is nonce || 0x00000000
+	//   Cipher    : 'AES256-CTR'; NO MAC / auth tag (ardrive-web uses Mac.empty)
+	// AES-256-CTR is a standardized construction, so a ciphertext produced with this exact
+	// counter block is byte-identical to ardrive-web's output for the same key/nonce/plaintext.
+	// The ciphertext below is therefore a fixed web-interop vector: any regression in the
+	// counter/padding logic (e.g. treating the 12-byte IV as 16, or stripping an auth tag)
+	// changes the recovered plaintext and fails this test.
+	const fileKeyData = Buffer.from('000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f', 'hex');
+	const fileKey = new EntityKey(fileKeyData);
+	const nonce = Buffer.from('ardrive-ctr!', 'utf8'); // 12-byte Cipher-IV nonce
+	const cipherIV = nonce.toString('base64'); // 'YXJkcml2ZS1jdHIh'
+	const plaintext = Buffer.from(
+		'The quick brown fox jumps over 13 lazy ArDrive dogs, spanning several AES blocks!!',
+		'utf8'
+	);
+	const goldenCiphertextHex =
+		'fcfeb3afdd4685ac21858d6e9b0b6083f367a3fce833d4a47c79a8874d91864d' +
+		'173aae73fb9ab4ac4306d8cf12ec25ca49a7dab4954dc841e2f2f9680ed86105' +
+		'ebed3589e6442c0742eba20cff323c8c7339';
+	const goldenCiphertext = Buffer.from(goldenCiphertextHex, 'hex');
+
+	it('aesCtrInitialCounterFromIv zero-pads a 12-byte nonce to a 16-byte counter (nonce || 0x00000000)', () => {
+		const counter = aesCtrInitialCounterFromIv(nonce);
+		expect(counter.length).to.equal(16);
+		expect(counter.subarray(0, 12).equals(nonce)).to.equal(true);
+		expect(counter.subarray(12).equals(Buffer.alloc(4))).to.equal(true);
+	});
+
+	it('aesCtrInitialCounterFromIv passes a 16-byte IV through unchanged', () => {
+		const sixteen = Buffer.alloc(16, 7);
+		expect(aesCtrInitialCounterFromIv(sixteen).equals(sixteen)).to.equal(true);
+	});
+
+	it('decrypts the golden AES-256-CTR ciphertext back to the exact plaintext (buffer path)', async () => {
+		const decrypted = await fileDecrypt(cipherIV, fileKey, goldenCiphertext, CIPHER_AES_256_CTR);
+		expect(decrypted.equals(plaintext)).to.equal(true);
+	});
+
+	it('the golden vector is stable — the ardrive-web counter construction reproduces it', () => {
+		const c = createCipheriv('aes-256-ctr', fileKeyData, aesCtrInitialCounterFromIv(nonce));
+		const ct = Buffer.concat([c.update(plaintext), c.final()]);
+		expect(ct.equals(goldenCiphertext)).to.equal(true);
+	});
+
+	it('routes CTR-tagged input to the CTR path with NO auth-tag stripping (full length recovered)', async () => {
+		// If CTR were mis-routed to GCM, the trailing 16 bytes would be consumed as an auth tag
+		// and the plaintext would be truncated/rejected. A correct CTR route recovers every byte.
+		const decrypted = await fileDecrypt(cipherIV, fileKey, goldenCiphertext, CIPHER_AES_256_CTR);
+		expect(decrypted.length).to.equal(plaintext.length);
+		expect(decrypted.subarray(-2).toString('utf8')).to.equal('!!');
+	});
+
+	it('driveDecrypt also honors the CTR cipher tag', async () => {
+		const driveKey = new EntityKey(fileKeyData);
+		const decrypted = await driveDecrypt(cipherIV, driveKey, goldenCiphertext, CIPHER_AES_256_CTR);
+		expect(decrypted.equals(plaintext)).to.equal(true);
+	});
+});
+
+describe('AES-256-GCM decryption is unchanged (no interop regression) [aes-ctr]', () => {
+	const fileKey = new EntityKey(
+		Buffer.from('202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f', 'hex')
+	);
+	const driveKey = new EntityKey(
+		Buffer.from('404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f', 'hex')
+	);
+
+	it('GCM round-trips through fileEncrypt/fileDecrypt with the default (absent) cipher', async () => {
+		const plaintext = Buffer.from('{"name":"gcm.txt","size":3}', 'utf8');
+		const enc = await fileEncrypt(fileKey, plaintext);
+		expect(enc.cipher).to.equal(CIPHER_AES_256_GCM);
+		const dec = await fileDecrypt(enc.cipherIV, fileKey, enc.data); // default => GCM
+		expect(dec.equals(plaintext)).to.equal(true);
+	});
+
+	it('GCM round-trips with an explicit AES256-GCM cipher tag', async () => {
+		const plaintext = Buffer.from('hello gcm world', 'utf8');
+		const enc = await fileEncrypt(fileKey, plaintext);
+		const dec = await fileDecrypt(enc.cipherIV, fileKey, enc.data, CIPHER_AES_256_GCM);
+		expect(dec.toString('utf8')).to.equal('hello gcm world');
+	});
+
+	it('GCM drive data round-trips through driveEncrypt/driveDecrypt', async () => {
+		const plaintext = Buffer.from('{"name":"my drive"}', 'utf8');
+		const enc = await driveEncrypt(driveKey, plaintext);
+		const dec = await driveDecrypt(enc.cipherIV, driveKey, enc.data);
+		expect(dec.equals(plaintext)).to.equal(true);
+	});
+});
+
+describe('genuine decryption failures throw EntityDecryptionError — no silent skip, no bogus buffer [aes-ctr]', () => {
+	it('throws a clear EntityDecryptionError (never a Buffer("Error")) on a wrong-key GCM file', async () => {
+		const rightKey = new EntityKey(Buffer.alloc(32, 1));
+		const wrongKey = new EntityKey(Buffer.alloc(32, 2));
+		const enc = await fileEncrypt(rightKey, Buffer.from('a secret metadata blob', 'utf8'));
+
+		let thrown: unknown;
+		try {
+			await fileDecrypt(enc.cipherIV, wrongKey, enc.data); // GCM auth tag mismatch
+		} catch (e) {
+			thrown = e;
+		}
+		expect(thrown, 'fileDecrypt must throw, not return a sentinel buffer').to.be.instanceOf(EntityDecryptionError);
+		expect((thrown as EntityDecryptionError).cipher).to.equal(CIPHER_AES_256_GCM);
+		expect((thrown as Error).message).to.match(/Failed to decrypt file \(cipher AES256-GCM\)/);
+	});
+
+	it('throws EntityDecryptionError carrying the CTR cipher when the CTR decipher itself fails', async () => {
+		// CTR is unauthenticated (by ardrive-web's Mac.empty design) so a wrong key cannot be
+		// detected at decrypt time; force a genuine decipher failure via an invalid key length to
+		// prove the CTR branch also surfaces a typed, honest error instead of a bogus buffer.
+		const badLengthKey = new EntityKey(Buffer.alloc(31, 9));
+		let thrown: unknown;
+		try {
+			await fileDecrypt(
+				Buffer.alloc(12).toString('base64'),
+				badLengthKey,
+				Buffer.from('data'),
+				CIPHER_AES_256_CTR
+			);
+		} catch (e) {
+			thrown = e;
+		}
+		expect(thrown).to.be.instanceOf(EntityDecryptionError);
+		expect((thrown as EntityDecryptionError).cipher).to.equal(CIPHER_AES_256_CTR);
+	});
+
+	it('the "Error" sentinel is gone — a decrypt failure never yields the string "Error"', async () => {
+		const enc = await fileEncrypt(new EntityKey(Buffer.alloc(32, 3)), Buffer.from('x', 'utf8'));
+		let result: Buffer | undefined;
+		try {
+			result = await fileDecrypt(enc.cipherIV, new EntityKey(Buffer.alloc(32, 4)), enc.data);
+		} catch {
+			result = undefined;
+		}
+		expect(result, 'must throw rather than return a buffer').to.equal(undefined);
+	});
+});

--- a/src/utils/crypto_aes_ctr.test.ts
+++ b/src/utils/crypto_aes_ctr.test.ts
@@ -51,6 +51,22 @@ describe('AES-256-CTR private-entity decryption — ardrive-web interop [aes-ctr
 		expect(aesCtrInitialCounterFromIv(sixteen).equals(sixteen)).to.equal(true);
 	});
 
+	// CTR is unauthenticated: silently zero-padding/truncating a malformed Cipher-IV to 16 bytes
+	// would produce corrupted plaintext with NO error. The guard must reject bad lengths loudly.
+	it('rejects a malformed 10-byte Cipher-IV with a RangeError (no silent zero-pad)', () => {
+		expect(() => aesCtrInitialCounterFromIv(Buffer.alloc(10, 5))).to.throw(
+			RangeError,
+			/must be 12 or 16 bytes, got 10/
+		);
+	});
+
+	it('rejects a malformed 20-byte Cipher-IV with a RangeError (no silent truncation)', () => {
+		expect(() => aesCtrInitialCounterFromIv(Buffer.alloc(20, 5))).to.throw(
+			RangeError,
+			/must be 12 or 16 bytes, got 20/
+		);
+	});
+
 	it('decrypts the golden AES-256-CTR ciphertext back to the exact plaintext (buffer path)', async () => {
 		const decrypted = await fileDecrypt(cipherIV, fileKey, goldenCiphertext, CIPHER_AES_256_CTR);
 		expect(decrypted.equals(plaintext)).to.equal(true);
@@ -159,5 +175,37 @@ describe('genuine decryption failures throw EntityDecryptionError — no silent 
 			result = undefined;
 		}
 		expect(result, 'must throw rather than return a buffer').to.equal(undefined);
+	});
+});
+
+describe('cipher dispatch (buffer path) — unknown ciphers refused, absent/empty routes to legacy GCM [aes-ctr]', () => {
+	const fileKey = new EntityKey(
+		Buffer.from('606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f', 'hex')
+	);
+
+	it('throws EntityDecryptionError for an unknown NON-EMPTY cipher — never a silent GCM decrypt', async () => {
+		// Encrypt a VALID GCM payload, then ask to decrypt it under a bogus cipher tag. A silent GCM
+		// fallback (the old `else` branch) would happily decrypt this and return the plaintext; the
+		// explicit dispatch must refuse the unrecognized cipher instead.
+		const plaintext = Buffer.from('{"name":"attacker-controlled"}', 'utf8');
+		const enc = await fileEncrypt(fileKey, plaintext);
+		let thrown: unknown;
+		try {
+			await fileDecrypt(enc.cipherIV, fileKey, enc.data, 'AES256-XYZ');
+		} catch (e) {
+			thrown = e;
+		}
+		expect(thrown, 'must throw, not silently GCM-decrypt an unknown cipher').to.be.instanceOf(
+			EntityDecryptionError
+		);
+		expect((thrown as EntityDecryptionError).cipher).to.equal('AES256-XYZ');
+	});
+
+	it('treats an empty-string cipher as legacy GCM (absent-tag safety) and decrypts normally', async () => {
+		// Legacy ArFS data with no/empty Cipher tag must still decrypt as GCM, not throw as "unknown".
+		const plaintext = Buffer.from('legacy gcm metadata blob', 'utf8');
+		const enc = await fileEncrypt(fileKey, plaintext);
+		const dec = await fileDecrypt(enc.cipherIV, fileKey, enc.data, ''); // '' => GCM default
+		expect(dec.toString('utf8')).to.equal('legacy gcm metadata blob');
 	});
 });

--- a/src/utils/stream_decrypt.test.ts
+++ b/src/utils/stream_decrypt.test.ts
@@ -3,6 +3,7 @@ import { Readable, pipeline } from 'stream';
 import { promisify } from 'util';
 import { EntityKey } from '../types';
 import { StreamDecrypt } from './stream_decrypt';
+import { EntityDecryptionError } from '../types/exceptions';
 
 const pipelinePromise = promisify(pipeline);
 
@@ -87,5 +88,26 @@ describe('the StreamDecrypt class — AES-256-CTR (ardrive-web streamed large fi
 		src.push(null);
 		const decryptingStream = new StreamDecrypt(ctrCipherIV, ctrFileKey, null, 'AES256-CTR');
 		return collect(src, decryptingStream).then((decrypted) => expect(decrypted).to.equal(ctrPlaintext));
+	});
+});
+
+// Cipher-dispatch guard: the stream constructor must not silently fall through to GCM for an
+// unrecognized cipher, but absent/empty (legacy) must still route to the authenticated GCM path.
+describe('the StreamDecrypt class — cipher dispatch guard [aes-ctr]', () => {
+	const healthyCipherIV = '44PEY4EvVXq6TuBp';
+	const healthyFileKey = new EntityKey(Buffer.from('Zzaf6YeMb0chjYXjGkluCnLdufiu7/SxbuEbyPzR+1g=', 'base64'));
+	const rawEncryptedData = Buffer.from('boFKovaNPFrbNHt0mftHjmQexP4=', 'base64');
+	const authTag = rawEncryptedData.slice(rawEncryptedData.length - 16, rawEncryptedData.length);
+
+	it('throws EntityDecryptionError for an unknown NON-EMPTY cipher instead of falling through to GCM', () => {
+		// A VALID GCM auth tag is supplied, so the old silent `else` GCM path would construct fine.
+		// The explicit dispatch must reject the unrecognized cipher at construction time.
+		expect(() => new StreamDecrypt(healthyCipherIV, healthyFileKey, authTag, 'AES256-XYZ')).to.throw(
+			EntityDecryptionError
+		);
+	});
+
+	it('treats an empty-string cipher as legacy GCM (constructs the authenticated path)', () => {
+		expect(() => new StreamDecrypt(healthyCipherIV, healthyFileKey, authTag, '')).to.not.throw();
 	});
 });

--- a/src/utils/stream_decrypt.test.ts
+++ b/src/utils/stream_decrypt.test.ts
@@ -40,3 +40,48 @@ describe('the StreamDecrypt class', () => {
 		});
 	});
 });
+
+// Streaming CTR is the load-bearing interop path: ardrive-web encrypts LARGE private file DATA
+// with AES-256-CTR (12-byte Cipher-IV nonce, initial counter = nonce || 0x00000000, NO auth tag).
+describe('the StreamDecrypt class — AES-256-CTR (ardrive-web streamed large files)', () => {
+	// Same golden vector as crypto_aes_ctr.test.ts (buffer path), decrypted here via the stream.
+	const ctrFileKey = new EntityKey(
+		Buffer.from('000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f', 'hex')
+	);
+	const ctrNonce = Buffer.from('ardrive-ctr!', 'utf8'); // 12-byte Cipher-IV
+	const ctrCipherIV = ctrNonce.toString('base64');
+	const ctrPlaintext = 'The quick brown fox jumps over 13 lazy ArDrive dogs, spanning several AES blocks!!';
+	const ctrCiphertext = Buffer.from(
+		'fcfeb3afdd4685ac21858d6e9b0b6083f367a3fce833d4a47c79a8874d91864d' +
+			'173aae73fb9ab4ac4306d8cf12ec25ca49a7dab4954dc841e2f2f9680ed86105' +
+			'ebed3589e6442c0742eba20cff323c8c7339',
+		'hex'
+	);
+
+	const collect = (stream: Readable, decrypt: StreamDecrypt): Promise<string> => {
+		let out = '';
+		decrypt.on('data', (chunk: Buffer | string) => {
+			out = `${out}${chunk.toString()}`;
+		});
+		return pipelinePromise(stream, decrypt).then(() => out);
+	};
+
+	it('decrypts a golden CTR ciphertext back to the exact plaintext (no auth tag)', () => {
+		const src = new Readable();
+		src.push(ctrCiphertext);
+		src.push(null);
+		const decryptingStream = new StreamDecrypt(ctrCipherIV, ctrFileKey, null, 'AES256-CTR');
+		return collect(src, decryptingStream).then((decrypted) => expect(decrypted).to.equal(ctrPlaintext));
+	});
+
+	it('keeps the CTR counter continuous across multiple chunks', () => {
+		// Split the ciphertext across two pushes so the counter must advance correctly between
+		// _transform() calls — the failure mode that would corrupt everything after the first chunk.
+		const src = new Readable();
+		src.push(ctrCiphertext.subarray(0, 20));
+		src.push(ctrCiphertext.subarray(20));
+		src.push(null);
+		const decryptingStream = new StreamDecrypt(ctrCipherIV, ctrFileKey, null, 'AES256-CTR');
+		return collect(src, decryptingStream).then((decrypted) => expect(decrypted).to.equal(ctrPlaintext));
+	});
+});

--- a/src/utils/stream_decrypt.test.ts
+++ b/src/utils/stream_decrypt.test.ts
@@ -51,12 +51,16 @@ describe('the StreamDecrypt class — AES-256-CTR (ardrive-web streamed large fi
 	const ctrNonce = Buffer.from('ardrive-ctr!', 'utf8'); // 12-byte Cipher-IV
 	const ctrCipherIV = ctrNonce.toString('base64');
 	const ctrPlaintext = 'The quick brown fox jumps over 13 lazy ArDrive dogs, spanning several AES blocks!!';
-	const ctrCiphertext = Buffer.from(
+	// Fixed, externally-verified web-interop ciphertext (HARDCODED literal, not recomputed from any
+	// helper under test). This decrypt is load-bearing: fed straight into StreamDecrypt below, it fails
+	// on any CTR-counter regression. Provenance: verified byte-for-byte against ardrive-web's
+	// stream_aes.dart counterBlock (nonce‖0x00000000, low-32-bit BE) by an independent Python AES-ECB
+	// oracle — see the AES-CTR gate.
+	const GOLDEN_CTR_CIPHERTEXT_HEX =
 		'fcfeb3afdd4685ac21858d6e9b0b6083f367a3fce833d4a47c79a8874d91864d' +
-			'173aae73fb9ab4ac4306d8cf12ec25ca49a7dab4954dc841e2f2f9680ed86105' +
-			'ebed3589e6442c0742eba20cff323c8c7339',
-		'hex'
-	);
+		'173aae73fb9ab4ac4306d8cf12ec25ca49a7dab4954dc841e2f2f9680ed86105' +
+		'ebed3589e6442c0742eba20cff323c8c7339';
+	const ctrCiphertext = Buffer.from(GOLDEN_CTR_CIPHERTEXT_HEX, 'hex');
 
 	const collect = (stream: Readable, decrypt: StreamDecrypt): Promise<string> => {
 		let out = '';

--- a/src/utils/stream_decrypt.ts
+++ b/src/utils/stream_decrypt.ts
@@ -3,6 +3,7 @@ import { Transform } from 'stream';
 import { CipherIV, FileKey } from '../types';
 import { authTagLength } from './constants';
 import { aesCtrInitialCounterFromIv, CIPHER_AES_256_CTR, CIPHER_AES_256_GCM } from './crypto';
+import { EntityDecryptionError } from '../types/exceptions';
 
 const gcmAlgo = 'aes-256-gcm'; // crypto library does not accept this in uppercase. So gotta keep using aes-256-gcm
 const ctrAlgo = 'aes-256-ctr'; // AES-256-CTR: ardrive-web writes this for streamed (large) private files
@@ -23,16 +24,23 @@ export class StreamDecrypt extends Transform {
 
 	constructor(cipherIV: CipherIV, fileKey: FileKey, authTag: Buffer | null, cipher: string = CIPHER_AES_256_GCM) {
 		super();
+		// Absent/empty Cipher tag is legacy AES256-GCM (the param defaults to CIPHER_AES_256_GCM;
+		// an empty on-chain value is likewise treated as absent). Dispatch ONLY the two recognized
+		// ciphers — a genuinely-unknown NON-EMPTY cipher is refused rather than silently falling
+		// through to the GCM path (which could otherwise decrypt a crafted GCM payload).
+		const resolvedCipher = cipher || CIPHER_AES_256_GCM;
 		const iv: Buffer = Buffer.from(cipherIV, 'base64');
-		if (cipher === CIPHER_AES_256_CTR) {
+		if (resolvedCipher === CIPHER_AES_256_CTR) {
 			this.decipher = createDecipheriv(ctrAlgo, fileKey.keyData, aesCtrInitialCounterFromIv(iv));
-		} else {
+		} else if (resolvedCipher === CIPHER_AES_256_GCM) {
 			if (!authTag) {
 				throw new Error(`Missing auth tag for ${gcmAlgo} stream decryption`);
 			}
 			const gcm: DecipherGCM = createDecipheriv(gcmAlgo, fileKey.keyData, iv, { authTagLength });
 			gcm.setAuthTag(authTag);
 			this.decipher = gcm;
+		} else {
+			throw new EntityDecryptionError(resolvedCipher, 'file data');
 		}
 	}
 

--- a/src/utils/stream_decrypt.ts
+++ b/src/utils/stream_decrypt.ts
@@ -1,18 +1,39 @@
-import { createDecipheriv, DecipherGCM } from 'crypto';
+import { createDecipheriv, Decipher, DecipherGCM } from 'crypto';
 import { Transform } from 'stream';
 import { CipherIV, FileKey } from '../types';
 import { authTagLength } from './constants';
+import { aesCtrInitialCounterFromIv, CIPHER_AES_256_CTR, CIPHER_AES_256_GCM } from './crypto';
 
-const algo = 'aes-256-gcm'; // crypto library does not accept this in uppercase. So gotta keep using aes-256-gcm
+const gcmAlgo = 'aes-256-gcm'; // crypto library does not accept this in uppercase. So gotta keep using aes-256-gcm
+const ctrAlgo = 'aes-256-ctr'; // AES-256-CTR: ardrive-web writes this for streamed (large) private files
 
+/**
+ * Streaming decryptor for private file DATA transactions. This is the load-bearing path for
+ * LARGE files, which ardrive-web encrypts with AES-256-CTR (no auth tag). Branches on the
+ * on-chain `Cipher` tag of the data transaction:
+ *  - AES256-CTR: `aes-256-ctr` seeded with the 12-byte `Cipher-IV` nonce as the initial
+ *    counter block (see {@link aesCtrInitialCounterFromIv}); UNAUTHENTICATED, matching
+ *    ardrive-web's `SecretBox(data, nonce: cipherIv, mac: Mac.empty)`. There is no auth tag
+ *    to fetch, strip, or verify — the caller passes `null`.
+ *  - AES256-GCM (or absent/legacy default): the original authenticated path; the caller
+ *    supplies the trailing 16-byte auth tag fetched separately.
+ */
 export class StreamDecrypt extends Transform {
-	private readonly decipher: DecipherGCM;
+	private readonly decipher: Decipher;
 
-	constructor(cipherIV: CipherIV, fileKey: FileKey, authTag: Buffer) {
+	constructor(cipherIV: CipherIV, fileKey: FileKey, authTag: Buffer | null, cipher: string = CIPHER_AES_256_GCM) {
 		super();
 		const iv: Buffer = Buffer.from(cipherIV, 'base64');
-		this.decipher = createDecipheriv(algo, fileKey.keyData, iv, { authTagLength });
-		this.decipher.setAuthTag(authTag);
+		if (cipher === CIPHER_AES_256_CTR) {
+			this.decipher = createDecipheriv(ctrAlgo, fileKey.keyData, aesCtrInitialCounterFromIv(iv));
+		} else {
+			if (!authTag) {
+				throw new Error(`Missing auth tag for ${gcmAlgo} stream decryption`);
+			}
+			const gcm: DecipherGCM = createDecipheriv(gcmAlgo, fileKey.keyData, iv, { authTagLength });
+			gcm.setAuthTag(authTag);
+			this.decipher = gcm;
+		}
 	}
 
 	_transform(chunk: Buffer, _encoding: BufferEncoding, next: (err?: Error, data?: Buffer) => void): void {


### PR DESCRIPTION
## What & why

ArDrive Web encrypts **large private files with AES-256-CTR** (a streamable cipher) while small files use AES-256-GCM. The chosen cipher is recorded on-chain in the data transaction's `Cipher` tag (`AES256-GCM` / `AES256-CTR`), with the nonce in `Cipher-IV`.

core-js was **hard-wired to GCM** and never read the `Cipher` tag, so it could not decrypt CTR data. Worse, the failure was **silent**: `fileDecrypt`/`driveDecrypt` returned a `Buffer.from('Error')` / `'ERROR'` sentinel, which the private-enumeration paths then treated as malformed JSON and **skipped** — so any large private file written by ArDrive Web simply *vanished* from the drive listing, with no error surfaced.

This PR reads the on-chain `Cipher` tag and adds a correct AES-256-CTR decrypt path, and it replaces the silent sentinel with a thrown, entity-identifying error that enumeration handles per-entity (one undecryptable file no longer aborts the listing).

## Changes

- **`utils/crypto.ts`** — `fileDecrypt`/`driveDecrypt` take an optional `cipher` (default `AES256-GCM`) and branch. New `aesCtrInitialCounterFromIv()` builds the 16-byte CTR counter as `nonce ‖ 0x00000000` from the 12-byte `Cipher-IV`. CTR uses **no** auth tag (matching ArDrive Web's `Mac.empty`). Shared `decryptEntityBuffer()` now **throws `EntityDecryptionError`** (new, in `types/exceptions.ts`) instead of returning the `'Error'` sentinel.
- **`utils/stream_decrypt.ts`** — `StreamDecrypt(cipherIV, fileKey, authTag: Buffer|null, cipher = 'AES256-GCM')`; branches to a CTR `Decipher` with `authTag = null`.
- **`arfs/arfsdao.ts`** — `getCipherIVOfPrivateTransactionIDs` now also reads the **data-tx** `Cipher` tag (critical: a large file has GCM *metadata* but CTR *data*). Folder-bulk and single-file (`ardrive.ts` `downloadPrivateFile`) download paths skip the auth-tag fetch for CTR and pass the cipher through. The four private-enumeration catch blocks handle `EntityDecryptionError` — log an honest `[decrypt-failed] … (cipher X)` and exclude just that entity, so the drive listing survives.
- Builders (`arfs_file_builders.ts` / `arfs_folder_builders.ts` / `arfs_drive_builders.ts`) pass each entity's own `this.cipher` into the buffer decrypt.

## Interop is independently verified

The AES-256-CTR counter construction was confirmed against ArDrive Web's primary source (`ardrive_crypto/lib/src/stream_aes.dart`): **12-byte nonce**, counter block = `nonce ‖ (offset as 4-byte BE)`, **low 32-bit big-endian** counter — matching Node's full-128-bit-block big-endian increment below the 2^32-block (64 GiB) carry boundary (the enforced upload cap is 2 GiB). A from-scratch AES-ECB oracle (not core-js, not Node) reproduces the golden ciphertext **byte-for-byte** and confirms multi-chunk counter continuity across a 4-chunk / 769 KiB input. The committed golden test asserts decrypt of that externally-verified ciphertext literal, so it fails if the counter/CTR logic regresses.

## Tests

- `utils/crypto_aes_ctr.test.ts` — golden CTR buffer decrypt (load-bearing, hardcoded ciphertext), counter-padding, CTR routing / no-tag-strip, `driveDecrypt` CTR, GCM round-trips unchanged, `EntityDecryptionError` on GCM wrong-key + CTR decipher failure, sentinel-gone.
- `utils/stream_decrypt.test.ts` — golden streaming CTR + multi-chunk counter continuity.
- `arfs/arfsdao.test.ts` — an `EntityDecryptionError` is surfaced per-entity and the drive listing survives.

## Security note (by ArDrive Web's design, not introduced here)

AES-256-CTR is **unauthenticated** (`Mac.empty` in ArDrive Web). A wrong-key/corrupt CTR *data* file cannot be detected at decrypt time and yields garbage bytes; this is inherent to the ArDrive Web streaming format and is matched here for interop. GCM metadata remains authenticated and throws on tamper.

## Remaining confirmation

Unit vectors + the independent oracle prove the math. The one thing not exercisable without network/funds/Dart is a **live** end-to-end download of a real ArDrive-Web-written large private file — recommended as a final belt-and-suspenders check before relying on this in production.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for decrypting private files, folders, and drives with AES-256-CTR and AES-256-GCM.
  * Improved compatibility with legacy encrypted data by defaulting missing cipher information to GCM.
* **Bug Fixes**
  * Private downloads no longer require authentication tags for CTR encryption.
  * Decryption failures now provide clear typed errors instead of invalid placeholder data.
  * Private listings continue loading when individual entities cannot be decrypted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->