### PR TITLE
ci(publish): npm trusted publishing (OIDC) — drop NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,10 @@ name: Publish to npm
 #   1. Push a version tag `vX.Y.Z` (recommended: cut from master after merge).
 #   2. Manually via the Actions tab (workflow_dispatch) with a dry_run toggle.
 #
-# Prerequisite (one-time, owner): add an `NPM_TOKEN` repo secret — an npm
-# automation token with publish rights for `ardrive-core-js`.
+# Auth: npm Trusted Publishing (OIDC) — no token/secret. One-time owner setup on
+# npm: the ardrive-core-js package -> Settings -> Trusted Publishers -> add a
+# GitHub Actions publisher for ardriveapp/ardrive-core-js + workflow publish.yml.
+# Requires npm >= 11.5.1, Node >= 22.14.0, and `id-token: write` (all set below).
 #
 # Why this exists: `npm publish` runs the `prepare` hook (tsc -> lib/) but does
 # NOT build the browser bundle `dist/web/`, which the package's `files` array
@@ -41,8 +43,12 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
+          node-version: "22.14.0" # OIDC trusted publishing needs Node >= 22.14.0 (repo .nvmrc is 18)
           registry-url: "https://registry.npmjs.org"
+
+      # Trusted publishing (OIDC) needs npm >= 11.5.1; Node 22's bundled npm is older.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -77,11 +83,12 @@ jobs:
             console.log(`Package OK: ${files.length} files, lib/ + dist/web/ present`);
           '
 
-      - name: Publish to npm (with provenance)
+      - name: Publish to npm (trusted publishing / OIDC)
         if: github.event_name == 'push' || inputs.dry_run == false
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # No NODE_AUTH_TOKEN — authenticated via OIDC against the npm Trusted
+        # Publisher configured for this repo + workflow. Provenance is generated
+        # automatically under trusted publishing (no --provenance flag needed).
+        run: npm publish --access public
 
       - name: Dry-run summary
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true


### PR DESCRIPTION
Converts `publish.yml` from a long-lived `NPM_TOKEN` secret to **npm Trusted Publishing (OIDC)** — aligned with npm's [bypass-2FA-token deprecation](https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/) and the Trusted Publisher now configured on the `ardrive-core-js` package.

## Changes
- **Remove** `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish step — auth is now OIDC.
- **Node 22.14.0** pinned for the publish job (repo `.nvmrc` is 18; OIDC requires Node ≥ 22.14.0).
- **Upgrade npm to latest** before publish (OIDC requires npm ≥ 11.5.1; Node 22 bundles older).
- **Drop `--provenance`** flag — provenance is generated automatically under trusted publishing.
- `permissions: id-token: write` + `setup-node` `registry-url` retained.

## Prerequisite (already done by owner)
Trusted Publisher configured on npm: `ardrive-core-js` → Settings → Trusted Publishers → GitHub Actions = `ardriveapp/ardrive-core-js`, workflow `publish.yml`. No secret needed.

## After merge
Push the `v4.3.0` tag → publishes via OIDC (no token). Or dry-run first via Actions → "Publish to npm" → workflow_dispatch (`dry_run: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing process to use secure, tokenless authentication.
  * Upgraded the publishing environment to Node.js 22.14.0 and the latest npm.
  * Preserved public publishing and dry-run support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->