### PR TITLE
chore(release): 4.3.0 — pinPublicFile (#281) + AES-256-CTR decrypt (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.3.0] - 2026-08-04
+
+### Added
+
+- **Public-file pinning — `ARDrive.pinPublicFile()`.** Creates a new **public** ArFS
+  File entity that "pins" an existing Arweave data transaction by its `dataTxId`,
+  **without re-uploading the data** — parity with ArDrive Web. The pin reuses the
+  target transaction's data, sets `pinnedDataOwner`, and is recognized on read via the
+  JSON `pinnedDataOwner` field. The destination drive is always resolved from the parent
+  folder; a supplied `driveId` that does not own that folder is rejected, so a public pin
+  can never be written into a private drive. A `Pinned-Data-Tx` tag that disagrees with the
+  metadata `dataTxId` is treated as malformed and dropped, and gateway string `data.size`
+  values are coerced in `getInfoOfTxToBePinned`. (#281)
+
+### Fixed
+
+- **Decrypt AES-256-CTR private files (large / streamed files).** ArDrive Web encrypts
+  *large* private files with **AES-256-CTR** (a streamable, unauthenticated cipher) while
+  small files use AES-256-GCM, recording the choice in the on-chain **`Cipher`** tag.
+  core-js was GCM-only and **silently dropped** CTR files from drive listings. It now reads
+  the `Cipher` tag and decrypts CTR correctly (12-byte `Cipher-IV` → CTR counter) in **both**
+  the buffer and streaming download paths. The CTR counter construction was verified
+  byte-for-byte against ArDrive Web's `stream_aes.dart`. (#282)
+- **Undecryptable entities no longer vanish silently.** `fileDecrypt`/`driveDecrypt` now
+  throw a typed `EntityDecryptionError` (carrying the cipher + entity) instead of returning
+  a `Buffer('Error')` / `'ERROR'` sentinel that private-drive enumeration then skipped.
+  Enumeration surfaces the error **per entity** and the rest of the listing survives. (#282)
+- **Reject malformed input on the CTR path.** A `Cipher-IV` that is not 12 or 16 bytes throws,
+  and an **unknown `Cipher` value** throws `EntityDecryptionError` instead of silently falling
+  back to GCM. Legacy files with no `Cipher` tag still decrypt as GCM. (#282)
+
 ## [4.2.0] - 2026-07-15
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ardrive-core-js",
-  "version": "4.1.0",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ardrive-core-js",
-      "version": "4.1.0",
+      "version": "4.3.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ardrive/ardrive-promise-cache": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ardrive-core-js",
-	"version": "4.2.0",
+	"version": "4.3.0",
 	"description": "ArDrive Core contains the essential back end application features to support the ArDrive CLI and Desktop apps, such as file management, Permaweb upload/download, wallet management and other common functions.",
 	"main": "./lib/exports.js",
 	"types": "./lib/exports.d.ts",


### PR DESCRIPTION
Release-prep for **v4.3.0** (bumps `package.json` 4.2.0 → 4.3.0 + CHANGELOG). No source changes — only the version + changelog, so this is tag-ready.

## What's in this release (already merged to master)
- **Added — `ARDrive.pinPublicFile()`** (#281): pin an existing Arweave `dataTxId` as a new public ArFS File entity, no re-upload; drive resolved from the parent folder; pin tx-id consistency + gateway size coercion.
- **Fixed — AES-256-CTR interop decrypt** (#282): read the on-chain `Cipher` tag and decrypt large *streamed private* files (previously GCM-only → they silently vanished); typed `EntityDecryptionError` replaces the silent-skip sentinel (per-entity, listing survives); guards reject malformed CTR IV lengths + unknown ciphers.

## To publish (owner)
1. Admin-merge this PR to `master`.
2. Push tag `v4.3.0` at the merge commit → `publish.yml` builds `lib/` + `dist/web/`, verifies `tag == package.json version` + tarball contents, and runs `npm publish --provenance --access public` (needs the `NPM_TOKEN` repo secret).

_Note: the desktop consumes core-js by git ref and does not require this npm publish; the tag is for external consumers + clean provenance._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release notes for public-file pinning, including ownership validation, metadata handling, and gateway size support.
  - Documented AES-256-CTR decryption for streamed and buffered private files, typed decryption errors, malformed input handling, and legacy GCM compatibility.

- **Chores**
  - Updated the package version to 4.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->